### PR TITLE
Fix SOAP params for bulk domain info

### DIFF
--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -13,8 +13,8 @@ class DomainController extends Controller
     {
         // Synergy Wholesale API credentials
         $apiEndpoint = 'https://api.synergywholesale.com';
-        $resellerId = config('services.synergy.reseller_id');
-        $apiKey = config('services.synergy.api_key');
+        $resellerId = config('synergy.reseller_id');
+        $apiKey = config('synergy.api_key');
 
         try {
             // SOAP Client setup
@@ -25,7 +25,7 @@ class DomainController extends Controller
 
             // API Request
             $response = $client->bulkDomainInfo([
-                'resellerId' => $resellerId,
+                'resellerID' => $resellerId,
                 'apiKey' => $apiKey,
             ]);
 


### PR DESCRIPTION
## Summary
- ensure reseller credentials use correct config path
- send `resellerID` and `apiKey` parameters for `bulkDomainInfo` SOAP call

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687b3cb2c5ec8331be3d872f1f6fb748