### PR TITLE
Add tests for Synergy SOAP client

### DIFF
--- a/tests/Feature/SynergyServiceTest.php
+++ b/tests/Feature/SynergyServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+use Mockery;
+use SoapFault;
+
+class SynergyServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure configuration uses local WSDL so SoapClient instantiation does not perform network calls
+        Config::set('synergy.api_url', base_path('tests/fixtures/synergy.wsdl'));
+        Config::set('synergy.reseller_id', 'test-reseller');
+        Config::set('synergy.api_key', 'test-key');
+    }
+
+    protected function getSynergyWithMockClient($mock)
+    {
+        $synergy = app('synergy');
+
+        $ref = new \ReflectionClass($synergy);
+        $prop = $ref->getProperty('client');
+        $prop->setAccessible(true);
+        $prop->setValue($synergy, $mock);
+
+        return $synergy;
+    }
+
+    public function test_check_domain_availability_invokes_correct_method(): void
+    {
+        $mock = Mockery::mock(\SoapClient::class);
+        $mock->shouldReceive('__soapCall')
+            ->once()
+            ->with('CheckDomain', [[
+                'resellerID' => 'test-reseller',
+                'apiKey' => 'test-key',
+                'domainName' => 'example.com',
+            ]])
+            ->andReturn((object)['available' => true]);
+
+        $synergy = $this->getSynergyWithMockClient($mock);
+
+        $result = $synergy->checkDomainAvailability('example.com');
+
+        $this->assertEquals(['available' => true], $result);
+    }
+
+    public function test_check_domain_availability_handles_soap_fault(): void
+    {
+        $mock = Mockery::mock(\SoapClient::class);
+        $mock->shouldReceive('__soapCall')
+            ->once()
+            ->andThrow(new SoapFault('Server', 'Unit test error'));
+
+        $synergy = $this->getSynergyWithMockClient($mock);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SOAP API Error: Unit test error');
+
+        $synergy->checkDomainAvailability('example.com');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/fixtures/synergy.wsdl
+++ b/tests/fixtures/synergy.wsdl
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<definitions name="Synergy" targetNamespace="urn:Synergy" xmlns:tns="urn:Synergy" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns="http://schemas.xmlsoap.org/wsdl/">
+    <types/>
+    <message name="CheckDomainRequest"/>
+    <message name="CheckDomainResponse"/>
+    <portType name="SynergyPortType">
+        <operation name="CheckDomain" />
+    </portType>
+    <binding name="SynergyBinding" type="tns:SynergyPortType">
+        <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="CheckDomain">
+            <soap:operation soapAction="CheckDomain"/>
+            <input><soap:body use="encoded" namespace="urn:Synergy" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+            <output><soap:body use="encoded" namespace="urn:Synergy" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+        </operation>
+    </binding>
+    <service name="SynergyService">
+        <port name="SynergyPort" binding="tns:SynergyBinding">
+            <soap:address location="http://localhost"/>
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
## Summary
- add fixture WSDL for SynergyWholesale service
- mock SOAP client in new feature test
- verify `checkDomainAvailability` uses the correct SOAP call
- ensure SOAP faults are converted to Exceptions

## Testing
- `vendor/bin/phpunit tests/Feature/SynergyServiceTest.php --colors=never`

------
https://chatgpt.com/codex/tasks/task_b_687b3c8513188331ae8aebeb08f32e25