### PR TITLE
Fix synergy SOAP call

### DIFF
--- a/app/Providers/SynergyWholesaleServiceProvider.php
+++ b/app/Providers/SynergyWholesaleServiceProvider.php
@@ -59,6 +59,13 @@ class SynergyWholesaleServiceProvider extends ServiceProvider
                     return $this->request('GetDomainList');
                 }
 
+                public function bulkDomainInfo(array $domainList)
+                {
+                    return $this->request('bulkDomainInfo', [
+                        'domainList' => $domainList,
+                    ]);
+                }
+
                 public function transferDomain($domain, $authCode)
                 {
                     return $this->request('TransferDomain', [

--- a/config/synergy.php
+++ b/config/synergy.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'api_url' => env('SYNERGY_API_URL', 'https://api.synergywholesale.com'),
+    'api_url' => env('SYNERGY_API_URL', 'https://api.synergywholesale.com/?wsdl'),
     'reseller_id' => env('SYNERGY_RESELLER_ID', ''),
     'api_key' => env('SYNERGY_API_KEY', ''),
 ];


### PR DESCRIPTION
## Summary
- update Synergy config to include the WSDL
- add bulkDomainInfo helper to Synergy service
- call Synergy service instead of raw SoapClient

## Testing
- `composer install --no-interaction`
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687b3c7c65fc83319127da1a3c5d5694