### PR TITLE
Store Synergy credentials in DB

### DIFF
--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Domain;
 use Illuminate\Http\Request;
 use SoapClient;
+use App\Models\SynergyCredential;
 
 class DomainController extends Controller
 {
@@ -13,8 +14,9 @@ class DomainController extends Controller
     {
         // Synergy Wholesale API credentials
         $apiEndpoint = 'https://api.synergywholesale.com';
-        $resellerId = config('services.synergy.reseller_id');
-        $apiKey = config('services.synergy.api_key');
+        $credentials = SynergyCredential::first();
+        $resellerId = $credentials->reseller_id ?? config('synergy.reseller_id');
+        $apiKey = $credentials->api_key ?? config('synergy.api_key');
 
         try {
             // SOAP Client setup

--- a/app/Http/Controllers/SynergyAPIController.php
+++ b/app/Http/Controllers/SynergyAPIController.php
@@ -3,14 +3,16 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\SynergyCredential;
 
 class SynergyAPIController extends Controller
 {
     public function edit()
     {
+        $credentials = SynergyCredential::first();
         $settings = [
-            'reseller_id' => env('SYNERGY_RESELLER_ID'),
-            'api_key' => env('SYNERGY_API_KEY'),
+            'reseller_id' => $credentials->reseller_id ?? '',
+            'api_key' => $credentials->api_key ?? '',
         ];
 
         return view('admin.synergy-api.edit', compact('settings'));
@@ -23,18 +25,18 @@ class SynergyAPIController extends Controller
             'api_key' => 'required|string|max:255',
         ]);
 
-        // Update .env file
-        $path = base_path('.env');
-        file_put_contents($path, str_replace(
-            'SYNERGY_RESELLER_ID=' . env('SYNERGY_RESELLER_ID'),
-            'SYNERGY_RESELLER_ID=' . $request->reseller_id,
-            file_get_contents($path)
-        ));
-        file_put_contents($path, str_replace(
-            'SYNERGY_API_KEY=' . env('SYNERGY_API_KEY'),
-            'SYNERGY_API_KEY=' . $request->api_key,
-            file_get_contents($path)
-        ));
+        $credential = SynergyCredential::first();
+        if ($credential) {
+            $credential->update([
+                'reseller_id' => $request->reseller_id,
+                'api_key' => $request->api_key,
+            ]);
+        } else {
+            SynergyCredential::create([
+                'reseller_id' => $request->reseller_id,
+                'api_key' => $request->api_key,
+            ]);
+        }
 
         return redirect()->route('synergy-api.edit')->with('success', 'Synergy API details updated successfully.');
     }

--- a/app/Models/SynergyCredential.php
+++ b/app/Models/SynergyCredential.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SynergyCredential extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'reseller_id',
+        'api_key',
+    ];
+}

--- a/app/Providers/SynergyWholesaleServiceProvider.php
+++ b/app/Providers/SynergyWholesaleServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\SynergyCredential;
 
 class SynergyWholesaleServiceProvider extends ServiceProvider
 {
@@ -19,8 +20,9 @@ class SynergyWholesaleServiceProvider extends ServiceProvider
 
                 public function __construct()
                 {
-                    $this->resellerId = config('synergy.reseller_id');
-                    $this->apiKey = config('synergy.api_key');
+                    $credentials = SynergyCredential::first();
+                    $this->resellerId = $credentials->reseller_id ?? config('synergy.reseller_id');
+                    $this->apiKey = $credentials->api_key ?? config('synergy.api_key');
 
                     // Initialize the SOAP client
                     $this->client = new \SoapClient(config('synergy.api_url'), [

--- a/database/migrations/2025_07_19_043525_create_synergy_credentials_table.php
+++ b/database/migrations/2025_07_19_043525_create_synergy_credentials_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('synergy_credentials', function (Blueprint $table) {
+            $table->id();
+            $table->string('reseller_id');
+            $table->string('api_key');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('synergy_credentials');
+    }
+};

--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};


### PR DESCRIPTION
## Summary
- add `SynergyCredential` model and migration
- use `SynergyCredential` in `SynergyAPIController`
- fetch credentials from DB in `SynergyWholesaleServiceProvider`
- read credentials in `DomainController`
- fix missing semicolon in `create_api_keys_table` migration

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687b2003156c8331a05ac472aa36b650