### PR TITLE
Implement role middleware and tests

### DIFF
--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -13,8 +13,14 @@ class RoleMiddleware
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next, string $role): Response
     {
+        $user = $request->user();
+
+        if (! $user || $user->role !== $role) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
         return $next($request);
     }
 }

--- a/tests/Feature/RoleMiddlewareTest.php
+++ b/tests/Feature/RoleMiddlewareTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RoleMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('role:admin')->get('/admin-only', fn () => 'admin');
+        Route::middleware('role:customer')->get('/customer-only', fn () => 'customer');
+    }
+
+    public function test_admin_can_access_admin_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'admin']);
+        $this->actingAs($user);
+
+        $this->get('/admin-only')->assertOk();
+    }
+
+    public function test_customer_cannot_access_admin_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'customer']);
+        $this->actingAs($user);
+
+        $this->get('/admin-only')->assertForbidden();
+    }
+
+    public function test_guest_cannot_access_admin_route(): void
+    {
+        $this->get('/admin-only')->assertForbidden();
+    }
+
+    public function test_customer_can_access_customer_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'customer']);
+        $this->actingAs($user);
+
+        $this->get('/customer-only')->assertOk();
+    }
+
+    public function test_admin_cannot_access_customer_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'admin']);
+        $this->actingAs($user);
+
+        $this->get('/customer-only')->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- implement role check in `RoleMiddleware`
- add a feature test covering admin and customer routes

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: ./vendor/bin/phpunit tests/Feature/RoleMiddlewareTest.php`

------
https://chatgpt.com/codex/tasks/task_b_687b1ffdb1c08331a39ea6e3ca933217