### PR TITLE
Switch to Str::random for API key tokens

### DIFF
--- a/app/Http/Controllers/APIKeyController.php
+++ b/app/Http/Controllers/APIKeyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\ApiKey;
+use Illuminate\Support\Str;
 
 class ApiKeyController extends Controller
 {
@@ -27,17 +28,21 @@ class ApiKeyController extends Controller
             'rate_limit' => 'required|integer|min:1',
         ]);
 
+        $plainToken = Str::random(32);
+
         ApiKey::create([
             'key_name' => $request->key_name,
             'description' => $request->description,
-            'hashed_key' => hash('sha256', uniqid()),
+            'hashed_key' => hash('sha256', $plainToken),
             'permissions' => $request->permissions,
             'allowed_ips' => $request->allowed_ips,
             'rate_limit' => $request->rate_limit,
             'expires_at' => $request->expires_at,
         ]);
 
-        return redirect()->route('api-keys.index')->with('success', 'API key created successfully.');
+        return redirect()->route('api-keys.index')
+            ->with('success', 'API key created successfully.')
+            ->with('plainToken', $plainToken);
     }
 
     public function destroy($id)

--- a/resources/views/admin/api-keys/index.blade.php
+++ b/resources/views/admin/api-keys/index.blade.php
@@ -6,6 +6,13 @@
 <a href="{{ route('api-keys.create') }}" class="bg-green-500 text-white px-4 py-2 rounded mb-4 inline-block">Create API Key</a>
 @endif
 
+@if(session('plainToken'))
+<div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+    <p>Your new API token:</p>
+    <pre class="font-mono break-all">{{ session('plainToken') }}</pre>
+</div>
+@endif
+
 <table class="table-auto w-full border-collapse border border-gray-300">
     <thead>
         <tr>


### PR DESCRIPTION
## Summary
- generate API tokens using `Str::random(32)` instead of `uniqid()`
- flash the plain token and show it once on the API key index page

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --stop-on-failure` *(fails: Route [home] not defined)*

------
https://chatgpt.com/codex/tasks/task_b_687b1ffa66f8833184f4e14b62729ecc