### PR TITLE
Fix API key resource routes

### DIFF
--- a/resources/views/admin/api-keys/index.blade.php
+++ b/resources/views/admin/api-keys/index.blade.php
@@ -25,7 +25,6 @@
             <td class="border border-gray-300 px-4 py-2">{{ $key->allowed_ips }}</td>
             @if(auth()->user()->role === 'admin')
             <td class="border border-gray-300 px-4 py-2">
-                <a href="{{ route('api-keys.edit', $key->id) }}" class="text-blue-500">Edit</a>
                 <form action="{{ route('api-keys.destroy', $key->id) }}" method="POST" style="display:inline;">
                     @csrf
                     @method('DELETE')

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('notifications', NotificationController::class)->only(['index']);
     Route::resource('backup-settings', BackupSettingController::class)->only(['edit', 'update']);
     Route::resource('smtp-settings', SMTPSettingController::class)->only(['edit', 'update']);
-    Route::resource('api-keys', ApiKeyController::class);
+    Route::resource('api-keys', ApiKeyController::class)->only(['index', 'create', 'store', 'destroy']);
     Route::get('synergy-api', [SynergyAPIController::class, 'edit'])->name('synergy-api.edit');
     Route::post('synergy-api', [SynergyAPIController::class, 'update'])->name('synergy-api.update');
 });


### PR DESCRIPTION
## Summary
- restrict available api-key routes to implemented actions
- drop unused edit link in api-key index view

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b1ff1c94c83319d37dabe6eed26c3