### PR TITLE
Implement CRUD for domain & service controllers

### DIFF
--- a/app/Http/Controllers/DomainController.php
+++ b/app/Http/Controllers/DomainController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Domain;
+use App\Models\User;
 
 class DomainController extends Controller
 {
@@ -11,7 +13,8 @@ class DomainController extends Controller
      */
     public function index()
     {
-        //
+        $domains = Domain::with('customer')->get();
+        return view('domains.index', compact('domains'));
     }
 
     /**
@@ -19,7 +22,8 @@ class DomainController extends Controller
      */
     public function create()
     {
-        //
+        $customers = User::all();
+        return view('domains.create', compact('customers'));
     }
 
     /**
@@ -27,7 +31,16 @@ class DomainController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'domain_name' => 'required|string|max:255',
+            'customer_id' => 'nullable|exists:users,id',
+            'auto_renew' => 'boolean',
+            'renewal_date' => 'nullable|date',
+        ]);
+
+        Domain::create($data);
+
+        return redirect()->route('domains.index')->with('success', 'Domain created successfully.');
     }
 
     /**
@@ -43,7 +56,9 @@ class DomainController extends Controller
      */
     public function edit(string $id)
     {
-        //
+        $domain = Domain::findOrFail($id);
+        $customers = User::all();
+        return view('domains.edit', compact('domain', 'customers'));
     }
 
     /**
@@ -51,7 +66,17 @@ class DomainController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        //
+        $data = $request->validate([
+            'domain_name' => 'required|string|max:255',
+            'customer_id' => 'nullable|exists:users,id',
+            'auto_renew' => 'boolean',
+            'renewal_date' => 'nullable|date',
+        ]);
+
+        $domain = Domain::findOrFail($id);
+        $domain->update($data);
+
+        return redirect()->route('domains.index')->with('success', 'Domain updated successfully.');
     }
 
     /**
@@ -59,6 +84,9 @@ class DomainController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $domain = Domain::findOrFail($id);
+        $domain->delete();
+
+        return redirect()->route('domains.index')->with('success', 'Domain deleted successfully.');
     }
 }

--- a/app/Http/Controllers/HostingServiceController.php
+++ b/app/Http/Controllers/HostingServiceController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\HostingService;
+use App\Models\User;
 
 class HostingServiceController extends Controller
 {
@@ -11,7 +13,8 @@ class HostingServiceController extends Controller
      */
     public function index()
     {
-        //
+        $hostingServices = HostingService::with('customer')->get();
+        return view('hosting-services.index', compact('hostingServices'));
     }
 
     /**
@@ -19,7 +22,8 @@ class HostingServiceController extends Controller
      */
     public function create()
     {
-        //
+        $customers = User::all();
+        return view('hosting-services.create', compact('customers'));
     }
 
     /**
@@ -27,7 +31,18 @@ class HostingServiceController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'service_name' => 'required|string|max:255',
+            'customer_id' => 'nullable|exists:users,id',
+            'disk_usage' => 'nullable|integer',
+            'database_usage' => 'nullable|integer',
+            'disk_space_threshold' => 'nullable|integer',
+            'hosting_plan' => 'required|string',
+        ]);
+
+        HostingService::create($data);
+
+        return redirect()->route('hosting-services.index')->with('success', 'Hosting service created successfully.');
     }
 
     /**
@@ -43,7 +58,9 @@ class HostingServiceController extends Controller
      */
     public function edit(string $id)
     {
-        //
+        $hostingService = HostingService::findOrFail($id);
+        $customers = User::all();
+        return view('hosting-services.edit', compact('hostingService', 'customers'));
     }
 
     /**
@@ -51,7 +68,19 @@ class HostingServiceController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        //
+        $data = $request->validate([
+            'service_name' => 'required|string|max:255',
+            'customer_id' => 'nullable|exists:users,id',
+            'disk_usage' => 'nullable|integer',
+            'database_usage' => 'nullable|integer',
+            'disk_space_threshold' => 'nullable|integer',
+            'hosting_plan' => 'required|string',
+        ]);
+
+        $hostingService = HostingService::findOrFail($id);
+        $hostingService->update($data);
+
+        return redirect()->route('hosting-services.index')->with('success', 'Hosting service updated successfully.');
     }
 
     /**
@@ -59,6 +88,9 @@ class HostingServiceController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $hostingService = HostingService::findOrFail($id);
+        $hostingService->delete();
+
+        return redirect()->route('hosting-services.index')->with('success', 'Hosting service deleted successfully.');
     }
 }

--- a/app/Http/Controllers/SSLServiceController.php
+++ b/app/Http/Controllers/SSLServiceController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\SSLService;
+use App\Models\User;
 
 class SSLServiceController extends Controller
 {
@@ -11,7 +13,8 @@ class SSLServiceController extends Controller
      */
     public function index()
     {
-        //
+        $sslServices = SSLService::with('customer')->get();
+        return view('ssl-services.index', compact('sslServices'));
     }
 
     /**
@@ -19,7 +22,8 @@ class SSLServiceController extends Controller
      */
     public function create()
     {
-        //
+        $customers = User::all();
+        return view('ssl-services.create', compact('customers'));
     }
 
     /**
@@ -27,7 +31,16 @@ class SSLServiceController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'certificate_name' => 'required|string|max:255',
+            'customer_id' => 'nullable|exists:users,id',
+            'expiration_date' => 'required|date',
+            'details' => 'nullable|string',
+        ]);
+
+        SSLService::create($data);
+
+        return redirect()->route('ssl-services.index')->with('success', 'SSL service created successfully.');
     }
 
     /**
@@ -43,7 +56,9 @@ class SSLServiceController extends Controller
      */
     public function edit(string $id)
     {
-        //
+        $sslService = SSLService::findOrFail($id);
+        $customers = User::all();
+        return view('ssl-services.edit', compact('sslService', 'customers'));
     }
 
     /**
@@ -51,7 +66,17 @@ class SSLServiceController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        //
+        $data = $request->validate([
+            'certificate_name' => 'required|string|max:255',
+            'customer_id' => 'nullable|exists:users,id',
+            'expiration_date' => 'required|date',
+            'details' => 'nullable|string',
+        ]);
+
+        $sslService = SSLService::findOrFail($id);
+        $sslService->update($data);
+
+        return redirect()->route('ssl-services.index')->with('success', 'SSL service updated successfully.');
     }
 
     /**
@@ -59,6 +84,9 @@ class SSLServiceController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $sslService = SSLService::findOrFail($id);
+        $sslService->delete();
+
+        return redirect()->route('ssl-services.index')->with('success', 'SSL service deleted successfully.');
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
@@ -11,7 +13,8 @@ class UserController extends Controller
      */
     public function index()
     {
-        //
+        $users = User::all();
+        return view('users.index', compact('users'));
     }
 
     /**
@@ -19,7 +22,7 @@ class UserController extends Controller
      */
     public function create()
     {
-        //
+        return view('users.create');
     }
 
     /**
@@ -27,7 +30,19 @@ class UserController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $data = $request->validate([
+            'first_name' => 'required|string|max:255',
+            'surname' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|string|min:6',
+            'role' => 'required|in:admin,customer',
+        ]);
+
+        $data['password'] = Hash::make($data['password']);
+
+        User::create($data);
+
+        return redirect()->route('users.index')->with('success', 'User created successfully.');
     }
 
     /**
@@ -43,7 +58,8 @@ class UserController extends Controller
      */
     public function edit(string $id)
     {
-        //
+        $user = User::findOrFail($id);
+        return view('users.edit', compact('user'));
     }
 
     /**
@@ -51,7 +67,25 @@ class UserController extends Controller
      */
     public function update(Request $request, string $id)
     {
-        //
+        $user = User::findOrFail($id);
+
+        $data = $request->validate([
+            'first_name' => 'required|string|max:255',
+            'surname' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email,' . $user->id,
+            'password' => 'nullable|string|min:6',
+            'role' => 'required|in:admin,customer',
+        ]);
+
+        if ($request->filled('password')) {
+            $data['password'] = Hash::make($data['password']);
+        } else {
+            unset($data['password']);
+        }
+
+        $user->update($data);
+
+        return redirect()->route('users.index')->with('success', 'User updated successfully.');
     }
 
     /**
@@ -59,6 +93,9 @@ class UserController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $user = User::findOrFail($id);
+        $user->delete();
+
+        return redirect()->route('users.index')->with('success', 'User deleted successfully.');
     }
 }

--- a/resources/views/domains/create.blade.php
+++ b/resources/views/domains/create.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create Domain</h1>
+<form action="{{ route('domains.store') }}" method="POST">
+    @csrf
+    <div>
+        <label>Domain Name</label>
+        <input type="text" name="domain_name" required>
+    </div>
+    <div>
+        <label>Customer</label>
+        <select name="customer_id">
+            <option value="">None</option>
+            @foreach($customers as $customer)
+                <option value="{{ $customer->id }}">{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Renewal Date</label>
+        <input type="date" name="renewal_date">
+    </div>
+    <div>
+        <label>Auto Renew</label>
+        <input type="checkbox" name="auto_renew" value="1" checked>
+    </div>
+    <button type="submit">Create</button>
+</form>
+@endsection

--- a/resources/views/domains/edit.blade.php
+++ b/resources/views/domains/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Domain</h1>
+<form action="{{ route('domains.update', $domain->id) }}" method="POST">
+    @csrf
+    @method('PUT')
+    <div>
+        <label>Domain Name</label>
+        <input type="text" name="domain_name" value="{{ $domain->domain_name }}" required>
+    </div>
+    <div>
+        <label>Customer</label>
+        <select name="customer_id">
+            <option value="">None</option>
+            @foreach($customers as $customer)
+                <option value="{{ $customer->id }}" @selected($domain->customer_id == $customer->id)>{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Renewal Date</label>
+        <input type="date" name="renewal_date" value="{{ optional($domain->renewal_date)->format('Y-m-d') }}">
+    </div>
+    <div>
+        <label>Auto Renew</label>
+        <input type="checkbox" name="auto_renew" value="1" @checked($domain->auto_renew)>
+    </div>
+    <button type="submit">Update</button>
+</form>
+@endsection

--- a/resources/views/hosting-services/create.blade.php
+++ b/resources/views/hosting-services/create.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create Hosting Service</h1>
+<form action="{{ route('hosting-services.store') }}" method="POST">
+    @csrf
+    <div>
+        <label>Service Name</label>
+        <input type="text" name="service_name" required>
+    </div>
+    <div>
+        <label>Customer</label>
+        <select name="customer_id">
+            <option value="">None</option>
+            @foreach($customers as $customer)
+                <option value="{{ $customer->id }}">{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Disk Usage (MB)</label>
+        <input type="number" name="disk_usage" value="0">
+    </div>
+    <div>
+        <label>Database Usage (MB)</label>
+        <input type="number" name="database_usage" value="0">
+    </div>
+    <div>
+        <label>Disk Space Threshold (%)</label>
+        <input type="number" name="disk_space_threshold" value="80">
+    </div>
+    <div>
+        <label>Hosting Plan</label>
+        <input type="text" name="hosting_plan" required>
+    </div>
+    <button type="submit">Create</button>
+</form>
+@endsection

--- a/resources/views/hosting-services/edit.blade.php
+++ b/resources/views/hosting-services/edit.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Hosting Service</h1>
+<form action="{{ route('hosting-services.update', $hostingService->id) }}" method="POST">
+    @csrf
+    @method('PUT')
+    <div>
+        <label>Service Name</label>
+        <input type="text" name="service_name" value="{{ $hostingService->service_name }}" required>
+    </div>
+    <div>
+        <label>Customer</label>
+        <select name="customer_id">
+            <option value="">None</option>
+            @foreach($customers as $customer)
+                <option value="{{ $customer->id }}" @selected($hostingService->customer_id == $customer->id)>{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Disk Usage (MB)</label>
+        <input type="number" name="disk_usage" value="{{ $hostingService->disk_usage }}">
+    </div>
+    <div>
+        <label>Database Usage (MB)</label>
+        <input type="number" name="database_usage" value="{{ $hostingService->database_usage }}">
+    </div>
+    <div>
+        <label>Disk Space Threshold (%)</label>
+        <input type="number" name="disk_space_threshold" value="{{ $hostingService->disk_space_threshold }}">
+    </div>
+    <div>
+        <label>Hosting Plan</label>
+        <input type="text" name="hosting_plan" value="{{ $hostingService->hosting_plan }}" required>
+    </div>
+    <button type="submit">Update</button>
+</form>
+@endsection

--- a/resources/views/ssl-services/create.blade.php
+++ b/resources/views/ssl-services/create.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create SSL Service</h1>
+<form action="{{ route('ssl-services.store') }}" method="POST">
+    @csrf
+    <div>
+        <label>Certificate Name</label>
+        <input type="text" name="certificate_name" required>
+    </div>
+    <div>
+        <label>Customer</label>
+        <select name="customer_id">
+            <option value="">None</option>
+            @foreach($customers as $customer)
+                <option value="{{ $customer->id }}">{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Expiration Date</label>
+        <input type="date" name="expiration_date" required>
+    </div>
+    <div>
+        <label>Details</label>
+        <textarea name="details"></textarea>
+    </div>
+    <button type="submit">Create</button>
+</form>
+@endsection

--- a/resources/views/ssl-services/edit.blade.php
+++ b/resources/views/ssl-services/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit SSL Service</h1>
+<form action="{{ route('ssl-services.update', $sslService->id) }}" method="POST">
+    @csrf
+    @method('PUT')
+    <div>
+        <label>Certificate Name</label>
+        <input type="text" name="certificate_name" value="{{ $sslService->certificate_name }}" required>
+    </div>
+    <div>
+        <label>Customer</label>
+        <select name="customer_id">
+            <option value="">None</option>
+            @foreach($customers as $customer)
+                <option value="{{ $customer->id }}" @selected($sslService->customer_id == $customer->id)>{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div>
+        <label>Expiration Date</label>
+        <input type="date" name="expiration_date" value="{{ optional($sslService->expiration_date)->format('Y-m-d') }}" required>
+    </div>
+    <div>
+        <label>Details</label>
+        <textarea name="details">{{ $sslService->details }}</textarea>
+    </div>
+    <button type="submit">Update</button>
+</form>
+@endsection

--- a/resources/views/ssl-services/index.blade.php
+++ b/resources/views/ssl-services/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">SSL Services</h1>
+<a href="{{ route('ssl-services.create') }}" class="bg-green-500 text-white px-4 py-2 rounded mb-4 inline-block">Add New SSL</a>
+<table class="table-auto w-full border-collapse border border-gray-300">
+    <thead>
+        <tr>
+            <th class="border border-gray-300 px-4 py-2">Certificate Name</th>
+            <th class="border border-gray-300 px-4 py-2">Customer</th>
+            <th class="border border-gray-300 px-4 py-2">Expiration Date</th>
+            <th class="border border-gray-300 px-4 py-2">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($sslServices as $ssl)
+        <tr>
+            <td class="border border-gray-300 px-4 py-2">{{ $ssl->certificate_name }}</td>
+            <td class="border border-gray-300 px-4 py-2">{{ optional($ssl->customer)->first_name }} {{ optional($ssl->customer)->surname }}</td>
+            <td class="border border-gray-300 px-4 py-2">{{ $ssl->expiration_date }}</td>
+            <td class="border border-gray-300 px-4 py-2">
+                <a href="{{ route('ssl-services.edit', $ssl->id) }}" class="text-blue-500">Edit</a>
+                <form action="{{ route('ssl-services.destroy', $ssl->id) }}" method="POST" style="display:inline;">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="text-red-500">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit User</h1>
+<form action="{{ route('users.update', $user->id) }}" method="POST">
+    @csrf
+    @method('PUT')
+    <div>
+        <label>First Name</label>
+        <input type="text" name="first_name" value="{{ $user->first_name }}" required>
+    </div>
+    <div>
+        <label>Surname</label>
+        <input type="text" name="surname" value="{{ $user->surname }}" required>
+    </div>
+    <div>
+        <label>Email</label>
+        <input type="email" name="email" value="{{ $user->email }}" required>
+    </div>
+    <div>
+        <label>Password (leave blank to keep current)</label>
+        <input type="password" name="password">
+    </div>
+    <div>
+        <label>Role</label>
+        <select name="role" required>
+            <option value="admin" @selected($user->role === 'admin')>Admin</option>
+            <option value="customer" @selected($user->role === 'customer')>Customer</option>
+        </select>
+    </div>
+    <button type="submit">Update</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,10 +14,10 @@ use Illuminate\Support\Facades\Route;
 */
 #Admin Only 
 Route::middleware(['auth', 'role:admin'])->group(function () {
-    Route::resource('users', UserController::class);
-    Route::resource('domains', DomainController::class);
-    Route::resource('hosting-services', HostingServiceController::class);
-    Route::resource('ssl-services', SSLServiceController::class);
+    Route::resource('users', UserController::class)->except(['show']);
+    Route::resource('domains', DomainController::class)->except(['show']);
+    Route::resource('hosting-services', HostingServiceController::class)->except(['show']);
+    Route::resource('ssl-services', SSLServiceController::class)->except(['show']);
     Route::resource('email-templates', EmailTemplateController::class)->except(['show']);
     Route::resource('notifications', NotificationController::class)->only(['index']);
     Route::resource('backup-settings', BackupSettingController::class)->only(['edit', 'update']);


### PR DESCRIPTION
## Summary
- add CRUD actions to Domain, HostingService, SSLService and User controllers
- create simple forms for domains, hosting, SSL services and user editing
- restrict admin routes to omit unimplemented `show` actions

## Testing
- `composer install`
- `./vendor/bin/phpunit --dont-report-useless-tests --colors=never` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687b200868b883318c56d26ad13d54a9