### PR TITLE
Fix migration autoloading issues

### DIFF
--- a/app/Console/Commands/CheckDiskUsage.php
+++ b/app/Console/Commands/CheckDiskUsage.php
@@ -1,6 +1,9 @@
+<?php
+
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use App\Models\HostingService;
 
 class CheckDiskUsage extends Command
 {

--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,5 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};
+

--- a/database/migrations/create_backup_settings_table.php
+++ b/database/migrations/create_backup_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateBackupSettingsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -24,4 +24,4 @@ class CreateBackupSettingsTable extends Migration
     {
         Schema::dropIfExists('backup_settings');
     }
-}
+};

--- a/database/migrations/create_domains_table.php
+++ b/database/migrations/create_domains_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateDomainsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class CreateDomainsTable extends Migration
     {
         Schema::dropIfExists('domains');
     }
-}
+};

--- a/database/migrations/create_email_templates_table.php
+++ b/database/migrations/create_email_templates_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateEmailTemplatesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -21,4 +21,4 @@ class CreateEmailTemplatesTable extends Migration
     {
         Schema::dropIfExists('email_templates');
     }
-}
+};

--- a/database/migrations/create_hosting_services_table.php
+++ b/database/migrations/create_hosting_services_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateHostingServicesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -24,4 +24,4 @@ class CreateHostingServicesTable extends Migration
     {
         Schema::dropIfExists('hosting_services');
     }
-}
+};

--- a/database/migrations/create_notifications_table.php
+++ b/database/migrations/create_notifications_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateNotificationsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class CreateNotificationsTable extends Migration
     {
         Schema::dropIfExists('notifications');
     }
-}
+};

--- a/database/migrations/create_smtp_settings_table.php
+++ b/database/migrations/create_smtp_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSmtpSettingsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,4 +23,4 @@ class CreateSmtpSettingsTable extends Migration
     {
         Schema::dropIfExists('smtp_settings');
     }
-}
+};

--- a/database/migrations/create_ssl_services_table.php
+++ b/database/migrations/create_ssl_services_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSslServicesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class CreateSslServicesTable extends Migration
     {
         Schema::dropIfExists('ssl_services');
     }
-}
+};

--- a/database/migrations/create_system_metrics_table.php
+++ b/database/migrations/create_system_metrics_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSystemMetricsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -20,4 +20,4 @@ class CreateSystemMetricsTable extends Migration
     {
         Schema::dropIfExists('system_metrics');
     }
-}
+};

--- a/database/migrations/create_users_table.php
+++ b/database/migrations/create_users_table.php
@@ -1,13 +1,27 @@
-public function up()
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
 {
-    Schema::create('users', function (Blueprint $table) {
-        $table->id();
-        $table->string('first_name');
-        $table->string('surname');
-        $table->string('email')->unique();
-        $table->string('password');
-        $table->enum('role', ['admin', 'customer']);
-        $table->boolean('dark_mode')->default(false);
-        $table->timestamps();
-    });
-}
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('surname');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('role', ['admin', 'customer']);
+            $table->boolean('dark_mode')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
## Summary
- fix missing PHP opening tag in `CheckDiskUsage` command
- switch migrations to anonymous classes to avoid class redeclaration
- repair corrupted `create_users_table` migration
- enable in-memory SQLite DB for tests

## Testing
- `vendor/bin/phpunit --filter=ExampleTest`


------
https://chatgpt.com/codex/tasks/task_b_687ac6647e3483319a9c2385a66a9704