### PR TITLE
Add technician role and permissions UI

### DIFF
--- a/app/Http/Controllers/PermissionController.php
+++ b/app/Http/Controllers/PermissionController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\RolePermission;
+
+class PermissionController extends Controller
+{
+    private array $availablePermissions = [
+        'manage_domains',
+        'manage_hosting',
+        'manage_ssl',
+    ];
+
+    private array $roles = ['admin', 'technician', 'customer'];
+
+    public function edit()
+    {
+        $rolePermissions = RolePermission::all()->groupBy('role');
+
+        return view('admin.permissions.edit', [
+            'permissions' => $this->availablePermissions,
+            'roles' => $this->roles,
+            'rolePermissions' => $rolePermissions,
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $data = $request->input('permissions', []);
+
+        foreach ($this->roles as $role) {
+            RolePermission::where('role', $role)->delete();
+            if (! empty($data[$role])) {
+                foreach ($data[$role] as $permission) {
+                    RolePermission::create([
+                        'role' => $role,
+                        'permission' => $permission,
+                    ]);
+                }
+            }
+        }
+
+        return redirect()->route('permissions.edit')->with('success', 'Permissions updated.');
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -35,7 +35,7 @@ class UserController extends Controller
             'surname' => 'required|string|max:255',
             'email' => 'required|email|unique:users,email',
             'password' => 'required|string|min:6',
-            'role' => 'required|in:admin,customer',
+            'role' => 'required|in:admin,technician,customer',
         ]);
 
         $data['password'] = Hash::make($data['password']);
@@ -74,7 +74,7 @@ class UserController extends Controller
             'surname' => 'required|string|max:255',
             'email' => 'required|email|unique:users,email,' . $user->id,
             'password' => 'nullable|string|min:6',
-            'role' => 'required|in:admin,customer',
+            'role' => 'required|in:admin,technician,customer',
         ]);
 
         if ($request->filled('password')) {

--- a/app/Models/RolePermission.php
+++ b/app/Models/RolePermission.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RolePermission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'role',
+        'permission',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,9 +24,12 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
+        'first_name',
+        'surname',
         'email',
         'password',
+        'role',
+        'dark_mode',
     ];
 
     /**

--- a/database/migrations/create_role_permissions_table.php
+++ b/database/migrations/create_role_permissions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('role_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('role');
+            $table->string('permission');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('role_permissions');
+    }
+};

--- a/database/migrations/create_users_table.php
+++ b/database/migrations/create_users_table.php
@@ -14,7 +14,7 @@ class CreateUsersTable extends Migration
             $table->string('surname');
             $table->string('email')->unique();
             $table->string('password');
-            $table->enum('role', ['admin', 'customer']);
+            $table->enum('role', ['admin', 'technician', 'customer']);
             $table->boolean('dark_mode')->default(false);
             $table->timestamps();
         });

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
 {
     $this->call([
         UserSeeder::class,
+        RolePermissionSeeder::class,
         DomainSeeder::class,
         HostingServiceSeeder::class,
         SSLServiceSeeder::class,

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\RolePermission;
+
+class RolePermissionSeeder extends Seeder
+{
+    public function run()
+    {
+        $permissions = ['manage_domains', 'manage_hosting', 'manage_ssl'];
+
+        foreach ($permissions as $perm) {
+            RolePermission::create([
+                'role' => 'admin',
+                'permission' => $perm,
+            ]);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -26,5 +26,14 @@ class UserSeeder extends Seeder
             'role' => 'customer',
             'dark_mode' => false,
         ]);
+
+        User::create([
+            'first_name' => 'Tech',
+            'surname' => 'User',
+            'email' => 'technician@jargonconsulting.com.au',
+            'password' => bcrypt('tech'),
+            'role' => 'technician',
+            'dark_mode' => false,
+        ]);
     }
 }

--- a/resources/views/admin/permissions/edit.blade.php
+++ b/resources/views/admin/permissions/edit.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Role Permissions</h1>
+@if(session('success'))
+    <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+        {{ session('success') }}
+    </div>
+@endif
+<form method="POST" action="{{ route('permissions.update') }}">
+    @csrf
+    <table class="table-auto w-full border-collapse border border-gray-300">
+        <thead>
+            <tr>
+                <th class="border border-gray-300 px-4 py-2">Role</th>
+                @foreach($permissions as $permission)
+                    <th class="border border-gray-300 px-4 py-2">{{ $permission }}</th>
+                @endforeach
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($roles as $role)
+            <tr>
+                <td class="border border-gray-300 px-4 py-2">{{ ucfirst($role) }}</td>
+                @foreach($permissions as $permission)
+                <td class="border border-gray-300 px-4 py-2 text-center">
+                    <input type="checkbox" name="permissions[{{ $role }}][]" value="{{ $permission }}"
+                        @checked(isset($rolePermissions[$role]) && $rolePermissions[$role]->pluck('permission')->contains($permission)) />
+                </td>
+                @endforeach
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded mt-4">Save</button>
+</form>
+@endsection

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -24,6 +24,7 @@
         <label>Role</label>
         <select name="role" required>
             <option value="admin">Admin</option>
+            <option value="technician">Technician</option>
             <option value="customer">Customer</option>
         </select>
     </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -25,6 +25,7 @@
         <label>Role</label>
         <select name="role" required>
             <option value="admin" @selected($user->role === 'admin')>Admin</option>
+            <option value="technician" @selected($user->role === 'technician')>Technician</option>
             <option value="customer" @selected($user->role === 'customer')>Customer</option>
         </select>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('api-keys', ApiKeyController::class)->only(['index', 'create', 'store', 'destroy']);
     Route::get('synergy-api', [SynergyAPIController::class, 'edit'])->name('synergy-api.edit');
     Route::post('synergy-api', [SynergyAPIController::class, 'update'])->name('synergy-api.update');
+    Route::get('permissions', [PermissionController::class, 'edit'])->name('permissions.edit');
+    Route::post('permissions', [PermissionController::class, 'update'])->name('permissions.update');
 });
 #Customer
 Route::middleware(['auth', 'role:customer'])->group(function () {

--- a/tests/Feature/RoleMiddlewareTest.php
+++ b/tests/Feature/RoleMiddlewareTest.php
@@ -14,6 +14,7 @@ class RoleMiddlewareTest extends TestCase
 
         Route::middleware('role:admin')->get('/admin-only', fn () => 'admin');
         Route::middleware('role:customer')->get('/customer-only', fn () => 'customer');
+        Route::middleware('role:technician')->get('/tech-only', fn () => 'tech');
     }
 
     public function test_admin_can_access_admin_route(): void
@@ -51,5 +52,29 @@ class RoleMiddlewareTest extends TestCase
         $this->actingAs($user);
 
         $this->get('/customer-only')->assertForbidden();
+    }
+
+    public function test_technician_can_access_technician_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'technician']);
+        $this->actingAs($user);
+
+        $this->get('/tech-only')->assertOk();
+    }
+
+    public function test_customer_cannot_access_technician_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'customer']);
+        $this->actingAs($user);
+
+        $this->get('/tech-only')->assertForbidden();
+    }
+
+    public function test_admin_cannot_access_technician_route(): void
+    {
+        $user = User::factory()->make(['id' => 1, 'role' => 'admin']);
+        $this->actingAs($user);
+
+        $this->get('/tech-only')->assertForbidden();
     }
 }


### PR DESCRIPTION
## Summary
- allow the new `technician` role in the users table
- seed an example technician user
- update `User` model and validation rules for the new role
- create role permission management with database storage
- add admin UI for editing role permissions
- tests for RoleMiddleware updated with technician role

## Testing
- `./vendor/bin/phpunit --display-warnings | tail -n 20` *(fails: Route [home] not defined and SynergyServiceTest errors)*

------
https://chatgpt.com/codex/tasks/task_b_687c41b0fd588331848b2cfed8623084