### PR TITLE
Capture additional user details on register

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -20,16 +20,22 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'surname' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
+            'role' => ['required', 'in:admin,customer'],
+            'dark_mode' => ['nullable', 'boolean'],
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
         return User::create([
-            'name' => $input['name'],
+            'first_name' => $input['first_name'],
+            'surname' => $input['surname'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
+            'role' => $input['role'],
+            'dark_mode' => $input['dark_mode'] ?? false,
         ]);
     }
 }

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -18,8 +18,10 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     public function update(User $user, array $input): void
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'surname' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+            'dark_mode' => ['nullable', 'boolean'],
             'photo' => ['nullable', 'mimes:jpg,jpeg,png', 'max:1024'],
         ])->validateWithBag('updateProfileInformation');
 
@@ -32,8 +34,10 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             $this->updateVerifiedUser($user, $input);
         } else {
             $user->forceFill([
-                'name' => $input['name'],
+                'first_name' => $input['first_name'],
+                'surname' => $input['surname'],
                 'email' => $input['email'],
+                'dark_mode' => $input['dark_mode'] ?? $user->dark_mode,
             ])->save();
         }
     }
@@ -46,8 +50,10 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     protected function updateVerifiedUser(User $user, array $input): void
     {
         $user->forceFill([
-            'name' => $input['name'],
+            'first_name' => $input['first_name'],
+            'surname' => $input['surname'],
             'email' => $input['email'],
+            'dark_mode' => $input['dark_mode'] ?? $user->dark_mode,
             'email_verified_at' => null,
         ])->save();
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,9 +24,12 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
+        'first_name',
+        'surname',
         'email',
         'password',
+        'role',
+        'dark_mode',
     ];
 
     /**
@@ -48,6 +51,7 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'dark_mode' => 'boolean',
     ];
 
     /**
@@ -58,4 +62,9 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
+
+    public function getNameAttribute(): string
+    {
+        return trim($this->first_name.' '.$this->surname);
+    }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -21,10 +21,13 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->name(),
+            'first_name' => $this->faker->firstName(),
+            'surname' => $this->faker->lastName(),
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'role' => $this->faker->randomElement(['admin', 'customer']),
+            'dark_mode' => $this->faker->boolean(),
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
             'remember_token' => Str::random(10),

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -10,8 +10,13 @@
             @csrf
 
             <div>
-                <x-label for="name" value="{{ __('Name') }}" />
-                <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+                <x-label for="first_name" value="{{ __('First Name') }}" />
+                <x-input id="first_name" class="block mt-1 w-full" type="text" name="first_name" :value="old('first_name')" required autofocus />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="surname" value="{{ __('Surname') }}" />
+                <x-input id="surname" class="block mt-1 w-full" type="text" name="surname" :value="old('surname')" required />
             </div>
 
             <div class="mt-4">
@@ -22,6 +27,19 @@
             <div class="mt-4">
                 <x-label for="password" value="{{ __('Password') }}" />
                 <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="role" value="{{ __('Role') }}" />
+                <select id="role" name="role" class="block mt-1 w-full" required>
+                    <option value="admin">Admin</option>
+                    <option value="customer" selected>Customer</option>
+                </select>
+            </div>
+
+            <div class="mt-4 flex items-center">
+                <x-checkbox id="dark_mode" name="dark_mode" class="me-2" />
+                <x-label for="dark_mode" value="{{ __('Dark Mode') }}" />
             </div>
 
             <div class="mt-4">

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -52,11 +52,35 @@
             </div>
         @endif
 
-        <!-- Name -->
+        <!-- First Name -->
         <div class="col-span-6 sm:col-span-4">
-            <x-label for="name" value="{{ __('Name') }}" />
-            <x-input id="name" type="text" class="mt-1 block w-full" wire:model="state.name" required autocomplete="name" />
-            <x-input-error for="name" class="mt-2" />
+            <x-label for="first_name" value="{{ __('First Name') }}" />
+            <x-input id="first_name" type="text" class="mt-1 block w-full" wire:model="state.first_name" required />
+            <x-input-error for="first_name" class="mt-2" />
+        </div>
+
+        <!-- Surname -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="surname" value="{{ __('Surname') }}" />
+            <x-input id="surname" type="text" class="mt-1 block w-full" wire:model="state.surname" required />
+            <x-input-error for="surname" class="mt-2" />
+        </div>
+
+        <!-- Role -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="role" value="{{ __('Role') }}" />
+            <select id="role" wire:model="state.role" class="mt-1 block w-full">
+                <option value="admin">Admin</option>
+                <option value="customer">Customer</option>
+            </select>
+            <x-input-error for="role" class="mt-2" />
+        </div>
+
+        <!-- Dark Mode -->
+        <div class="col-span-6 sm:col-span-4 flex items-center">
+            <x-checkbox id="dark_mode" wire:model="state.dark_mode" class="me-2" />
+            <x-label for="dark_mode" value="{{ __('Dark Mode') }}" />
+            <x-input-error for="dark_mode" class="mt-2" />
         </div>
 
         <!-- Email -->

--- a/tests/Feature/ProfileInformationTest.php
+++ b/tests/Feature/ProfileInformationTest.php
@@ -18,7 +18,8 @@ class ProfileInformationTest extends TestCase
 
         $component = Livewire::test(UpdateProfileInformationForm::class);
 
-        $this->assertEquals($user->name, $component->state['name']);
+        $this->assertEquals($user->first_name, $component->state['first_name']);
+        $this->assertEquals($user->surname, $component->state['surname']);
         $this->assertEquals($user->email, $component->state['email']);
     }
 
@@ -27,10 +28,18 @@ class ProfileInformationTest extends TestCase
         $this->actingAs($user = User::factory()->create());
 
         Livewire::test(UpdateProfileInformationForm::class)
-            ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
+            ->set('state', [
+                'first_name' => 'Test',
+                'surname' => 'Name',
+                'email' => 'test@example.com',
+                'dark_mode' => true,
+                'role' => $user->role,
+            ])
             ->call('updateProfileInformation');
 
-        $this->assertEquals('Test Name', $user->fresh()->name);
+        $this->assertEquals('Test', $user->fresh()->first_name);
+        $this->assertEquals('Name', $user->fresh()->surname);
         $this->assertEquals('test@example.com', $user->fresh()->email);
+        $this->assertTrue($user->fresh()->dark_mode);
     }
 }

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -41,10 +41,13 @@ class RegistrationTest extends TestCase
         }
 
         $response = $this->post('/register', [
-            'name' => 'Test User',
+            'first_name' => 'Test',
+            'surname' => 'User',
             'email' => 'test@example.com',
             'password' => 'password',
             'password_confirmation' => 'password',
+            'role' => 'customer',
+            'dark_mode' => false,
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature(),
         ]);
 


### PR DESCRIPTION
## Summary
- register using first name, surname, role and dark mode
- allow profile updates for these fields
- show new fields in Jetstream registration and profile forms
- update factory and tests for new user attributes

## Testing
- `vendor/bin/phpunit --filter ''` *(fails: Route [home] not defined)*

------
https://chatgpt.com/codex/tasks/task_b_687c41b281248331b7d4e202d280fb2c