### PR TITLE
Add support ticket integration with HaloPSA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ REDIS_PORT=6379
 SYNERGY_API_URL=https://api.synergywholesale.com/server.php?wsdl
 SYNERGY_RESELLER_ID=
 SYNERGY_API_KEY=
+HALO_BASE_URL=
+HALO_API_KEY=
 
 MAIL_MAILER=smtp
 MAIL_HOST=mailpit

--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Services\HaloPsaClient;
+use Illuminate\Support\Facades\Auth;
+
+class SupportTicketController extends Controller
+{
+    private HaloPsaClient $halo;
+
+    public function __construct(HaloPsaClient $halo)
+    {
+        $this->middleware(['auth', 'verified']);
+        $this->halo = $halo;
+    }
+
+    public function create()
+    {
+        return view('support-tickets.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'subject' => 'required|string|max:255',
+            'message' => 'required|string',
+        ]);
+
+        $user = Auth::user();
+        $ticketData = [
+            'summary' => $data['subject'],
+            'details' => $data['message'],
+            'clientId' => $user->id,
+        ];
+
+        try {
+            $this->halo->createTicket($ticketData);
+            return redirect()->route('dashboard')->with('success', 'Support ticket logged successfully.');
+        } catch (\Exception $e) {
+            return back()->withErrors(['error' => 'Failed to log ticket: ' . $e->getMessage()]);
+        }
+    }
+}

--- a/app/Providers/HaloPsaServiceProvider.php
+++ b/app/Providers/HaloPsaServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Services\HaloPsaClient;
+
+class HaloPsaServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(HaloPsaClient::class, fn () => new HaloPsaClient());
+        $this->app->alias(HaloPsaClient::class, 'halo');
+    }
+}

--- a/app/Services/HaloPsaClient.php
+++ b/app/Services/HaloPsaClient.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class HaloPsaClient
+{
+    private Client $client;
+    private string $apiKey;
+
+    public function __construct()
+    {
+        $baseUrl = rtrim(config('halo.base_url'), '/');
+        $this->apiKey = config('halo.api_key');
+
+        $this->client = new Client([
+            'base_uri' => $baseUrl,
+            'headers' => [
+                'apikey' => $this->apiKey,
+                'Accept' => 'application/json',
+            ],
+        ]);
+    }
+
+    public function createTicket(array $data): array
+    {
+        try {
+            $response = $this->client->post('/api/tickets', [
+                'json' => $data,
+            ]);
+
+            return json_decode((string) $response->getBody(), true);
+        } catch (GuzzleException $e) {
+            throw new \Exception('HaloPSA API Error: ' . $e->getMessage());
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -171,6 +171,7 @@ return [
         App\Providers\FortifyServiceProvider::class,
         App\Providers\JetstreamServiceProvider::class,
         App\Providers\SynergyWholesaleServiceProvider::class,
+        App\Providers\HaloPsaServiceProvider::class,
 
     ])->toArray(),
 

--- a/config/halo.php
+++ b/config/halo.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'base_url' => env('HALO_BASE_URL', ''),
+    'api_key' => env('HALO_API_KEY', ''),
+];

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -107,6 +107,9 @@
                                     {{ __('API Tokens') }}
                                 </x-dropdown-link>
                             @endif
+                            <x-dropdown-link href="{{ route('support-ticket.create') }}">
+                                {{ __('Log Support Ticket') }}
+                            </x-dropdown-link>
 
                             <div class="border-t border-gray-200"></div>
 
@@ -170,6 +173,9 @@
                         {{ __('API Tokens') }}
                     </x-responsive-nav-link>
                 @endif
+                <x-responsive-nav-link href="{{ route('support-ticket.create') }}" :active="request()->routeIs('support-ticket.create')">
+                    {{ __('Log Support Ticket') }}
+                </x-responsive-nav-link>
 
                 <!-- Authentication -->
                 <form method="POST" action="{{ route('logout') }}" x-data>

--- a/resources/views/support-tickets/create.blade.php
+++ b/resources/views/support-tickets/create.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Log Support Ticket</h1>
+<form action="{{ route('support-ticket.store') }}" method="POST">
+    @csrf
+    <div>
+        <label>Subject</label>
+        <input type="text" name="subject" required>
+    </div>
+    <div>
+        <label>Message</label>
+        <textarea name="message" required></textarea>
+    </div>
+    <button type="submit">Submit</button>
+</form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,4 +46,6 @@ Route::middleware([
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/dashboard', [CustomerController::class, 'index'])->name('customer.dashboard');
     Route::get('/dashboard/search', [CustomerController::class, 'searchDomains'])->name('customer.domains.search');
+    Route::get('/support-ticket', [SupportTicketController::class, 'create'])->name('support-ticket.create');
+    Route::post('/support-ticket', [SupportTicketController::class, 'store'])->name('support-ticket.store');
 });


### PR DESCRIPTION
## Summary
- create HaloPsaClient service for REST API calls
- add HaloPsaServiceProvider
- allow users to create support tickets via new controller and view
- expose `/support-ticket` routes
- show "Log Support Ticket" in account dropdowns
- document HALO environment variables

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Tests: 39, Assertions: 8, Errors: 31, Failures: 2)*

------
https://chatgpt.com/codex/tasks/task_b_687c41b9fd0c8331b8afc33857c6c36b