### PR TITLE
Add notification emails and disk settings

### DIFF
--- a/app/Console/Commands/CheckDiskUsage.php
+++ b/app/Console/Commands/CheckDiskUsage.php
@@ -4,6 +4,10 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use App\Models\HostingService;
+use App\Models\EmailTemplate;
+use App\Models\Notification;
+use App\Models\DiskSetting;
+use Illuminate\Support\Facades\Mail;
 
 class CheckDiskUsage extends Command
 {
@@ -14,8 +18,38 @@ class CheckDiskUsage extends Command
     {
         $hostingServices = HostingService::all();
         foreach ($hostingServices as $service) {
-            if ($service->disk_usage > $service->disk_space_threshold) {
-                // Notify customer
+            $threshold = $service->disk_space_threshold;
+            if (!$threshold) {
+                $threshold = optional(DiskSetting::first())->warning_threshold ?? 80;
+            }
+
+            if ($service->disk_usage > $threshold && $service->customer) {
+                $template = EmailTemplate::where('template_type', 'disk_space_warning')->first();
+                if ($template) {
+                    $body = str_replace([
+                        '{{ customer_name }}',
+                        '{{ disk_usage }}'
+                    ], [
+                        $service->customer->first_name,
+                        $service->disk_usage
+                    ], $template->body);
+
+                    Mail::raw(strip_tags($body), function ($message) use ($service, $template) {
+                        $message->to($service->customer->email)
+                                ->subject($template->subject);
+                    });
+                }
+
+                Notification::create([
+                    'user_id' => $service->customer->id,
+                    'notification_type' => 'disk_space_warning',
+                    'details' => [
+                        'disk_usage' => $service->disk_usage,
+                        'threshold' => $threshold,
+                        'service_id' => $service->id,
+                    ],
+                    'is_read' => false,
+                ]);
             }
         }
     }

--- a/app/Console/Commands/CheckExpirations.php
+++ b/app/Console/Commands/CheckExpirations.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Domain;
+use App\Models\SSLService;
+use App\Models\EmailTemplate;
+use App\Models\Notification;
+use Illuminate\Support\Facades\Mail;
+use Carbon\Carbon;
+
+class CheckExpirations extends Command
+{
+    protected $signature = 'check:expirations';
+    protected $description = 'Notify customers about upcoming domain and SSL expirations';
+
+    public function handle()
+    {
+        $domainTemplate = EmailTemplate::where('template_type', 'domain_expiry')->first();
+        $sslTemplate = EmailTemplate::where('template_type', 'ssl_expiry')->first();
+
+        $soon = Carbon::now()->addDays(30);
+
+        $domains = Domain::with('customer')->where('renewal_date', '<=', $soon)->get();
+        foreach ($domains as $domain) {
+            if ($domain->customer && $domainTemplate) {
+                $body = str_replace([
+                    '{{ customer_name }}',
+                    '{{ domain_name }}',
+                    '{{ renewal_date }}'
+                ], [
+                    $domain->customer->first_name,
+                    $domain->domain_name,
+                    $domain->renewal_date->toDateString()
+                ], $domainTemplate->body);
+
+                Mail::raw(strip_tags($body), function ($message) use ($domainTemplate, $domain) {
+                    $message->to($domain->customer->email)
+                            ->subject($domainTemplate->subject);
+                });
+
+                Notification::create([
+                    'user_id' => $domain->customer->id,
+                    'notification_type' => 'domain_expiry',
+                    'details' => [
+                        'domain_id' => $domain->id,
+                        'renewal_date' => $domain->renewal_date,
+                    ],
+                    'is_read' => false,
+                ]);
+            }
+        }
+
+        $sslServices = SSLService::with('customer')->where('expiration_date', '<=', $soon)->get();
+        foreach ($sslServices as $ssl) {
+            if ($ssl->customer && $sslTemplate) {
+                $body = str_replace([
+                    '{{ customer_name }}',
+                    '{{ domain_name }}',
+                    '{{ expiration_date }}'
+                ], [
+                    $ssl->customer->first_name,
+                    $ssl->certificate_name,
+                    $ssl->expiration_date->toDateString()
+                ], $sslTemplate->body);
+
+                Mail::raw(strip_tags($body), function ($message) use ($sslTemplate, $ssl) {
+                    $message->to($ssl->customer->email)
+                            ->subject($sslTemplate->subject);
+                });
+
+                Notification::create([
+                    'user_id' => $ssl->customer->id,
+                    'notification_type' => 'ssl_expiry',
+                    'details' => [
+                        'ssl_service_id' => $ssl->id,
+                        'expiration_date' => $ssl->expiration_date,
+                    ],
+                    'is_read' => false,
+                ]);
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,8 +12,9 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
-	
+        $schedule->command('disk:check')->hourly();
+        $schedule->command('check:expirations')->daily();
+
     }
 
     /**

--- a/app/Http/Controllers/DiskSettingController.php
+++ b/app/Http/Controllers/DiskSettingController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\DiskSetting;
+
+class DiskSettingController extends Controller
+{
+    public function edit()
+    {
+        $settings = DiskSetting::first();
+        return view('admin.disk-settings.edit', compact('settings'));
+    }
+
+    public function update(Request $request)
+    {
+        $request->validate([
+            'warning_threshold' => 'required|integer|min:1',
+        ]);
+
+        $settings = DiskSetting::first();
+        $settings->update($request->only('warning_threshold'));
+
+        return redirect()->route('disk-settings.edit')->with('success', 'Disk settings updated successfully.');
+    }
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -12,4 +12,12 @@ class NotificationController extends Controller
         $notifications = Notification::latest()->get();
         return view('admin.notifications.index', compact('notifications'));
     }
+
+    public function markAsRead($id)
+    {
+        $notification = Notification::findOrFail($id);
+        $notification->update(['is_read' => true]);
+
+        return redirect()->back();
+    }
 }

--- a/app/Models/DiskSetting.php
+++ b/app/Models/DiskSetting.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DiskSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'warning_threshold',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
+use App\Models\Notification;
 
 class User extends Authenticatable
 {
@@ -58,4 +59,9 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
+
+    public function notifications()
+    {
+        return $this->hasMany(Notification::class);
+    }
 }

--- a/database/migrations/create_disk_settings_table.php
+++ b/database/migrations/create_disk_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDiskSettingsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('disk_settings', function (Blueprint $table) {
+            $table->id();
+            $table->integer('warning_threshold')->default(80);
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('disk_settings');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
         ApiKeySeeder::class,
         EmailTemplateSeeder::class,
         BackupSettingSeeder::class,
+        DiskSettingSeeder::class,
         NotificationSeeder::class,
         SMTPSettingSeeder::class,
         SystemMetricSeeder::class,

--- a/database/seeders/DiskSettingSeeder.php
+++ b/database/seeders/DiskSettingSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\DiskSetting;
+
+class DiskSettingSeeder extends Seeder
+{
+    public function run()
+    {
+        DiskSetting::create([
+            'warning_threshold' => 80,
+        ]);
+    }
+}

--- a/resources/views/admin/disk-settings/edit.blade.php
+++ b/resources/views/admin/disk-settings/edit.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Disk Usage Settings</h1>
+<form method="POST" action="{{ route('disk-settings.update') }}">
+    @csrf
+    @method('PUT')
+    <div class="mb-4">
+        <label for="warning_threshold" class="block text-gray-700 font-bold mb-2">Warning Threshold (%)</label>
+        <input type="number" name="warning_threshold" id="warning_threshold" value="{{ $settings->warning_threshold }}" class="w-full border rounded px-4 py-2">
+    </div>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save Changes</button>
+</form>
+@endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -20,6 +20,11 @@
             <p>Manage API keys for third-party integrations.</p>
             <a href="{{ route('api-keys.index') }}" class="text-blue-500">Go to API Keys</a>
         </div>
+        <div class="bg-white shadow rounded p-4">
+            <h2 class="text-xl font-bold">Disk Settings</h2>
+            <p>Configure disk usage warning threshold.</p>
+            <a href="{{ route('disk-settings.edit') }}" class="text-blue-500">Edit Disk Settings</a>
+        </div>
     @endif
 
     @if(auth()->user()->role === 'customer')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,7 @@
                             <a href="{{ route('users.index') }}" class="px-4">Users</a>
                             <a href="{{ route('email-templates.index') }}" class="px-4">Email Templates</a>
                             <a href="{{ route('api-keys.index') }}" class="px-4">API Keys</a>
+                            <a href="{{ route('disk-settings.edit') }}" class="px-4">Disk Settings</a>
                         @endif
                         <a href="{{ route('logout') }}" class="px-4">Logout</a>
                     @endauth
@@ -26,8 +27,34 @@
             </div>
         </header>
 
-        <main class="flex-grow container mx-auto py-8">
-            @yield('content')
+        <main class="flex-grow container mx-auto py-8 flex">
+            <div class="w-3/4">
+                @yield('content')
+            </div>
+            @auth
+            <aside class="w-1/4 ml-4">
+                <h2 class="text-xl font-bold mb-2">Notifications</h2>
+                @php
+                    $unread = auth()->user()->notifications()->where('is_read', false)->latest()->get();
+                @endphp
+                <ul>
+                    @forelse($unread as $note)
+                        <li class="mb-2 border-b pb-1">
+                            <div class="flex justify-between">
+                                <span>{{ ucfirst($note->notification_type) }}</span>
+                                <form method="POST" action="{{ route('notifications.read', $note->id) }}">
+                                    @csrf
+                                    <button class="text-sm text-blue-500">Mark Read</button>
+                                </form>
+                            </div>
+                            <div class="text-sm">{{ json_encode($note->details) }}</div>
+                        </li>
+                    @empty
+                        <li>No unread notifications</li>
+                    @endforelse
+                </ul>
+            </aside>
+            @endauth
         </main>
 
         <footer class="bg-gray-800 text-white py-4 text-center">

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,9 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('ssl-services', SSLServiceController::class)->except(['show']);
     Route::resource('email-templates', EmailTemplateController::class)->except(['show']);
     Route::resource('notifications', NotificationController::class)->only(['index']);
+    Route::post('notifications/{notification}/read', [NotificationController::class, 'markAsRead'])->name('notifications.read');
     Route::resource('backup-settings', BackupSettingController::class)->only(['edit', 'update']);
+    Route::resource('disk-settings', DiskSettingController::class)->only(['edit', 'update']);
     Route::resource('smtp-settings', SMTPSettingController::class)->only(['edit', 'update']);
     Route::resource('api-keys', ApiKeyController::class)->only(['index', 'create', 'store', 'destroy']);
     Route::get('synergy-api', [SynergyAPIController::class, 'edit'])->name('synergy-api.edit');


### PR DESCRIPTION
## Summary
- notify users of disk space usage, domain expiries and SSL expiries
- allow editing disk warning threshold
- show unread notifications in a right side panel

## Testing
- `composer install`
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687c41c0f5ec8331b16814d3ba3b76cb