### PR TITLE
Add theme settings with dark mode support

### DIFF
--- a/app/Http/Controllers/DarkModeController.php
+++ b/app/Http/Controllers/DarkModeController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class DarkModeController extends Controller
+{
+    public function toggle()
+    {
+        $user = auth()->user();
+        $user->dark_mode = ! $user->dark_mode;
+        $user->save();
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Storage;
+
+class SettingController extends Controller
+{
+    public function edit()
+    {
+        $settings = Setting::first();
+        return view('admin.settings.edit', compact('settings'));
+    }
+
+    public function update(Request $request)
+    {
+        $request->validate([
+            'primary_color' => 'required|string',
+            'secondary_color' => 'required|string',
+            'logo' => 'nullable|image',
+        ]);
+
+        $settings = Setting::first();
+
+        $data = $request->only('primary_color', 'secondary_color');
+
+        if ($request->hasFile('logo')) {
+            $path = $request->file('logo')->store('logos', 'public');
+            $data['logo_path'] = $path;
+        }
+
+        $settings->update($data);
+
+        return redirect()->route('settings.edit')->with('success', 'Settings updated successfully.');
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'primary_color',
+        'secondary_color',
+        'logo_path',
+    ];
+}

--- a/database/migrations/2025_07_20_011138_create_settings_table.php
+++ b/database/migrations/2025_07_20_011138_create_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('primary_color')->default('#2563eb');
+            $table->string('secondary_color')->default('#1e40af');
+            $table->string('logo_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,6 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+
+
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         BackupSettingSeeder::class,
         NotificationSeeder::class,
         SMTPSettingSeeder::class,
+        SettingSeeder::class,
         SystemMetricSeeder::class,
     ]);
 }

--- a/database/seeders/SettingSeeder.php
+++ b/database/seeders/SettingSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SettingSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        \App\Models\Setting::create([
+            'primary_color' => '#2563eb',
+            'secondary_color' => '#1e40af',
+            'logo_path' => null,
+        ]);
+    }
+}

--- a/resources/views/admin/settings/edit.blade.php
+++ b/resources/views/admin/settings/edit.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Theme Settings</h1>
+<form method="POST" action="{{ route('settings.update') }}" enctype="multipart/form-data">
+    @csrf
+    @method('PUT')
+    <div class="mb-4">
+        <label for="primary_color" class="block text-gray-700 font-bold mb-2">Primary Colour</label>
+        <input type="color" name="primary_color" id="primary_color" value="{{ $settings->primary_color }}" class="w-32 h-10 p-0 border rounded">
+    </div>
+    <div class="mb-4">
+        <label for="secondary_color" class="block text-gray-700 font-bold mb-2">Secondary Colour</label>
+        <input type="color" name="secondary_color" id="secondary_color" value="{{ $settings->secondary_color }}" class="w-32 h-10 p-0 border rounded">
+    </div>
+    <div class="mb-4">
+        <label for="logo" class="block text-gray-700 font-bold mb-2">Logo</label>
+        <input type="file" name="logo" id="logo" class="w-full">
+        @if($settings->logo_path)
+            <img src="{{ asset('storage/'.$settings->logo_path) }}" alt="Logo" class="h-16 mt-2">
+        @endif
+    </div>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save Changes</button>
+</form>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="{{ auth()->check() && auth()->user()->dark_mode ? 'dark' : '' }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,11 +7,21 @@
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <script src="{{ mix('js/app.js') }}" defer></script>
 </head>
-<body class="bg-gray-100">
+@php
+    $appSettings = \App\Models\Setting::first();
+    $primary = $appSettings->primary_color ?? '#2563eb';
+    $secondary = $appSettings->secondary_color ?? '#1e40af';
+@endphp
+
+<body class="bg-gray-100 dark:bg-gray-900">
     <div class="min-h-screen flex flex-col">
-        <header class="bg-blue-600 text-white py-4">
+        <header class="text-white py-4" style="background-color: {{ $primary }}">
             <div class="container mx-auto flex justify-between items-center">
-                <h1 class="text-xl font-bold">{{ config('app.name', 'DomainDash') }}</h1>
+                @if($appSettings && $appSettings->logo_path)
+                    <img src="{{ asset('storage/'.$appSettings->logo_path) }}" alt="Logo" class="h-8">
+                @else
+                    <h1 class="text-xl font-bold">{{ config('app.name', 'DomainDash') }}</h1>
+                @endif
                 <nav>
                     @auth
                         <a href="{{ route('home') }}" class="px-4">Home</a>
@@ -19,7 +29,14 @@
                             <a href="{{ route('users.index') }}" class="px-4">Users</a>
                             <a href="{{ route('email-templates.index') }}" class="px-4">Email Templates</a>
                             <a href="{{ route('api-keys.index') }}" class="px-4">API Keys</a>
+                            <a href="{{ route('settings.edit') }}" class="px-4">Theme</a>
                         @endif
+                        <form action="{{ route('dark-mode.toggle') }}" method="POST" class="inline">
+                            @csrf
+                            <button type="submit" class="px-4">
+                                {{ auth()->user()->dark_mode ? 'Light' : 'Dark' }} Mode
+                            </button>
+                        </form>
                         <a href="{{ route('logout') }}" class="px-4">Logout</a>
                     @endauth
                 </nav>
@@ -30,7 +47,7 @@
             @yield('content')
         </main>
 
-        <footer class="bg-gray-800 text-white py-4 text-center">
+        <footer class="text-white py-4 text-center" style="background-color: {{ $secondary }}">
             &copy; {{ date('Y') }} DomainDash. All rights reserved.
         </footer>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,10 +22,13 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('notifications', NotificationController::class)->only(['index']);
     Route::resource('backup-settings', BackupSettingController::class)->only(['edit', 'update']);
     Route::resource('smtp-settings', SMTPSettingController::class)->only(['edit', 'update']);
+    Route::resource('settings', SettingController::class)->only(['edit', 'update']);
     Route::resource('api-keys', ApiKeyController::class)->only(['index', 'create', 'store', 'destroy']);
     Route::get('synergy-api', [SynergyAPIController::class, 'edit'])->name('synergy-api.edit');
     Route::post('synergy-api', [SynergyAPIController::class, 'update'])->name('synergy-api.update');
 });
+#Toggle dark mode for any authenticated user
+Route::middleware('auth')->post('dark-mode', [DarkModeController::class, 'toggle'])->name('dark-mode.toggle');
 #Customer
 Route::middleware(['auth', 'role:customer'])->group(function () {
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');


### PR DESCRIPTION
## Summary
- create `settings` table and model
- allow admins to update primary/secondary colours and upload a logo
- expose a dark mode toggle per user
- render logo and colours from settings in layout

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687c41c32a308331960263ac5067e06d