### PR TITLE
Add system metrics and admin dashboard

### DIFF
--- a/app/Console/Commands/RecordBackup.php
+++ b/app/Console/Commands/RecordBackup.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class RecordBackup extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'system:record-backup';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Record the time of last backup';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        \App\Models\SystemStatus::first()->update(['last_backup_at' => now()]);
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RecordSystemMetrics.php
+++ b/app/Console/Commands/RecordSystemMetrics.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class RecordSystemMetrics extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'system:record-metrics';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Record storage, CPU, memory and DB metrics';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $storageTotal = disk_total_space('/') ?: 0;
+        $storageFree = disk_free_space('/') ?: 0;
+        $storageUsed = $storageTotal > 0 ? (int) round(100 * ($storageTotal - $storageFree) / $storageTotal) : 0;
+
+        \App\Models\SystemMetric::create([
+            'metric_type' => 'storage',
+            'value' => $storageUsed,
+            'recorded_at' => now(),
+        ]);
+
+        $load = sys_getloadavg();
+        $cpu = isset($load[0]) ? (int) round($load[0] * 100) : 0;
+
+        \App\Models\SystemMetric::create([
+            'metric_type' => 'cpu',
+            'value' => $cpu,
+            'recorded_at' => now(),
+        ]);
+
+        $memInfo = file_get_contents('/proc/meminfo');
+        preg_match('/MemTotal:\s+(\d+)/', $memInfo, $totalMatch);
+        preg_match('/MemAvailable:\s+(\d+)/', $memInfo, $availMatch);
+        $memory = 0;
+        if ($totalMatch && $availMatch && $totalMatch[1] > 0) {
+            $memory = (int) round(100 * (($totalMatch[1] - $availMatch[1]) / $totalMatch[1]));
+        }
+
+        \App\Models\SystemMetric::create([
+            'metric_type' => 'memory',
+            'value' => $memory,
+            'recorded_at' => now(),
+        ]);
+
+        $size = \DB::selectOne("SELECT SUM(data_length + index_length) AS size FROM information_schema.tables WHERE table_schema = DATABASE()");
+        $dbSize = isset($size->size) ? (int) round($size->size / 1024 / 1024) : 0;
+
+        \App\Models\SystemMetric::create([
+            'metric_type' => 'database',
+            'value' => $dbSize,
+            'recorded_at' => now(),
+        ]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,8 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
-	
+        $schedule->command('system:record-metrics')->hourly();
+        $schedule->command('system:record-backup')->dailyAt('03:00');
     }
 
     /**

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\SystemMetric;
+use App\Models\SystemStatus;
+use App\Services\SynergyClient;
+
+class DashboardController extends Controller
+{
+    private SynergyClient $synergy;
+
+    public function __construct(SynergyClient $synergy)
+    {
+        $this->synergy = $synergy;
+    }
+
+    public function index()
+    {
+        $metrics = [
+            'storage' => SystemMetric::where('metric_type', 'storage')->orderBy('recorded_at', 'desc')->limit(30)->get(),
+            'cpu' => SystemMetric::where('metric_type', 'cpu')->orderBy('recorded_at', 'desc')->limit(30)->get(),
+            'memory' => SystemMetric::where('metric_type', 'memory')->orderBy('recorded_at', 'desc')->limit(30)->get(),
+            'database' => SystemMetric::where('metric_type', 'database')->orderBy('recorded_at', 'desc')->limit(30)->get(),
+        ];
+
+        $status = SystemStatus::first();
+
+        $balanceResponse = $this->synergy->getAccountBalance();
+        $balance = $balanceResponse['balance'] ?? null;
+
+        return view('admin.dashboard', compact('metrics', 'status', 'balance'));
+    }
+}

--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -44,6 +44,8 @@ class DomainController extends Controller
                 );
             }
 
+            \App\Models\SystemStatus::first()->update(['last_sync_at' => now()]);
+
             return redirect()->route('admin.domains.index')
                              ->with('success', 'Domains updated successfully.');
         } catch (\Exception $e) {

--- a/app/Models/SystemStatus.php
+++ b/app/Models/SystemStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SystemStatus extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'last_sync_at',
+        'last_backup_at',
+    ];
+
+    protected $casts = [
+        'last_sync_at' => 'datetime',
+        'last_backup_at' => 'datetime',
+    ];
+}

--- a/app/Services/SynergyClient.php
+++ b/app/Services/SynergyClient.php
@@ -40,6 +40,11 @@ class SynergyClient
         return $this->request('BulkDomainInfo', $params);
     }
 
+    public function getAccountBalance()
+    {
+        return $this->request('GetResellerBalance');
+    }
+
     public function __call(string $name, array $arguments)
     {
         $params = $arguments[0] ?? [];

--- a/database/migrations/2025_07_20_011249_create_system_statuses_table.php
+++ b/database/migrations/2025_07_20_011249_create_system_statuses_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('system_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('last_sync_at')->nullable();
+            $table->timestamp('last_backup_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('system_statuses');
+    }
+};

--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
         NotificationSeeder::class,
         SMTPSettingSeeder::class,
         SystemMetricSeeder::class,
+        SystemStatusSeeder::class,
     ]);
 }
 

--- a/database/seeders/SystemStatusSeeder.php
+++ b/database/seeders/SystemStatusSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SystemStatusSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        \App\Models\SystemStatus::create([
+            'last_sync_at' => now(),
+            'last_backup_at' => now(),
+        ]);
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">System Dashboard</h1>
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div>
+        <canvas id="storageChart"></canvas>
+    </div>
+    <div>
+        <canvas id="cpuChart"></canvas>
+    </div>
+    <div>
+        <canvas id="memoryChart"></canvas>
+    </div>
+    <div>
+        <canvas id="dbChart"></canvas>
+    </div>
+</div>
+<div class="mt-6">
+    <p><strong>Last Sync:</strong> {{ optional($status)->last_sync_at?->toDateTimeString() ?? 'N/A' }}</p>
+    <p><strong>Last Backup:</strong> {{ optional($status)->last_backup_at?->toDateTimeString() ?? 'N/A' }}</p>
+    <p><strong>Synergy Balance:</strong> {{ $balance ?? 'N/A' }}</p>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const metrics = @json($metrics);
+function makeChart(id, data) {
+    new Chart(document.getElementById(id), {
+        type: 'line',
+        data: {
+            labels: data.map(m => m.recorded_at),
+            datasets: [{
+                label: id,
+                data: data.map(m => m.value),
+                borderColor: 'rgb(75, 192, 192)',
+                tension: 0.1
+            }]
+        }
+    });
+}
+makeChart('storageChart', metrics.storage);
+makeChart('cpuChart', metrics.cpu);
+makeChart('memoryChart', metrics.memory);
+makeChart('dbChart', metrics.database);
+</script>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,6 +19,7 @@
                             <a href="{{ route('users.index') }}" class="px-4">Users</a>
                             <a href="{{ route('email-templates.index') }}" class="px-4">Email Templates</a>
                             <a href="{{ route('api-keys.index') }}" class="px-4">API Keys</a>
+                            <a href="{{ route('admin.dashboard') }}" class="px-4">Dashboard</a>
                         @endif
                         <a href="{{ route('logout') }}" class="px-4">Logout</a>
                     @endauth

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('api-keys', ApiKeyController::class)->only(['index', 'create', 'store', 'destroy']);
     Route::get('synergy-api', [SynergyAPIController::class, 'edit'])->name('synergy-api.edit');
     Route::post('synergy-api', [SynergyAPIController::class, 'update'])->name('synergy-api.update');
+    Route::get('admin-dashboard', [\App\Http\Controllers\Admin\DashboardController::class, 'index'])->name('admin.dashboard');
 });
 #Customer
 Route::middleware(['auth', 'role:customer'])->group(function () {


### PR DESCRIPTION
## Summary
- add `system_statuses` table and model
- create commands for recording metrics and backups
- update Kernel schedule
- update domain sync to track last sync time
- fetch Synergy balance in dashboard
- create admin dashboard view and route
- expose dashboard link in layout

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687c41c93fa48331b6454250c17d013e