### PR TITLE
Add cPanel login route via Synergy API

### DIFF
--- a/app/Http/Controllers/HostingServiceController.php
+++ b/app/Http/Controllers/HostingServiceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\HostingService;
 use App\Models\User;
+use App\Services\SynergyClient;
 
 class HostingServiceController extends Controller
 {
@@ -92,5 +93,20 @@ class HostingServiceController extends Controller
         $hostingService->delete();
 
         return redirect()->route('hosting-services.index')->with('success', 'Hosting service deleted successfully.');
+    }
+
+    /**
+     * Redirect to the cPanel login URL for the hosting service.
+     */
+    public function cpanel(string $id, SynergyClient $synergy)
+    {
+        $service = HostingService::findOrFail($id);
+        $response = $synergy->hostingGetLogin($service->id);
+
+        if (isset($response['loginUrl'])) {
+            return redirect()->away($response['loginUrl']);
+        }
+
+        return back()->with('error', 'Unable to generate cPanel login link.');
     }
 }

--- a/app/Services/SynergyClient.php
+++ b/app/Services/SynergyClient.php
@@ -40,6 +40,22 @@ class SynergyClient
         return $this->request('BulkDomainInfo', $params);
     }
 
+    /**
+     * Check the availability of a domain name.
+     */
+    public function checkDomainAvailability(string $domainName)
+    {
+        return $this->request('CheckDomain', ['domainName' => $domainName]);
+    }
+
+    /**
+     * Retrieve a cPanel single sign on URL for the supplied hosting order ID.
+     */
+    public function hostingGetLogin(int $hoid)
+    {
+        return $this->request('hostingGetLogin', ['hoid' => $hoid]);
+    }
+
     public function __call(string $name, array $arguments)
     {
         $params = $arguments[0] ?? [];

--- a/resources/views/hosting-services/index.blade.php
+++ b/resources/views/hosting-services/index.blade.php
@@ -26,6 +26,12 @@
                     @method('DELETE')
                     <button type="submit" class="text-red-500">Delete</button>
                 </form>
+                @php
+                    $cpanelRoute = auth()->user()->role === 'admin'
+                        ? route('hosting-services.cpanel', $service->id)
+                        : route('customer.hosting.cpanel', $service->id);
+                @endphp
+                <a href="{{ $cpanelRoute }}" class="text-green-500 ml-2">cPanel Login</a>
             </td>
         </tr>
         @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('users', UserController::class)->except(['show']);
     Route::resource('domains', DomainController::class)->except(['show']);
     Route::resource('hosting-services', HostingServiceController::class)->except(['show']);
+    Route::get('hosting-services/{id}/cpanel', [HostingServiceController::class, 'cpanel'])->name('hosting-services.cpanel');
     Route::resource('ssl-services', SSLServiceController::class)->except(['show']);
     Route::resource('email-templates', EmailTemplateController::class)->except(['show']);
     Route::resource('notifications', NotificationController::class)->only(['index']);
@@ -31,6 +32,7 @@ Route::middleware(['auth', 'role:customer'])->group(function () {
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::get('domains', [DomainController::class, 'index'])->name('customer.domains.index');
     Route::get('hosting-services', [HostingServiceController::class, 'index'])->name('customer.hosting.index');
+    Route::get('hosting-services/{id}/cpanel', [HostingServiceController::class, 'cpanel'])->name('customer.hosting.cpanel');
     Route::get('ssl-services', [SSLServiceController::class, 'index'])->name('customer.ssl.index');
 });
 

--- a/tests/Feature/SynergyServiceTest.php
+++ b/tests/Feature/SynergyServiceTest.php
@@ -65,6 +65,25 @@ class SynergyServiceTest extends TestCase
         $synergy->checkDomainAvailability('example.com');
     }
 
+    public function test_hosting_get_login_invokes_correct_method(): void
+    {
+        $mock = Mockery::mock(\SoapClient::class);
+        $mock->shouldReceive('__soapCall')
+            ->once()
+            ->with('hostingGetLogin', [[
+                'resellerID' => 'test-reseller',
+                'apiKey' => 'test-key',
+                'hoid' => 123,
+            ]])
+            ->andReturn((object)['loginUrl' => 'https://example.com/cpanel']);
+
+        $synergy = $this->getSynergyWithMockClient($mock);
+
+        $result = $synergy->hostingGetLogin(123);
+
+        $this->assertEquals(['loginUrl' => 'https://example.com/cpanel'], $result);
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();


### PR DESCRIPTION
## Summary
- allow the Synergy client to check domains and fetch cPanel login URLs
- expose cPanel login route in `HostingServiceController`
- link to the new route from the hosting services view
- register routes for admins and customers
- expand Synergy tests with login URL check

## Testing
- `./vendor/bin/phpunit --filter SynergyServiceTest --testdox`
- `./vendor/bin/phpunit --testdox` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687c41c9dd18833191b7b3478dc1840d