### PR TITLE
Add global search bar

### DIFF
--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -16,14 +16,4 @@ class CustomerController extends Controller
         return view('customer.dashboard', compact('domains'));
     }
 
-    public function searchDomains(Request $request)
-    {
-        // Search within the logged-in customer's domains
-        $query = $request->input('query');
-        $domains = Domain::where('customer_id', auth()->id())
-                         ->where('domain_name', 'LIKE', '%' . $query . '%')
-                         ->get();
-
-        return view('customer.dashboard', compact('domains'));
-    }
 }

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Domain;
+use App\Models\HostingService;
+use App\Models\SSLService;
+use App\Models\User;
+
+class SearchController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = $request->input('q');
+        $status = $request->input('status');
+        $serviceType = $request->input('service_type');
+        $tag = $request->input('tag');
+
+        $domains = Domain::query();
+        if (auth()->user()->role === 'customer') {
+            $domains->where('customer_id', auth()->id());
+        }
+        if ($query) {
+            $domains->where('domain_name', 'like', "%{$query}%");
+        }
+        if ($status && $domains->getModel()->isFillable('status')) {
+            $domains->where('status', $status);
+        }
+        if ($tag && $domains->getModel()->isFillable('tag')) {
+            $domains->where('tag', $tag);
+        }
+        $domains = $domains->get();
+
+        $hostingServices = HostingService::query();
+        if (auth()->user()->role === 'customer') {
+            $hostingServices->where('customer_id', auth()->id());
+        }
+        if ($query) {
+            $hostingServices->where('service_name', 'like', "%{$query}%");
+        }
+        if ($serviceType && $hostingServices->getModel()->isFillable('service_type')) {
+            $hostingServices->where('service_type', $serviceType);
+        } elseif ($serviceType) {
+            $hostingServices->where('hosting_plan', $serviceType);
+        }
+        if ($status && $hostingServices->getModel()->isFillable('status')) {
+            $hostingServices->where('status', $status);
+        }
+        if ($tag && $hostingServices->getModel()->isFillable('tag')) {
+            $hostingServices->where('tag', $tag);
+        }
+        $hostingServices = $hostingServices->get();
+
+        $sslServices = SSLService::query();
+        if (auth()->user()->role === 'customer') {
+            $sslServices->where('customer_id', auth()->id());
+        }
+        if ($query) {
+            $sslServices->where('certificate_name', 'like', "%{$query}%");
+        }
+        if ($status && $sslServices->getModel()->isFillable('status')) {
+            $sslServices->where('status', $status);
+        }
+        if ($serviceType && $sslServices->getModel()->isFillable('service_type')) {
+            $sslServices->where('service_type', $serviceType);
+        }
+        if ($tag && $sslServices->getModel()->isFillable('tag')) {
+            $sslServices->where('tag', $tag);
+        }
+        $sslServices = $sslServices->get();
+
+        $clients = collect();
+        if (auth()->user()->role === 'admin') {
+            $clientsQuery = User::query()->where('role', 'customer');
+            if ($query) {
+                $clientsQuery->where(function ($q) use ($query) {
+                    $q->where('first_name', 'like', "%{$query}%")
+                      ->orWhere('surname', 'like', "%{$query}%")
+                      ->orWhere('email', 'like', "%{$query}%");
+                });
+            }
+            if ($status && $clientsQuery->getModel()->isFillable('status')) {
+                $clientsQuery->where('status', $status);
+            }
+            if ($tag && $clientsQuery->getModel()->isFillable('tag')) {
+                $clientsQuery->where('tag', $tag);
+            }
+            $clients = $clientsQuery->get();
+        }
+
+        return view('search.index', compact('domains', 'hostingServices', 'sslServices', 'clients', 'query', 'status', 'serviceType', 'tag'));
+    }
+}

--- a/resources/views/customer/dashboard.blade.php
+++ b/resources/views/customer/dashboard.blade.php
@@ -4,8 +4,8 @@
 <div class="container mx-auto py-8">
     <h1 class="text-2xl font-bold mb-4">My Domains</h1>
 
-    <form action="{{ route('customer.domains.search') }}" method="GET" class="flex mb-4">
-        <input type="text" name="query" placeholder="Search domains" class="border rounded-l px-4 py-2" />
+    <form action="{{ route('search.index') }}" method="GET" class="flex mb-4">
+        <input type="text" name="q" placeholder="Search" class="border rounded-l px-4 py-2 text-black" />
         <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-r">Search</button>
     </form>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,6 +12,10 @@
         <header class="bg-blue-600 text-white py-4">
             <div class="container mx-auto flex justify-between items-center">
                 <h1 class="text-xl font-bold">{{ config('app.name', 'DomainDash') }}</h1>
+                <form action="{{ route('search.index') }}" method="GET" class="flex items-center mx-4">
+                    <input type="text" name="q" placeholder="Search" class="rounded px-2 py-1 text-black" />
+                    <button type="submit" class="ml-2 bg-white text-blue-600 px-2 py-1 rounded">Go</button>
+                </form>
                 <nav>
                     @auth
                         <a href="{{ route('home') }}" class="px-4">Home</a>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Search Results</h1>
+
+<form method="GET" action="{{ route('search.index') }}" class="mb-6 flex space-x-2">
+    <input type="text" name="q" value="{{ request('q') }}" placeholder="Search" class="border px-2 py-1 rounded text-black" />
+    <input type="text" name="status" value="{{ request('status') }}" placeholder="Status" class="border px-2 py-1 rounded text-black" />
+    <input type="text" name="service_type" value="{{ request('service_type') }}" placeholder="Service Type" class="border px-2 py-1 rounded text-black" />
+    <input type="text" name="tag" value="{{ request('tag') }}" placeholder="Tag" class="border px-2 py-1 rounded text-black" />
+    <button type="submit" class="bg-blue-500 text-white px-4 py-1 rounded">Search</button>
+</form>
+
+<div class="space-y-6">
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Domains</h2>
+        <ul class="list-disc pl-5">
+            @forelse($domains as $domain)
+                <li>{{ $domain->domain_name }}</li>
+            @empty
+                <li>No domains found.</li>
+            @endforelse
+        </ul>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Hosting Services</h2>
+        <ul class="list-disc pl-5">
+            @forelse($hostingServices as $service)
+                <li>{{ $service->service_name }}</li>
+            @empty
+                <li>No hosting services found.</li>
+            @endforelse
+        </ul>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">SSL Services</h2>
+        <ul class="list-disc pl-5">
+            @forelse($sslServices as $service)
+                <li>{{ $service->certificate_name }}</li>
+            @empty
+                <li>No SSL services found.</li>
+            @endforelse
+        </ul>
+    </div>
+
+    @if(auth()->user()->role === 'admin')
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Clients</h2>
+        <ul class="list-disc pl-5">
+            @forelse($clients as $client)
+                <li>{{ $client->first_name }} {{ $client->surname }}</li>
+            @empty
+                <li>No clients found.</li>
+            @endforelse
+        </ul>
+    </div>
+    @endif
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,5 +45,8 @@ Route::middleware([
 });
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/dashboard', [CustomerController::class, 'index'])->name('customer.dashboard');
-    Route::get('/dashboard/search', [CustomerController::class, 'searchDomains'])->name('customer.domains.search');
+});
+
+Route::middleware(['auth'])->group(function () {
+    Route::get('/search', [SearchController::class, 'index'])->name('search.index');
 });


### PR DESCRIPTION
## Summary
- add a SearchController with global search logic
- expose a `/search` route for all logged-in users
- add search bar to the main layout header
- update customer dashboard to use new search
- create view to display search results

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_b_687c41ce73d88331b37b65ff422ba8ef