### PR TITLE
Add sqlite testing setup and feature tests

### DIFF
--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};

--- a/database/migrations/create_backup_settings_table.php
+++ b/database/migrations/create_backup_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateBackupSettingsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -24,4 +24,4 @@ class CreateBackupSettingsTable extends Migration
     {
         Schema::dropIfExists('backup_settings');
     }
-}
+};

--- a/database/migrations/create_domains_table.php
+++ b/database/migrations/create_domains_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateDomainsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class CreateDomainsTable extends Migration
     {
         Schema::dropIfExists('domains');
     }
-}
+};

--- a/database/migrations/create_email_templates_table.php
+++ b/database/migrations/create_email_templates_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateEmailTemplatesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -21,4 +21,4 @@ class CreateEmailTemplatesTable extends Migration
     {
         Schema::dropIfExists('email_templates');
     }
-}
+};

--- a/database/migrations/create_hosting_services_table.php
+++ b/database/migrations/create_hosting_services_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateHostingServicesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -24,4 +24,4 @@ class CreateHostingServicesTable extends Migration
     {
         Schema::dropIfExists('hosting_services');
     }
-}
+};

--- a/database/migrations/create_notifications_table.php
+++ b/database/migrations/create_notifications_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateNotificationsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class CreateNotificationsTable extends Migration
     {
         Schema::dropIfExists('notifications');
     }
-}
+};

--- a/database/migrations/create_smtp_settings_table.php
+++ b/database/migrations/create_smtp_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSmtpSettingsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,4 +23,4 @@ class CreateSmtpSettingsTable extends Migration
     {
         Schema::dropIfExists('smtp_settings');
     }
-}
+};

--- a/database/migrations/create_ssl_services_table.php
+++ b/database/migrations/create_ssl_services_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSslServicesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,4 +22,4 @@ class CreateSslServicesTable extends Migration
     {
         Schema::dropIfExists('ssl_services');
     }
-}
+};

--- a/database/migrations/create_system_metrics_table.php
+++ b/database/migrations/create_system_metrics_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSystemMetricsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -20,4 +20,4 @@ class CreateSystemMetricsTable extends Migration
     {
         Schema::dropIfExists('system_metrics');
     }
-}
+};

--- a/database/migrations/create_users_table.php
+++ b/database/migrations/create_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateUsersTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -24,4 +24,4 @@ class CreateUsersTable extends Migration
     {
         Schema::dropIfExists('users');
     }
-}
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/ApiKeyRestrictionsTest.php
+++ b/tests/Feature/ApiKeyRestrictionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ApiKey;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiKeyRestrictionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_allowed_ips_casts_to_array(): void
+    {
+        $apiKey = ApiKey::create([
+            'key_name' => 'Test Key',
+            'hashed_key' => hash('sha256', 'secret'),
+            'permissions' => 'read-only',
+            'allowed_ips' => '127.0.0.1',
+            'rate_limit' => 10,
+        ]);
+
+        $apiKey->refresh();
+
+        $this->assertSame('127.0.0.1', $apiKey->allowed_ips);
+    }
+
+    public function test_invalid_permission_value_throws_exception(): void
+    {
+        $this->expectException(QueryException::class);
+
+        ApiKey::create([
+            'key_name' => 'Bad',
+            'hashed_key' => hash('sha256', 'secret'),
+            'permissions' => 'invalid',
+            'rate_limit' => 1,
+        ]);
+    }
+}

--- a/tests/Feature/BackupSchedulingTest.php
+++ b/tests/Feature/BackupSchedulingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BackupSetting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BackupSchedulingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backup_settings_can_be_updated(): void
+    {
+        $setting = BackupSetting::create([
+            'sftp_server' => 'old.example.com',
+            'sftp_port' => 22,
+            'sftp_username' => 'old',
+            'sftp_password' => 'oldpass',
+            'backup_retention' => 5,
+            'backup_time' => '03:00:00',
+        ]);
+
+        $setting->update([
+            'sftp_server' => 'new.example.com',
+            'sftp_username' => 'new',
+            'sftp_password' => 'newpass',
+            'backup_retention' => 10,
+            'backup_time' => '02:00:00',
+        ]);
+
+        $this->assertDatabaseHas('backup_settings', [
+            'sftp_server' => 'new.example.com',
+            'backup_retention' => 10,
+            'backup_time' => '02:00:00',
+        ]);
+    }
+}

--- a/tests/Feature/ClientRelationshipTest.php
+++ b/tests/Feature/ClientRelationshipTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClientRelationshipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_domain_belongs_to_customer(): void
+    {
+        User::unguard();
+        $user = User::create([
+            'first_name' => 'Test',
+            'surname' => 'User',
+            'email' => 'test@example.com',
+            'password' => bcrypt('secret'),
+            'role' => 'customer',
+            'dark_mode' => false,
+        ]);
+
+        $domain = Domain::create([
+            'domain_name' => 'example.com',
+            'customer_id' => $user->id,
+        ]);
+
+        $this->assertTrue($domain->customer->is($user));
+    }
+}


### PR DESCRIPTION
## Summary
- enable SQLite in-memory DB for tests
- convert migrations to anonymous classes
- add feature tests for API key model, backup settings, and customer relationships

## Testing
- `php artisan test tests/Feature/RoleMiddlewareTest.php tests/Feature/ApiKeyRestrictionsTest.php tests/Feature/ClientRelationshipTest.php tests/Feature/BackupSchedulingTest.php --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_b_687c41cffc4c833184721e4b67c0493a