### PR TITLE
Add clients and multi-user associations

### DIFF
--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -36,7 +36,7 @@ class DomainController extends Controller
                 Domain::updateOrCreate(
                     ['domain_name' => $domainData['domainName']],
                     [
-                        'customer_id' => null,
+                        'client_id' => null,
                         'auto_renew' => $domainData['autoRenew'] ?? null,
                         'renewal_date' => $domainData['domain_expiry'] ?? null,
                         'transfer_status' => $domainData['transfer_status'] ?? null,

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function index()
+    {
+        $clients = Client::with('users')->get();
+        return view('clients.index', compact('clients'));
+    }
+
+    public function create()
+    {
+        $users = User::all();
+        return view('clients.create', compact('users'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'business_name' => 'required|string|max:255',
+            'abn' => 'nullable|string|max:255',
+            'halo_reference' => 'nullable|string|max:255',
+            'itglue_org_id' => 'nullable|integer',
+            'active' => 'boolean',
+            'users' => 'array',
+            'users.*' => 'exists:users,id',
+        ]);
+
+        $client = Client::create($data);
+        if (isset($data['users'])) {
+            $client->users()->sync($data['users']);
+        }
+
+        return redirect()->route('clients.index')
+            ->with('success', 'Client created successfully.');
+    }
+
+    public function show(string $id)
+    {
+        $client = Client::with('users')->findOrFail($id);
+        return view('clients.show', compact('client'));
+    }
+
+    public function edit(string $id)
+    {
+        $client = Client::findOrFail($id);
+        $users = User::all();
+        $assigned = $client->users->pluck('id')->toArray();
+        return view('clients.edit', compact('client', 'users', 'assigned'));
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $data = $request->validate([
+            'business_name' => 'required|string|max:255',
+            'abn' => 'nullable|string|max:255',
+            'halo_reference' => 'nullable|string|max:255',
+            'itglue_org_id' => 'nullable|integer',
+            'active' => 'boolean',
+            'users' => 'array',
+            'users.*' => 'exists:users,id',
+        ]);
+
+        $client = Client::findOrFail($id);
+        $client->update($data);
+        $client->users()->sync($data['users'] ?? []);
+
+        return redirect()->route('clients.index')
+            ->with('success', 'Client updated successfully.');
+    }
+
+    public function destroy(string $id)
+    {
+        $client = Client::findOrFail($id);
+        $client->delete();
+
+        return redirect()->route('clients.index')
+            ->with('success', 'Client deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/Customer/CustomerController.php
+++ b/app/Http/Controllers/Customer/CustomerController.php
@@ -10,8 +10,9 @@ class CustomerController extends Controller
 {
     public function index()
     {
-        // Fetch domains assigned to the logged-in customer
-        $domains = Domain::where('customer_id', auth()->id())->get();
+        // Fetch domains assigned to any of the customer's clients
+        $clientIds = auth()->user()->clients()->pluck('clients.id');
+        $domains = Domain::whereIn('client_id', $clientIds)->get();
 
         return view('customer.dashboard', compact('domains'));
     }
@@ -20,7 +21,8 @@ class CustomerController extends Controller
     {
         // Search within the logged-in customer's domains
         $query = $request->input('query');
-        $domains = Domain::where('customer_id', auth()->id())
+        $clientIds = auth()->user()->clients()->pluck('clients.id');
+        $domains = Domain::whereIn('client_id', $clientIds)
                          ->where('domain_name', 'LIKE', '%' . $query . '%')
                          ->get();
 

--- a/app/Http/Controllers/DomainController.php
+++ b/app/Http/Controllers/DomainController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Domain;
-use App\Models\User;
+use App\Models\Client;
 
 class DomainController extends Controller
 {
@@ -13,7 +13,7 @@ class DomainController extends Controller
      */
     public function index()
     {
-        $domains = Domain::with('customer')->get();
+        $domains = Domain::with('client')->get();
         return view('domains.index', compact('domains'));
     }
 
@@ -22,8 +22,8 @@ class DomainController extends Controller
      */
     public function create()
     {
-        $customers = User::all();
-        return view('domains.create', compact('customers'));
+        $clients = Client::all();
+        return view('domains.create', compact('clients'));
     }
 
     /**
@@ -33,7 +33,7 @@ class DomainController extends Controller
     {
         $data = $request->validate([
             'domain_name' => 'required|string|max:255',
-            'customer_id' => 'nullable|exists:users,id',
+            'client_id' => 'nullable|exists:clients,id',
             'auto_renew' => 'boolean',
             'renewal_date' => 'nullable|date',
         ]);
@@ -57,8 +57,8 @@ class DomainController extends Controller
     public function edit(string $id)
     {
         $domain = Domain::findOrFail($id);
-        $customers = User::all();
-        return view('domains.edit', compact('domain', 'customers'));
+        $clients = Client::all();
+        return view('domains.edit', compact('domain', 'clients'));
     }
 
     /**
@@ -68,7 +68,7 @@ class DomainController extends Controller
     {
         $data = $request->validate([
             'domain_name' => 'required|string|max:255',
-            'customer_id' => 'nullable|exists:users,id',
+            'client_id' => 'nullable|exists:clients,id',
             'auto_renew' => 'boolean',
             'renewal_date' => 'nullable|date',
         ]);

--- a/app/Http/Controllers/HostingServiceController.php
+++ b/app/Http/Controllers/HostingServiceController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\HostingService;
-use App\Models\User;
+use App\Models\Client;
 
 class HostingServiceController extends Controller
 {
@@ -13,7 +13,7 @@ class HostingServiceController extends Controller
      */
     public function index()
     {
-        $hostingServices = HostingService::with('customer')->get();
+        $hostingServices = HostingService::with('client')->get();
         return view('hosting-services.index', compact('hostingServices'));
     }
 
@@ -22,8 +22,8 @@ class HostingServiceController extends Controller
      */
     public function create()
     {
-        $customers = User::all();
-        return view('hosting-services.create', compact('customers'));
+        $clients = Client::all();
+        return view('hosting-services.create', compact('clients'));
     }
 
     /**
@@ -33,7 +33,7 @@ class HostingServiceController extends Controller
     {
         $data = $request->validate([
             'service_name' => 'required|string|max:255',
-            'customer_id' => 'nullable|exists:users,id',
+            'client_id' => 'nullable|exists:clients,id',
             'disk_usage' => 'nullable|integer',
             'database_usage' => 'nullable|integer',
             'disk_space_threshold' => 'nullable|integer',
@@ -59,8 +59,8 @@ class HostingServiceController extends Controller
     public function edit(string $id)
     {
         $hostingService = HostingService::findOrFail($id);
-        $customers = User::all();
-        return view('hosting-services.edit', compact('hostingService', 'customers'));
+        $clients = Client::all();
+        return view('hosting-services.edit', compact('hostingService', 'clients'));
     }
 
     /**
@@ -70,7 +70,7 @@ class HostingServiceController extends Controller
     {
         $data = $request->validate([
             'service_name' => 'required|string|max:255',
-            'customer_id' => 'nullable|exists:users,id',
+            'client_id' => 'nullable|exists:clients,id',
             'disk_usage' => 'nullable|integer',
             'database_usage' => 'nullable|integer',
             'disk_space_threshold' => 'nullable|integer',

--- a/app/Http/Controllers/SSLServiceController.php
+++ b/app/Http/Controllers/SSLServiceController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\SSLService;
-use App\Models\User;
+use App\Models\Client;
 
 class SSLServiceController extends Controller
 {
@@ -13,7 +13,7 @@ class SSLServiceController extends Controller
      */
     public function index()
     {
-        $sslServices = SSLService::with('customer')->get();
+        $sslServices = SSLService::with('client')->get();
         return view('ssl-services.index', compact('sslServices'));
     }
 
@@ -22,8 +22,8 @@ class SSLServiceController extends Controller
      */
     public function create()
     {
-        $customers = User::all();
-        return view('ssl-services.create', compact('customers'));
+        $clients = Client::all();
+        return view('ssl-services.create', compact('clients'));
     }
 
     /**
@@ -33,7 +33,7 @@ class SSLServiceController extends Controller
     {
         $data = $request->validate([
             'certificate_name' => 'required|string|max:255',
-            'customer_id' => 'nullable|exists:users,id',
+            'client_id' => 'nullable|exists:clients,id',
             'expiration_date' => 'required|date',
             'details' => 'nullable|string',
         ]);
@@ -57,8 +57,8 @@ class SSLServiceController extends Controller
     public function edit(string $id)
     {
         $sslService = SSLService::findOrFail($id);
-        $customers = User::all();
-        return view('ssl-services.edit', compact('sslService', 'customers'));
+        $clients = Client::all();
+        return view('ssl-services.edit', compact('sslService', 'clients'));
     }
 
     /**
@@ -68,7 +68,7 @@ class SSLServiceController extends Controller
     {
         $data = $request->validate([
             'certificate_name' => 'required|string|max:255',
-            'customer_id' => 'nullable|exists:users,id',
+            'client_id' => 'nullable|exists:clients,id',
             'expiration_date' => 'required|date',
             'details' => 'nullable|string',
         ]);

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'business_name',
+        'abn',
+        'halo_reference',
+        'itglue_org_id',
+        'active',
+    ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    public function domains()
+    {
+        return $this->hasMany(Domain::class);
+    }
+
+    public function hostingServices()
+    {
+        return $this->hasMany(HostingService::class);
+    }
+
+    public function sslServices()
+    {
+        return $this->hasMany(SSLService::class);
+    }
+}

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -11,13 +11,13 @@ class Domain extends Model
 
     protected $fillable = [
         'domain_name',
-        'customer_id',
+        'client_id',
         'auto_renew',
         'renewal_date',
     ];
 
-    public function customer()
+    public function client()
     {
-        return $this->belongsTo(User::class, 'customer_id');
+        return $this->belongsTo(Client::class, 'client_id');
     }
 }

--- a/app/Models/HostingService.php
+++ b/app/Models/HostingService.php
@@ -11,15 +11,15 @@ class HostingService extends Model
 
     protected $fillable = [
         'service_name',
-        'customer_id',
+        'client_id',
         'disk_usage',
         'database_usage',
         'disk_space_threshold',
         'hosting_plan',
     ];
 
-    public function customer()
+    public function client()
     {
-        return $this->belongsTo(User::class, 'customer_id');
+        return $this->belongsTo(Client::class, 'client_id');
     }
 }

--- a/app/Models/SSLService.php
+++ b/app/Models/SSLService.php
@@ -11,13 +11,13 @@ class SSLService extends Model
 
     protected $fillable = [
         'certificate_name',
-        'customer_id',
+        'client_id',
         'expiration_date',
         'details',
     ];
 
-    public function customer()
+    public function client()
     {
-        return $this->belongsTo(User::class, 'customer_id');
+        return $this->belongsTo(Client::class, 'client_id');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
+use App\Models\Client;
 
 class User extends Authenticatable
 {
@@ -58,4 +59,9 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
+
+    public function clients()
+    {
+        return $this->belongsToMany(Client::class);
+    }
 }

--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};

--- a/database/migrations/create_client_user_table.php
+++ b/database/migrations/create_client_user_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateClientUserTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('client_user', function (Blueprint $table) {
+            $table->foreignId('client_id')->constrained('clients')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->primary(['client_id', 'user_id']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('client_user');
+    }
+}

--- a/database/migrations/create_clients_table.php
+++ b/database/migrations/create_clients_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateClientsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('business_name');
+            $table->string('abn')->nullable();
+            $table->string('halo_reference')->nullable();
+            $table->unsignedBigInteger('itglue_org_id')->nullable();
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('clients');
+    }
+}

--- a/database/migrations/create_domains_table.php
+++ b/database/migrations/create_domains_table.php
@@ -11,7 +11,7 @@ class CreateDomainsTable extends Migration
         Schema::create('domains', function (Blueprint $table) {
             $table->id();
             $table->string('domain_name');
-            $table->foreignId('customer_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->foreignId('client_id')->nullable()->constrained('clients')->onDelete('set null');
             $table->boolean('auto_renew')->default(true);
             $table->date('renewal_date')->nullable();
             $table->timestamps();

--- a/database/migrations/create_hosting_services_table.php
+++ b/database/migrations/create_hosting_services_table.php
@@ -11,7 +11,7 @@ class CreateHostingServicesTable extends Migration
         Schema::create('hosting_services', function (Blueprint $table) {
             $table->id();
             $table->string('service_name');
-            $table->foreignId('customer_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->foreignId('client_id')->nullable()->constrained('clients')->onDelete('set null');
             $table->integer('disk_usage')->default(0);
             $table->integer('database_usage')->default(0);
             $table->integer('disk_space_threshold')->default(80);

--- a/database/migrations/create_ssl_services_table.php
+++ b/database/migrations/create_ssl_services_table.php
@@ -11,7 +11,7 @@ class CreateSslServicesTable extends Migration
         Schema::create('ssl_services', function (Blueprint $table) {
             $table->id();
             $table->string('certificate_name');
-            $table->foreignId('customer_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->foreignId('client_id')->nullable()->constrained('clients')->onDelete('set null');
             $table->date('expiration_date');
             $table->json('details');
             $table->timestamps();

--- a/database/seeders/ClientSeeder.php
+++ b/database/seeders/ClientSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Client;
+use App\Models\User;
+
+class ClientSeeder extends Seeder
+{
+    public function run()
+    {
+        $client = Client::create([
+            'business_name' => 'Example Pty Ltd',
+            'abn' => '123456789',
+            'halo_reference' => 'HALO123',
+            'itglue_org_id' => 1,
+            'active' => true,
+        ]);
+
+        $customer = User::where('role', 'customer')->first();
+        if ($customer) {
+            $client->users()->attach($customer->id);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
 {
     $this->call([
         UserSeeder::class,
+        ClientSeeder::class,
         DomainSeeder::class,
         HostingServiceSeeder::class,
         SSLServiceSeeder::class,

--- a/database/seeders/DomainSeeder.php
+++ b/database/seeders/DomainSeeder.php
@@ -11,14 +11,14 @@ class DomainSeeder extends Seeder
     {
         Domain::create([
             'domain_name' => 'example.com',
-            'customer_id' => 2,
+            'client_id' => 1,
             'auto_renew' => true,
             'renewal_date' => now()->addYear(),
         ]);
 
         Domain::create([
             'domain_name' => 'example.org',
-            'customer_id' => 2,
+            'client_id' => 1,
             'auto_renew' => false,
             'renewal_date' => now()->addMonths(6),
         ]);

--- a/database/seeders/HostingServiceSeeder.php
+++ b/database/seeders/HostingServiceSeeder.php
@@ -11,7 +11,7 @@ class HostingServiceSeeder extends Seeder
     {
         HostingService::create([
             'service_name' => 'Basic Hosting',
-            'customer_id' => 2,
+            'client_id' => 1,
             'disk_usage' => 10,
             'database_usage' => 2,
             'disk_space_threshold' => 80,
@@ -20,7 +20,7 @@ class HostingServiceSeeder extends Seeder
 
         HostingService::create([
             'service_name' => 'Premium Hosting',
-            'customer_id' => 2,
+            'client_id' => 1,
             'disk_usage' => 50,
             'database_usage' => 10,
             'disk_space_threshold' => 80,

--- a/database/seeders/SSLServiceSeeder.php
+++ b/database/seeders/SSLServiceSeeder.php
@@ -11,14 +11,14 @@ class SSLServiceSeeder extends Seeder
     {
         SSLService::create([
             'certificate_name' => 'SSL for example.com',
-            'customer_id' => 2,
+            'client_id' => 1,
             'expiration_date' => now()->addMonths(11),
             'details' => json_encode(['provider' => 'Comodo', 'type' => 'DV']),
         ]);
 
         SSLService::create([
             'certificate_name' => 'SSL for example.org',
-            'customer_id' => 2,
+            'client_id' => 1,
             'expiration_date' => now()->addMonths(6),
             'details' => json_encode(['provider' => 'GoDaddy', 'type' => 'EV']),
         ]);

--- a/resources/views/clients/create.blade.php
+++ b/resources/views/clients/create.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Create Client</h1>
+<form action="{{ route('clients.store') }}" method="POST">
+    @csrf
+    <div>
+        <label>Business Name</label>
+        <input type="text" name="business_name" required>
+    </div>
+    <div>
+        <label>ABN</label>
+        <input type="text" name="abn">
+    </div>
+    <div>
+        <label>Halo Reference</label>
+        <input type="text" name="halo_reference">
+    </div>
+    <div>
+        <label>ITGlue Org ID</label>
+        <input type="number" name="itglue_org_id">
+    </div>
+    <div>
+        <label>Active</label>
+        <input type="checkbox" name="active" value="1" checked>
+    </div>
+    <div>
+        <label>Users</label>
+        <select name="users[]" multiple>
+            @foreach($users as $user)
+                <option value="{{ $user->id }}">{{ $user->first_name ?? $user->name }} {{ $user->surname ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <button type="submit">Create</button>
+</form>
+@endsection

--- a/resources/views/clients/edit.blade.php
+++ b/resources/views/clients/edit.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+
+@section('content')
+<h1>Edit Client</h1>
+<form action="{{ route('clients.update', $client->id) }}" method="POST">
+    @csrf
+    @method('PUT')
+    <div>
+        <label>Business Name</label>
+        <input type="text" name="business_name" value="{{ $client->business_name }}" required>
+    </div>
+    <div>
+        <label>ABN</label>
+        <input type="text" name="abn" value="{{ $client->abn }}">
+    </div>
+    <div>
+        <label>Halo Reference</label>
+        <input type="text" name="halo_reference" value="{{ $client->halo_reference }}">
+    </div>
+    <div>
+        <label>ITGlue Org ID</label>
+        <input type="number" name="itglue_org_id" value="{{ $client->itglue_org_id }}">
+    </div>
+    <div>
+        <label>Active</label>
+        <input type="checkbox" name="active" value="1" @checked($client->active)>
+    </div>
+    <div>
+        <label>Users</label>
+        <select name="users[]" multiple>
+            @foreach($users as $user)
+                <option value="{{ $user->id }}" @selected(in_array($user->id, $assigned))>{{ $user->first_name ?? $user->name }} {{ $user->surname ?? '' }}</option>
+            @endforeach
+        </select>
+    </div>
+    <button type="submit">Update</button>
+</form>
+@endsection

--- a/resources/views/clients/index.blade.php
+++ b/resources/views/clients/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Clients</h1>
+<a href="{{ route('clients.create') }}" class="bg-green-500 text-white px-4 py-2 rounded mb-4 inline-block">Add New Client</a>
+
+<table class="table-auto w-full border-collapse border border-gray-300">
+    <thead>
+        <tr>
+            <th class="border border-gray-300 px-4 py-2">Business Name</th>
+            <th class="border border-gray-300 px-4 py-2">Active</th>
+            <th class="border border-gray-300 px-4 py-2">Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($clients as $client)
+        <tr>
+            <td class="border border-gray-300 px-4 py-2">{{ $client->business_name }}</td>
+            <td class="border border-gray-300 px-4 py-2">{{ $client->active ? 'Yes' : 'No' }}</td>
+            <td class="border border-gray-300 px-4 py-2">
+                <a href="{{ route('clients.show', $client->id) }}" class="text-blue-500 mr-2">View</a>
+                <a href="{{ route('clients.edit', $client->id) }}" class="text-blue-500 mr-2">Edit</a>
+                <form action="{{ route('clients.destroy', $client->id) }}" method="POST" style="display:inline;">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="text-red-500">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/clients/show.blade.php
+++ b/resources/views/clients/show.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">{{ $client->business_name }}</h1>
+<p><strong>ABN:</strong> {{ $client->abn }}</p>
+<p><strong>Halo Reference:</strong> {{ $client->halo_reference }}</p>
+<p><strong>ITGlue Org ID:</strong> {{ $client->itglue_org_id }}</p>
+<p><strong>Active:</strong> {{ $client->active ? 'Yes' : 'No' }}</p>
+
+<h2 class="text-xl font-bold mt-4 mb-2">Users</h2>
+<ul class="list-disc list-inside">
+@foreach($client->users as $user)
+    <li>{{ $user->first_name ?? $user->name }} {{ $user->surname ?? '' }} ({{ $user->email }})</li>
+@endforeach
+</ul>
+@endsection

--- a/resources/views/domains/create.blade.php
+++ b/resources/views/domains/create.blade.php
@@ -9,11 +9,11 @@
         <input type="text" name="domain_name" required>
     </div>
     <div>
-        <label>Customer</label>
-        <select name="customer_id">
+        <label>Client</label>
+        <select name="client_id">
             <option value="">None</option>
-            @foreach($customers as $customer)
-                <option value="{{ $customer->id }}">{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @foreach($clients as $client)
+                <option value="{{ $client->id }}">{{ $client->business_name }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/domains/edit.blade.php
+++ b/resources/views/domains/edit.blade.php
@@ -10,11 +10,11 @@
         <input type="text" name="domain_name" value="{{ $domain->domain_name }}" required>
     </div>
     <div>
-        <label>Customer</label>
-        <select name="customer_id">
+        <label>Client</label>
+        <select name="client_id">
             <option value="">None</option>
-            @foreach($customers as $customer)
-                <option value="{{ $customer->id }}" @selected($domain->customer_id == $customer->id)>{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @foreach($clients as $client)
+                <option value="{{ $client->id }}" @selected($domain->client_id == $client->id)>{{ $client->business_name }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/domains/index.blade.php
+++ b/resources/views/domains/index.blade.php
@@ -8,7 +8,7 @@
     <thead>
         <tr>
             <th class="border border-gray-300 px-4 py-2">Domain Name</th>
-            <th class="border border-gray-300 px-4 py-2">Customer</th>
+            <th class="border border-gray-300 px-4 py-2">Client</th>
             <th class="border border-gray-300 px-4 py-2">Renewal Date</th>
             <th class="border border-gray-300 px-4 py-2">Actions</th>
         </tr>
@@ -17,7 +17,7 @@
         @foreach ($domains as $domain)
         <tr>
             <td class="border border-gray-300 px-4 py-2">{{ $domain->domain_name }}</td>
-            <td class="border border-gray-300 px-4 py-2">{{ $domain->customer->first_name }} {{ $domain->customer->surname }}</td>
+            <td class="border border-gray-300 px-4 py-2">{{ optional($domain->client)->business_name }}</td>
             <td class="border border-gray-300 px-4 py-2">{{ $domain->renewal_date }}</td>
             <td class="border border-gray-300 px-4 py-2">
                 <a href="{{ route('domains.edit', $domain->id) }}" class="text-blue-500">Edit</a>

--- a/resources/views/hosting-services/create.blade.php
+++ b/resources/views/hosting-services/create.blade.php
@@ -9,11 +9,11 @@
         <input type="text" name="service_name" required>
     </div>
     <div>
-        <label>Customer</label>
-        <select name="customer_id">
+        <label>Client</label>
+        <select name="client_id">
             <option value="">None</option>
-            @foreach($customers as $customer)
-                <option value="{{ $customer->id }}">{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @foreach($clients as $client)
+                <option value="{{ $client->id }}">{{ $client->business_name }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/hosting-services/edit.blade.php
+++ b/resources/views/hosting-services/edit.blade.php
@@ -10,11 +10,11 @@
         <input type="text" name="service_name" value="{{ $hostingService->service_name }}" required>
     </div>
     <div>
-        <label>Customer</label>
-        <select name="customer_id">
+        <label>Client</label>
+        <select name="client_id">
             <option value="">None</option>
-            @foreach($customers as $customer)
-                <option value="{{ $customer->id }}" @selected($hostingService->customer_id == $customer->id)>{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @foreach($clients as $client)
+                <option value="{{ $client->id }}" @selected($hostingService->client_id == $client->id)>{{ $client->business_name }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/hosting-services/index.blade.php
+++ b/resources/views/hosting-services/index.blade.php
@@ -8,7 +8,7 @@
     <thead>
         <tr>
             <th class="border border-gray-300 px-4 py-2">Service Name</th>
-            <th class="border border-gray-300 px-4 py-2">Customer</th>
+            <th class="border border-gray-300 px-4 py-2">Client</th>
             <th class="border border-gray-300 px-4 py-2">Disk Usage</th>
             <th class="border border-gray-300 px-4 py-2">Actions</th>
         </tr>
@@ -17,7 +17,7 @@
         @foreach ($hostingServices as $service)
         <tr>
             <td class="border border-gray-300 px-4 py-2">{{ $service->service_name }}</td>
-            <td class="border border-gray-300 px-4 py-2">{{ $service->customer->first_name }} {{ $service->customer->surname }}</td>
+            <td class="border border-gray-300 px-4 py-2">{{ optional($service->client)->business_name }}</td>
             <td class="border border-gray-300 px-4 py-2">{{ $service->disk_usage }} MB</td>
             <td class="border border-gray-300 px-4 py-2">
                 <a href="{{ route('hosting-services.edit', $service->id) }}" class="text-blue-500">Edit</a>

--- a/resources/views/ssl-services/create.blade.php
+++ b/resources/views/ssl-services/create.blade.php
@@ -9,11 +9,11 @@
         <input type="text" name="certificate_name" required>
     </div>
     <div>
-        <label>Customer</label>
-        <select name="customer_id">
+        <label>Client</label>
+        <select name="client_id">
             <option value="">None</option>
-            @foreach($customers as $customer)
-                <option value="{{ $customer->id }}">{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @foreach($clients as $client)
+                <option value="{{ $client->id }}">{{ $client->business_name }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/ssl-services/edit.blade.php
+++ b/resources/views/ssl-services/edit.blade.php
@@ -10,11 +10,11 @@
         <input type="text" name="certificate_name" value="{{ $sslService->certificate_name }}" required>
     </div>
     <div>
-        <label>Customer</label>
-        <select name="customer_id">
+        <label>Client</label>
+        <select name="client_id">
             <option value="">None</option>
-            @foreach($customers as $customer)
-                <option value="{{ $customer->id }}" @selected($sslService->customer_id == $customer->id)>{{ $customer->first_name }} {{ $customer->surname }}</option>
+            @foreach($clients as $client)
+                <option value="{{ $client->id }}" @selected($sslService->client_id == $client->id)>{{ $client->business_name }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/ssl-services/index.blade.php
+++ b/resources/views/ssl-services/index.blade.php
@@ -7,7 +7,7 @@
     <thead>
         <tr>
             <th class="border border-gray-300 px-4 py-2">Certificate Name</th>
-            <th class="border border-gray-300 px-4 py-2">Customer</th>
+            <th class="border border-gray-300 px-4 py-2">Client</th>
             <th class="border border-gray-300 px-4 py-2">Expiration Date</th>
             <th class="border border-gray-300 px-4 py-2">Actions</th>
         </tr>
@@ -16,7 +16,7 @@
         @foreach ($sslServices as $ssl)
         <tr>
             <td class="border border-gray-300 px-4 py-2">{{ $ssl->certificate_name }}</td>
-            <td class="border border-gray-300 px-4 py-2">{{ optional($ssl->customer)->first_name }} {{ optional($ssl->customer)->surname }}</td>
+            <td class="border border-gray-300 px-4 py-2">{{ optional($ssl->client)->business_name }}</td>
             <td class="border border-gray-300 px-4 py-2">{{ $ssl->expiration_date }}</td>
             <td class="border border-gray-300 px-4 py-2">
                 <a href="{{ route('ssl-services.edit', $ssl->id) }}" class="text-blue-500">Edit</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Route;
 #Admin Only 
 Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('users', UserController::class)->except(['show']);
+    Route::resource('clients', ClientController::class);
     Route::resource('domains', DomainController::class)->except(['show']);
     Route::resource('hosting-services', HostingServiceController::class)->except(['show']);
     Route::resource('ssl-services', SSLServiceController::class)->except(['show']);


### PR DESCRIPTION
## Summary
- add `Client` model and migration
- create pivot table for assigning users to clients
- reference clients instead of customers in service tables
- show client data in controllers and views
- seed example clients and relations

## Testing
- `composer install`
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test` *(fails: Cannot redeclare class CreateBackupSettingsTable)*

------
https://chatgpt.com/codex/tasks/task_b_687c41fd666c8331a910b9c41a05328b