### PR TITLE
Add DNS record management

### DIFF
--- a/app/Livewire/DnsRecords.php
+++ b/app/Livewire/DnsRecords.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use App\Models\Domain;
+use App\Models\DnsRecord;
+use App\Services\SynergyClient;
+use Illuminate\Support\Facades\Auth;
+
+class DnsRecords extends Component
+{
+    public Domain $domain;
+    public $recordId = null;
+    public $type = '';
+    public $name = '';
+    public $value = '';
+    public $ttl = 3600;
+
+    protected function rules()
+    {
+        return [
+            'type' => 'required|string|max:50',
+            'name' => 'required|string|max:255',
+            'value' => 'required|string',
+            'ttl' => 'required|integer',
+        ];
+    }
+
+    public function mount(Domain $domain)
+    {
+        $this->domain = $domain;
+    }
+
+    protected function authorizeAction()
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin' && $this->domain->customer_id !== $user->id) {
+            abort(403);
+        }
+    }
+
+    public function createRecord(SynergyClient $synergy)
+    {
+        $this->authorizeAction();
+        $this->validate();
+        $record = $this->domain->dnsRecords()->create([
+            'type' => $this->type,
+            'name' => $this->name,
+            'value' => $this->value,
+            'ttl' => $this->ttl,
+        ]);
+
+        $synergy->addDNSRecord([
+            'domainName' => $this->domain->domain_name,
+            'recordType' => $record->type,
+            'host' => $record->name,
+            'value' => $record->value,
+            'ttl' => $record->ttl,
+        ]);
+
+        $this->reset(['type', 'name', 'value', 'ttl']);
+    }
+
+    public function editRecord($id)
+    {
+        $this->authorizeAction();
+        $record = DnsRecord::findOrFail($id);
+        $this->recordId = $record->id;
+        $this->type = $record->type;
+        $this->name = $record->name;
+        $this->value = $record->value;
+        $this->ttl = $record->ttl;
+    }
+
+    public function updateRecord(SynergyClient $synergy)
+    {
+        $this->authorizeAction();
+        $this->validate();
+        $record = DnsRecord::findOrFail($this->recordId);
+        $record->update([
+            'type' => $this->type,
+            'name' => $this->name,
+            'value' => $this->value,
+            'ttl' => $this->ttl,
+        ]);
+
+        $synergy->updateDNSRecord([
+            'domainName' => $this->domain->domain_name,
+            'recordID' => $record->id,
+            'recordType' => $record->type,
+            'host' => $record->name,
+            'value' => $record->value,
+            'ttl' => $record->ttl,
+        ]);
+
+        $this->reset(['recordId', 'type', 'name', 'value', 'ttl']);
+    }
+
+    public function deleteRecord($id, SynergyClient $synergy)
+    {
+        $this->authorizeAction();
+        $record = DnsRecord::findOrFail($id);
+        $record->delete();
+
+        $synergy->deleteDNSRecord([
+            'domainName' => $this->domain->domain_name,
+            'recordID' => $id,
+        ]);
+    }
+
+    public function render()
+    {
+        $records = $this->domain->dnsRecords()->get();
+        return view('livewire.dns-records', [
+            'records' => $records,
+        ]);
+    }
+}

--- a/app/Models/DnsRecord.php
+++ b/app/Models/DnsRecord.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DnsRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'domain_id',
+        'type',
+        'name',
+        'value',
+        'ttl',
+    ];
+
+    public function domain()
+    {
+        return $this->belongsTo(Domain::class);
+    }
+}

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
+use App\Models\DnsRecord;
 
 class Domain extends Model
 {
@@ -19,5 +21,10 @@ class Domain extends Model
     public function customer()
     {
         return $this->belongsTo(User::class, 'customer_id');
+    }
+
+    public function dnsRecords()
+    {
+        return $this->hasMany(DnsRecord::class);
     }
 }

--- a/database/migrations/2025_07_20_011322_create_dns_records_table.php
+++ b/database/migrations/2025_07_20_011322_create_dns_records_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('dns_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('domain_id')->constrained()->onDelete('cascade');
+            $table->string('type');
+            $table->string('name');
+            $table->text('value');
+            $table->integer('ttl')->default(3600);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('dns_records');
+    }
+};

--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};

--- a/resources/views/domains/edit.blade.php
+++ b/resources/views/domains/edit.blade.php
@@ -28,4 +28,8 @@
     </div>
     <button type="submit">Update</button>
 </form>
+
+<div class="mt-6">
+    @livewire('dns-records', ['domain' => $domain])
+</div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,7 @@
     <title>{{ config('app.name', 'DomainDash') }}</title>
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <script src="{{ mix('js/app.js') }}" defer></script>
+    @livewireStyles
 </head>
 <body class="bg-gray-100">
     <div class="min-h-screen flex flex-col">
@@ -34,5 +35,6 @@
             &copy; {{ date('Y') }} DomainDash. All rights reserved.
         </footer>
     </div>
+    @livewireScripts
 </body>
 </html>

--- a/resources/views/livewire/dns-records.blade.php
+++ b/resources/views/livewire/dns-records.blade.php
@@ -1,0 +1,44 @@
+<div>
+    <form wire:submit.prevent="{{ $recordId ? 'updateRecord' : 'createRecord' }}" class="mb-4">
+        <div class="flex space-x-2">
+            <input type="text" wire:model.defer="type" placeholder="Type" class="border p-1">
+            <input type="text" wire:model.defer="name" placeholder="Name" class="border p-1">
+            <input type="text" wire:model.defer="value" placeholder="Value" class="border p-1">
+            <input type="number" wire:model.defer="ttl" placeholder="TTL" class="border p-1">
+            <button type="submit" class="bg-blue-500 text-white px-2 py-1">{{ $recordId ? 'Update' : 'Add' }}</button>
+            @if($recordId)
+                <button type="button" wire:click="$set('recordId', null)" class="px-2 py-1">Cancel</button>
+            @endif
+        </div>
+        @error('type') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
+        @error('name') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
+        @error('value') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
+        @error('ttl') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
+    </form>
+
+    <table class="table-auto w-full border-collapse border border-gray-300">
+        <thead>
+            <tr>
+                <th class="border px-2">Type</th>
+                <th class="border px-2">Name</th>
+                <th class="border px-2">Value</th>
+                <th class="border px-2">TTL</th>
+                <th class="border px-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($records as $r)
+                <tr>
+                    <td class="border px-2">{{ $r->type }}</td>
+                    <td class="border px-2">{{ $r->name }}</td>
+                    <td class="border px-2">{{ $r->value }}</td>
+                    <td class="border px-2">{{ $r->ttl }}</td>
+                    <td class="border px-2 space-x-2">
+                        <button wire:click="editRecord({{ $r->id }})" class="text-blue-500">Edit</button>
+                        <button wire:click="deleteRecord({{ $r->id }})" class="text-red-500">Delete</button>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
## Summary
- add `DnsRecord` model and migration
- link `Domain` model to DNS records
- create a Livewire component to manage DNS records
- integrate basic Synergy API calls for add/update/delete DNS records
- include the DNS management component on the domain edit page
- load Livewire assets in the application layout
- fix API key migration syntax

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687c42041f6c83318d6505739fd598e8