### PR TITLE
Add scheduled jobs and notification bell

### DIFF
--- a/app/Console/Commands/CheckDiskUsage.php
+++ b/app/Console/Commands/CheckDiskUsage.php
@@ -4,19 +4,29 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use App\Models\HostingService;
+use App\Services\NotificationService;
 
 class CheckDiskUsage extends Command
 {
     protected $signature = 'disk:check';
     protected $description = 'Check disk usage and notify users if limits exceeded';
 
-    public function handle()
+    public function handle(NotificationService $service)
     {
-        $hostingServices = HostingService::all();
-        foreach ($hostingServices as $service) {
-            if ($service->disk_usage > $service->disk_space_threshold) {
-                // Notify customer
+        $hostingServices = HostingService::with('customer')->get();
+        foreach ($hostingServices as $hs) {
+            if ($hs->customer && $hs->disk_usage > $hs->disk_space_threshold) {
+                $service->notify(
+                    $hs->customer,
+                    'disk_space_warning',
+                    ['hosting_service_id' => $hs->id, 'disk_usage' => $hs->disk_usage],
+                    [
+                        'disk_usage' => $hs->disk_usage,
+                    ]
+                );
             }
         }
+
+        $this->info('Disk usage check completed.');
     }
 }

--- a/app/Console/Commands/CheckDomainExpiry.php
+++ b/app/Console/Commands/CheckDomainExpiry.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Domain;
+use App\Services\NotificationService;
+use Carbon\Carbon;
+
+class CheckDomainExpiry extends Command
+{
+    protected $signature = 'domains:check-expiry';
+    protected $description = 'Check for domains nearing expiration';
+
+    public function handle(NotificationService $service)
+    {
+        $threshold = Carbon::now()->addDays(30);
+        $domains = Domain::with('customer')
+            ->whereNotNull('renewal_date')
+            ->where('renewal_date', '<=', $threshold)
+            ->get();
+
+        foreach ($domains as $domain) {
+            if (!$domain->customer) {
+                continue;
+            }
+
+            $service->notify(
+                $domain->customer,
+                'domain_expiry',
+                ['domain_id' => $domain->id, 'renewal_date' => $domain->renewal_date],
+                [
+                    'domain_name' => $domain->domain_name,
+                    'renewal_date' => $domain->renewal_date->toDateString(),
+                ]
+            );
+        }
+
+        $this->info('Domain expiry check completed.');
+    }
+}

--- a/app/Console/Commands/CheckSSLExpiry.php
+++ b/app/Console/Commands/CheckSSLExpiry.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\SSLService;
+use App\Services\NotificationService;
+use Carbon\Carbon;
+
+class CheckSSLExpiry extends Command
+{
+    protected $signature = 'ssl:check-expiry';
+    protected $description = 'Check for SSL certificates nearing expiration';
+
+    public function handle(NotificationService $service)
+    {
+        $threshold = Carbon::now()->addDays(30);
+        $certs = SSLService::with('customer')
+            ->where('expiration_date', '<=', $threshold)
+            ->get();
+
+        foreach ($certs as $cert) {
+            if (!$cert->customer) {
+                continue;
+            }
+
+            $service->notify(
+                $cert->customer,
+                'ssl_expiry',
+                ['ssl_service_id' => $cert->id, 'expiration_date' => $cert->expiration_date],
+                [
+                    'domain_name' => $cert->certificate_name,
+                    'expiration_date' => $cert->expiration_date->toDateString(),
+                ]
+            );
+        }
+
+        $this->info('SSL expiry check completed.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,8 +12,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
-	
+        // Schedule maintenance tasks
+        $schedule->command('disk:check')->daily();
+        $schedule->command('domains:check-expiry')->daily();
+        $schedule->command('ssl:check-expiry')->daily();
+
     }
 
     /**

--- a/app/Http/Controllers/EmailTemplateController.php
+++ b/app/Http/Controllers/EmailTemplateController.php
@@ -13,6 +13,11 @@ class EmailTemplateController extends Controller
         return view('admin.email-templates.index', compact('templates'));
     }
 
+    public function create()
+    {
+        return view('admin.email-templates.create');
+    }
+
     public function edit($id)
     {
         $template = EmailTemplate::findOrFail($id);
@@ -30,5 +35,24 @@ class EmailTemplateController extends Controller
         $template->update($request->only('subject', 'body'));
 
         return redirect()->route('email-templates.index')->with('success', 'Template updated successfully.');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'template_type' => 'required|string',
+            'subject' => 'required|string|max:255',
+            'body' => 'required',
+        ]);
+
+        EmailTemplate::create($data);
+        return redirect()->route('email-templates.index')->with('success', 'Template created successfully.');
+    }
+
+    public function destroy($id)
+    {
+        $template = EmailTemplate::findOrFail($id);
+        $template->delete();
+        return redirect()->route('email-templates.index')->with('success', 'Template deleted successfully.');
     }
 }

--- a/app/Http/Livewire/NotificationBell.php
+++ b/app/Http/Livewire/NotificationBell.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+use App\Models\Notification;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationBell extends Component
+{
+    public $count = 0;
+
+    public function mount()
+    {
+        $this->loadCount();
+    }
+
+    public function loadCount()
+    {
+        $this->count = Notification::where('user_id', Auth::id())
+            ->where('is_read', false)
+            ->count();
+    }
+
+    public function markAllRead()
+    {
+        Notification::where('user_id', Auth::id())
+            ->where('is_read', false)
+            ->update(['is_read' => true]);
+        $this->loadCount();
+    }
+
+    public function render()
+    {
+        return view('livewire.notification-bell');
+    }
+}

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Notification;
+use App\Models\EmailTemplate;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+
+class NotificationService
+{
+    public function createNotification(User $user, string $type, array $details = []): Notification
+    {
+        return Notification::create([
+            'user_id' => $user->id,
+            'notification_type' => $type,
+            'details' => $details,
+            'is_read' => false,
+        ]);
+    }
+
+    public function sendEmail(User $user, string $type, array $data = []): void
+    {
+        $template = EmailTemplate::where('template_type', $type)->first();
+        if (!$template) {
+            return;
+        }
+
+        $placeholders = array_merge([
+            'customer_name' => $user->first_name ?? $user->name,
+        ], $data);
+
+        $subject = $this->replacePlaceholders($template->subject, $placeholders);
+        $body = $this->replacePlaceholders($template->body, $placeholders);
+
+        Mail::html($body, function ($message) use ($user, $subject) {
+            $message->to($user->email)->subject($subject);
+        });
+    }
+
+    private function replacePlaceholders(string $text, array $data): string
+    {
+        foreach ($data as $key => $value) {
+            $text = str_replace('{{ '.$key.' }}', $value, $text);
+        }
+        return $text;
+    }
+
+    public function notify(User $user, string $type, array $details = [], array $emailData = []): void
+    {
+        $this->createNotification($user, $type, $details);
+        $this->sendEmail($user, $type, $emailData);
+    }
+}

--- a/resources/views/admin/email-templates/create.blade.php
+++ b/resources/views/admin/email-templates/create.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-bold mb-4">Create Email Template</h1>
+<form method="POST" action="{{ route('email-templates.store') }}">
+    @csrf
+    <div class="mb-4">
+        <label for="template_type" class="block text-gray-700 font-bold mb-2">Template Type</label>
+        <input type="text" name="template_type" id="template_type" class="w-full border rounded px-4 py-2">
+    </div>
+    <div class="mb-4">
+        <label for="subject" class="block text-gray-700 font-bold mb-2">Subject</label>
+        <input type="text" name="subject" id="subject" class="w-full border rounded px-4 py-2">
+    </div>
+    <div class="mb-4">
+        <label for="body" class="block text-gray-700 font-bold mb-2">Body</label>
+        <textarea name="body" id="body" rows="10" class="w-full border rounded px-4 py-2"></textarea>
+    </div>
+    <p class="text-sm text-gray-600 mb-4">Available placeholders: {{ '{customer_name}' }}, {{ '{domain_name}' }}, {{ '{renewal_date}' }}, {{ '{expiration_date}' }}, {{ '{disk_usage}' }}</p>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Create</button>
+</form>
+@endsection

--- a/resources/views/admin/email-templates/edit.blade.php
+++ b/resources/views/admin/email-templates/edit.blade.php
@@ -22,6 +22,7 @@
         <label for="body" class="block text-gray-700 font-bold mb-2">Body</label>
         <textarea name="body" id="body" rows="10" class="w-full border rounded px-4 py-2">{{ $template->body }}</textarea>
     </div>
+    <p class="text-sm text-gray-600 mb-4">Available placeholders: {{ '{customer_name}' }}, {{ '{domain_name}' }}, {{ '{renewal_date}' }}, {{ '{expiration_date}' }}, {{ '{disk_usage}' }}</p>
 
     <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save Changes</button>
 </form>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config('app.name', 'DomainDash') }}</title>
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
+    @livewireStyles
     <script src="{{ mix('js/app.js') }}" defer></script>
 </head>
 <body class="bg-gray-100">
@@ -20,6 +21,7 @@
                             <a href="{{ route('email-templates.index') }}" class="px-4">Email Templates</a>
                             <a href="{{ route('api-keys.index') }}" class="px-4">API Keys</a>
                         @endif
+                        <livewire:notification-bell />
                         <a href="{{ route('logout') }}" class="px-4">Logout</a>
                     @endauth
                 </nav>
@@ -34,5 +36,6 @@
             &copy; {{ date('Y') }} DomainDash. All rights reserved.
         </footer>
     </div>
+    @livewireScripts
 </body>
 </html>

--- a/resources/views/livewire/notification-bell.blade.php
+++ b/resources/views/livewire/notification-bell.blade.php
@@ -1,0 +1,10 @@
+<div>
+    <button wire:click="markAllRead" class="relative">
+        <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V4a2 2 0 10-4 0v1.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+        @if($count > 0)
+            <span class="absolute -top-1 -right-1 bg-red-600 text-white rounded-full text-xs px-1">{{ $count }}</span>
+        @endif
+    </button>
+</div>


### PR DESCRIPTION
## Summary
- add NotificationService for creating alerts and sending template-based emails
- implement commands to check domain and SSL expirations
- enhance disk check command to alert customers
- schedule daily execution of monitoring commands
- create Livewire notification bell component and include it in the layout
- allow admins to create/edit/delete email templates with placeholder guidance

## Testing
- `composer install`
- `vendor/bin/phpunit --stop-on-failure` *(fails: Route [home] not defined)*

------
https://chatgpt.com/codex/tasks/task_b_687c420ca21083319435501599df8f4c