### PR TITLE
Integrate HaloPSA and ITGlue automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ REDIS_PORT=6379
 SYNERGY_API_URL=https://api.synergywholesale.com/server.php?wsdl
 SYNERGY_RESELLER_ID=
 SYNERGY_API_KEY=
+HALOPSA_URL=https://api.halopsa.com/v1
+HALOPSA_API_KEY=
+ITGLUE_URL=https://api.itglue.com
+ITGLUE_API_KEY=
+AUTOMATION_WEBHOOK_URL=
 
 MAIL_MAILER=smtp
 MAIL_HOST=mailpit

--- a/app/Events/AutomationWebhook.php
+++ b/app/Events/AutomationWebhook.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class AutomationWebhook
+{
+    use Dispatchable;
+
+    public string $type;
+    public array $payload;
+
+    public function __construct(string $type, array $payload)
+    {
+        $this->type = $type;
+        $this->payload = $payload;
+    }
+}

--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Events\AutomationWebhook;
+
+class WebhookController extends Controller
+{
+    public function handle(Request $request, string $type)
+    {
+        AutomationWebhook::dispatch($type, $request->all());
+        return response()->json(['status' => 'ok']);
+    }
+}

--- a/app/Listeners/SendAutomationWebhook.php
+++ b/app/Listeners/SendAutomationWebhook.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\AutomationWebhook;
+use Illuminate\Support\Facades\Http;
+
+class SendAutomationWebhook
+{
+    public function handle(AutomationWebhook $event): void
+    {
+        $url = config('integrations.webhook_url');
+        if (!$url) {
+            return;
+        }
+        Http::post($url, [
+            'type' => $event->type,
+            'payload' => $event->payload,
+        ]);
+    }
+}

--- a/app/Observers/DomainObserver.php
+++ b/app/Observers/DomainObserver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Domain;
+use App\Services\HaloPSAClient;
+use App\Services\ITGlueClient;
+use App\Events\AutomationWebhook;
+
+class DomainObserver
+{
+    protected HaloPSAClient $halo;
+    protected ITGlueClient $itglue;
+
+    public function __construct(HaloPSAClient $halo, ITGlueClient $itglue)
+    {
+        $this->halo = $halo;
+        $this->itglue = $itglue;
+    }
+
+    public function saved(Domain $domain): void
+    {
+        if ($domain->wasChanged('customer_id') && $domain->customer_id) {
+            $payload = [
+                'domain' => $domain->domain_name,
+                'customer_id' => $domain->customer_id,
+            ];
+            $this->halo->createOrUpdateAsset($payload);
+            $this->itglue->createOrUpdateConfiguration($payload);
+            AutomationWebhook::dispatch('domain_linked', $payload);
+        }
+
+        if ($domain->wasChanged('renewal_date') && $domain->renewal_date) {
+            $payload = [
+                'domain' => $domain->domain_name,
+                'expiry' => $domain->renewal_date->format('Y-m-d'),
+            ];
+            $this->halo->updateExpiry($domain->domain_name, $payload['expiry']);
+            $this->itglue->updateExpiry($domain->domain_name, $payload['expiry']);
+            AutomationWebhook::dispatch('domain_renewed', $payload);
+        }
+    }
+}

--- a/app/Observers/HostingServiceObserver.php
+++ b/app/Observers/HostingServiceObserver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\HostingService;
+use App\Services\HaloPSAClient;
+use App\Services\ITGlueClient;
+use App\Events\AutomationWebhook;
+
+class HostingServiceObserver
+{
+    protected HaloPSAClient $halo;
+    protected ITGlueClient $itglue;
+
+    public function __construct(HaloPSAClient $halo, ITGlueClient $itglue)
+    {
+        $this->halo = $halo;
+        $this->itglue = $itglue;
+    }
+
+    public function saved(HostingService $service): void
+    {
+        if ($service->wasChanged('customer_id') && $service->customer_id) {
+            $payload = [
+                'service' => $service->service_name,
+                'customer_id' => $service->customer_id,
+            ];
+            $this->halo->createOrUpdateAsset($payload);
+            $this->itglue->createOrUpdateConfiguration($payload);
+            AutomationWebhook::dispatch('hosting_linked', $payload);
+        }
+    }
+}

--- a/app/Observers/SSLServiceObserver.php
+++ b/app/Observers/SSLServiceObserver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\SSLService;
+use App\Services\HaloPSAClient;
+use App\Services\ITGlueClient;
+use App\Events\AutomationWebhook;
+
+class SSLServiceObserver
+{
+    protected HaloPSAClient $halo;
+    protected ITGlueClient $itglue;
+
+    public function __construct(HaloPSAClient $halo, ITGlueClient $itglue)
+    {
+        $this->halo = $halo;
+        $this->itglue = $itglue;
+    }
+
+    public function saved(SSLService $service): void
+    {
+        if ($service->wasChanged('customer_id') && $service->customer_id) {
+            $payload = [
+                'certificate' => $service->certificate_name,
+                'customer_id' => $service->customer_id,
+            ];
+            $this->halo->createOrUpdateAsset($payload);
+            $this->itglue->createOrUpdateConfiguration($payload);
+            AutomationWebhook::dispatch('ssl_linked', $payload);
+        }
+
+        if ($service->wasChanged('expiration_date') && $service->expiration_date) {
+            $payload = [
+                'certificate' => $service->certificate_name,
+                'expiry' => $service->expiration_date->format('Y-m-d'),
+            ];
+            $this->halo->updateExpiry($service->certificate_name, $payload['expiry']);
+            $this->itglue->updateExpiry($service->certificate_name, $payload['expiry']);
+            AutomationWebhook::dispatch('ssl_renewed', $payload);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,12 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\Domain;
+use App\Models\HostingService;
+use App\Models\SSLService;
+use App\Observers\DomainObserver;
+use App\Observers\HostingServiceObserver;
+use App\Observers\SSLServiceObserver;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +25,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Domain::observe(DomainObserver::class);
+        HostingService::observe(HostingServiceObserver::class);
+        SSLService::observe(SSLServiceObserver::class);
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -18,6 +18,9 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        \App\Events\AutomationWebhook::class => [
+            \App\Listeners\SendAutomationWebhook::class,
+        ],
     ];
 
     /**

--- a/app/Providers/IntegrationServiceProvider.php
+++ b/app/Providers/IntegrationServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Services\HaloPSAClient;
+use App\Services\ITGlueClient;
+
+class IntegrationServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(HaloPSAClient::class, fn () => new HaloPSAClient());
+        $this->app->alias(HaloPSAClient::class, 'halopsa');
+
+        $this->app->singleton(ITGlueClient::class, fn () => new ITGlueClient());
+        $this->app->alias(ITGlueClient::class, 'itglue');
+    }
+}

--- a/app/Services/HaloPSAClient.php
+++ b/app/Services/HaloPSAClient.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class HaloPSAClient
+{
+    private string $baseUrl;
+    private ?string $apiKey;
+
+    public function __construct()
+    {
+        $this->baseUrl = rtrim(config('integrations.halopsa.url'), '/');
+        $this->apiKey = config('integrations.halopsa.api_key');
+    }
+
+    public function createOrUpdateAsset(array $data)
+    {
+        return Http::withHeaders(['Authorization' => $this->apiKey])
+            ->post("{$this->baseUrl}/assets", $data)
+            ->json();
+    }
+
+    public function updateExpiry($assetId, string $expiry)
+    {
+        return Http::withHeaders(['Authorization' => $this->apiKey])
+            ->patch("{$this->baseUrl}/assets/{$assetId}", ['expiry' => $expiry])
+            ->json();
+    }
+}

--- a/app/Services/ITGlueClient.php
+++ b/app/Services/ITGlueClient.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class ITGlueClient
+{
+    private string $baseUrl;
+    private ?string $apiKey;
+
+    public function __construct()
+    {
+        $this->baseUrl = rtrim(config('integrations.itglue.url'), '/');
+        $this->apiKey = config('integrations.itglue.api_key');
+    }
+
+    public function createOrUpdateConfiguration(array $data)
+    {
+        return Http::withHeaders(['x-api-key' => $this->apiKey])
+            ->post("{$this->baseUrl}/configurations", $data)
+            ->json();
+    }
+
+    public function updateExpiry($configId, string $expiry)
+    {
+        return Http::withHeaders(['x-api-key' => $this->apiKey])
+            ->patch("{$this->baseUrl}/configurations/{$configId}", ['expiry_date' => $expiry])
+            ->json();
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -171,6 +171,7 @@ return [
         App\Providers\FortifyServiceProvider::class,
         App\Providers\JetstreamServiceProvider::class,
         App\Providers\SynergyWholesaleServiceProvider::class,
+        App\Providers\IntegrationServiceProvider::class,
 
     ])->toArray(),
 

--- a/config/integrations.php
+++ b/config/integrations.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'halopsa' => [
+        'url' => env('HALOPSA_URL', 'https://api.halopsa.com/v1'),
+        'api_key' => env('HALOPSA_API_KEY'),
+    ],
+    'itglue' => [
+        'url' => env('ITGLUE_URL', 'https://api.itglue.com'),
+        'api_key' => env('ITGLUE_API_KEY'),
+    ],
+    'webhook_url' => env('AUTOMATION_WEBHOOK_URL'),
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post('/webhooks/{type}', [\App\Http\Controllers\WebhookController::class, 'handle']);

--- a/tests/Unit/DomainObserverTest.php
+++ b/tests/Unit/DomainObserverTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Domain;
+use App\Observers\DomainObserver;
+use App\Services\HaloPSAClient;
+use App\Services\ITGlueClient;
+use Illuminate\Support\Facades\Event;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class DomainObserverTest extends TestCase
+{
+    public function test_saved_triggers_integration_calls(): void
+    {
+        $domain = new Domain(['domain_name' => 'example.com', 'customer_id' => 1, 'renewal_date' => Carbon::parse('2024-01-01')]);
+        $domain->syncOriginal();
+        $domain->customer_id = 2;
+        $domain->renewal_date = Carbon::parse('2025-01-01');
+        $domain->syncChanges();
+
+        $halo = \Mockery::mock(HaloPSAClient::class);
+        $halo->shouldReceive('createOrUpdateAsset')->once();
+        $halo->shouldReceive('updateExpiry')->once();
+
+        $itglue = \Mockery::mock(ITGlueClient::class);
+        $itglue->shouldReceive('createOrUpdateConfiguration')->once();
+        $itglue->shouldReceive('updateExpiry')->once();
+
+        Event::fake();
+
+        $observer = new DomainObserver($halo, $itglue);
+        $observer->saved($domain);
+
+        Event::assertDispatched(\App\Events\AutomationWebhook::class, 2);
+    }
+}

--- a/tests/Unit/HaloPSAClientTest.php
+++ b/tests/Unit/HaloPSAClientTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\HaloPSAClient;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Config;
+
+class HaloPSAClientTest extends TestCase
+{
+    public function test_create_or_update_asset_sends_request(): void
+    {
+        Config::set('integrations.halopsa.url', 'https://example.com');
+        Config::set('integrations.halopsa.api_key', 'token');
+
+        Http::fake();
+
+        $client = new HaloPSAClient();
+        $client->createOrUpdateAsset(['foo' => 'bar']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://example.com/assets'
+                && $request->method() === 'POST'
+                && $request['foo'] === 'bar'
+                && $request->hasHeader('Authorization', 'token');
+        });
+    }
+}

--- a/tests/Unit/ITGlueClientTest.php
+++ b/tests/Unit/ITGlueClientTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ITGlueClient;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Config;
+
+class ITGlueClientTest extends TestCase
+{
+    public function test_create_or_update_configuration_sends_request(): void
+    {
+        Config::set('integrations.itglue.url', 'https://example.com');
+        Config::set('integrations.itglue.api_key', 'token');
+
+        Http::fake();
+
+        $client = new ITGlueClient();
+        $client->createOrUpdateConfiguration(['foo' => 'bar']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://example.com/configurations'
+                && $request->method() === 'POST'
+                && $request['foo'] === 'bar'
+                && $request->hasHeader('x-api-key', 'token');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add integration config and service providers
- implement HaloPSA and ITGlue service clients
- create observers to sync assets on domain/service updates
- send automation webhooks on relevant events
- expose webhook endpoint
- include unit tests for new services and observer

## Testing
- `./vendor/bin/phpunit tests/Unit/HaloPSAClientTest.php tests/Unit/ITGlueClientTest.php tests/Unit/DomainObserverTest.php`

------
https://chatgpt.com/codex/tasks/task_b_687c422b99988331bd788f24661d6494