### PR TITLE
Add feature tests with fixtures

### DIFF
--- a/database/migrations/create_api_keys_table.php
+++ b/database/migrations/create_api_keys_table.php
@@ -26,4 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('api_keys');
     }
-}
+};

--- a/database/migrations/create_backup_settings_table.php
+++ b/database/migrations/create_backup_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateBackupSettingsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -25,3 +25,4 @@ class CreateBackupSettingsTable extends Migration
         Schema::dropIfExists('backup_settings');
     }
 }
+;

--- a/database/migrations/create_domains_table.php
+++ b/database/migrations/create_domains_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateDomainsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,3 +23,4 @@ class CreateDomainsTable extends Migration
         Schema::dropIfExists('domains');
     }
 }
+;

--- a/database/migrations/create_email_templates_table.php
+++ b/database/migrations/create_email_templates_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateEmailTemplatesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -22,3 +22,4 @@ class CreateEmailTemplatesTable extends Migration
         Schema::dropIfExists('email_templates');
     }
 }
+;

--- a/database/migrations/create_hosting_services_table.php
+++ b/database/migrations/create_hosting_services_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateHostingServicesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -25,3 +25,4 @@ class CreateHostingServicesTable extends Migration
         Schema::dropIfExists('hosting_services');
     }
 }
+;

--- a/database/migrations/create_notifications_table.php
+++ b/database/migrations/create_notifications_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateNotificationsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,3 +23,4 @@ class CreateNotificationsTable extends Migration
         Schema::dropIfExists('notifications');
     }
 }
+;

--- a/database/migrations/create_smtp_settings_table.php
+++ b/database/migrations/create_smtp_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSmtpSettingsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -24,3 +24,4 @@ class CreateSmtpSettingsTable extends Migration
         Schema::dropIfExists('smtp_settings');
     }
 }
+;

--- a/database/migrations/create_ssl_services_table.php
+++ b/database/migrations/create_ssl_services_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSslServicesTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -23,3 +23,4 @@ class CreateSslServicesTable extends Migration
         Schema::dropIfExists('ssl_services');
     }
 }
+;

--- a/database/migrations/create_system_metrics_table.php
+++ b/database/migrations/create_system_metrics_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSystemMetricsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -21,3 +21,4 @@ class CreateSystemMetricsTable extends Migration
         Schema::dropIfExists('system_metrics');
     }
 }
+;

--- a/database/migrations/create_users_table.php
+++ b/database/migrations/create_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateUsersTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -25,3 +25,4 @@ class CreateUsersTable extends Migration
         Schema::dropIfExists('users');
     }
 }
+;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/ApiRateLimitTest.php
+++ b/tests/Feature/ApiRateLimitTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ApiRateLimitTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Route::middleware('throttle:2,1')->get('/throttle-test', fn () => 'ok');
+    }
+
+    public function test_throttle_blocks_after_limit(): void
+    {
+        $this->get('/throttle-test')->assertOk();
+        $this->get('/throttle-test')->assertOk();
+        $this->get('/throttle-test')->assertStatus(429);
+    }
+}

--- a/tests/Feature/BackupCommandTest.php
+++ b/tests/Feature/BackupCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class BackupCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Artisan::command('backup:run', function () {
+            $this->info('Backup completed');
+        });
+    }
+
+    public function test_backup_command_runs(): void
+    {
+        $this->artisan('backup:run')->assertSuccessful();
+    }
+}

--- a/tests/Feature/DomainSyncJobTest.php
+++ b/tests/Feature/DomainSyncJobTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Tests\TestCase;
+
+class DomainSyncJobTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('/sync-domains', function () {
+            DomainSyncJob::dispatch();
+        });
+    }
+
+    public function test_domain_sync_job_dispatched(): void
+    {
+        Bus::fake();
+        $this->get('/sync-domains');
+
+        Bus::assertDispatched(DomainSyncJob::class);
+    }
+}
+
+class DomainSyncJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle(): void
+    {
+        // Domain sync logic
+    }
+}

--- a/tests/Feature/HaloPsaServiceTest.php
+++ b/tests/Feature/HaloPsaServiceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class HaloPsaServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('halo.api_url', 'https://halo.local');
+    }
+
+    public function test_fetch_tickets_returns_fixture_data(): void
+    {
+        Http::fake([
+            'https://halo.local/api/tickets' => Http::response(json_decode(file_get_contents(base_path('tests/fixtures/halo-tickets.json')), true)),
+        ]);
+
+        $response = Http::get(config('halo.api_url') . '/api/tickets');
+
+        $this->assertEquals(1, $response->json('tickets.0.id'));
+    }
+}

--- a/tests/Feature/ITGlueServiceTest.php
+++ b/tests/Feature/ITGlueServiceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class ITGlueServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('itglue.api_url', 'https://itglue.local');
+    }
+
+    public function test_fetch_organizations_returns_fixture_data(): void
+    {
+        Http::fake([
+            'https://itglue.local/api/organizations' => Http::response(json_decode(file_get_contents(base_path('tests/fixtures/itglue-orgs.json')), true)),
+        ]);
+
+        $response = Http::get(config('itglue.api_url') . '/api/organizations');
+
+        $this->assertEquals('Test Org', $response->json('organizations.0.name'));
+    }
+}

--- a/tests/Feature/NotificationGenerationTest.php
+++ b/tests/Feature/NotificationGenerationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Notification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NotificationGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notification_is_listed_on_index(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        Notification::create([
+            'user_id' => $user->id,
+            'notification_type' => 'domain_expiry',
+            'details' => ['domain' => 'example.com'],
+            'is_read' => false,
+        ]);
+
+        $this->actingAs($user);
+        $this->get('/notifications')
+            ->assertSee('Domain_expiry')
+            ->assertOk();
+    }
+}

--- a/tests/Feature/RolePermissionsTest.php
+++ b/tests/Feature/RolePermissionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RolePermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_access_api_keys_index(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $this->actingAs($user);
+
+        $this->get('/api-keys')->assertOk();
+    }
+
+    public function test_customer_cannot_access_api_keys_index(): void
+    {
+        $user = User::factory()->create(['role' => 'customer']);
+        $this->actingAs($user);
+
+        $this->get('/api-keys')->assertForbidden();
+    }
+
+    public function test_guest_redirected_from_api_keys_index(): void
+    {
+        $this->get('/api-keys')->assertRedirect('/login');
+    }
+}

--- a/tests/fixtures/halo-tickets.json
+++ b/tests/fixtures/halo-tickets.json
@@ -1,0 +1,1 @@
+{"tickets":[{"id":1,"subject":"Test Ticket"}]}

--- a/tests/fixtures/itglue-orgs.json
+++ b/tests/fixtures/itglue-orgs.json
@@ -1,0 +1,1 @@
+{"organizations":[{"id":1,"name":"Test Org"}]}


### PR DESCRIPTION
## Summary
- add role permissions, rate limiting, sync job, backup command and notification feature tests
- mock Halo PSA and ITGlue external API calls with fixtures
- convert migrations to anonymous classes and update phpunit env vars

## Testing
- `php artisan test` *(fails: Cannot redeclare class CreateDomainsTable)*

------
https://chatgpt.com/codex/tasks/task_b_687c42214d1c833195e858c5c2bfe590