### PR TITLE
Add HaloPSA domain relink action

### DIFF
--- a/app/Http/Controllers/Admin/ClientsController.php
+++ b/app/Http/Controllers/Admin/ClientsController.php
@@ -738,6 +738,8 @@ class ClientsController extends Controller
             }
 
             $linked = 0;
+            $matched = 0;
+            $alreadyLinked = 0;
             $updated = [];
 
             foreach ($domainAssets as $asset) {
@@ -753,6 +755,8 @@ class ClientsController extends Controller
                 if (!$domain) {
                     continue;
                 }
+
+                $matched++;
 
                 $changes = [];
 
@@ -772,10 +776,13 @@ class ClientsController extends Controller
                         'halo_asset_id' => $assetId,
                         'changes' => array_keys($changes),
                     ];
+                } else {
+                    $alreadyLinked++;
                 }
             }
 
-            if ($linked === 0) {
+            // If we matched assets but nothing needed updating, treat as success
+            if ($linked === 0 && $matched === 0) {
                 return response()->json([
                     'success' => false,
                     'message' => 'No matching HaloPSA domain assets found to link'
@@ -784,8 +791,12 @@ class ClientsController extends Controller
 
             return response()->json([
                 'success' => true,
-                'message' => "Linked {$linked} HaloPSA domain asset" . ($linked === 1 ? '' : 's'),
+                'message' => $linked > 0
+                    ? "Linked {$linked} HaloPSA domain asset" . ($linked === 1 ? '' : 's')
+                    : "All {$alreadyLinked} HaloPSA domain assets are already linked",
                 'linked' => $linked,
+                'already_linked' => $alreadyLinked,
+                'matched' => $matched,
                 'updated' => $updated,
             ]);
 

--- a/resources/views/admin/clients/form.blade.php
+++ b/resources/views/admin/clients/form.blade.php
@@ -226,6 +226,13 @@
                             @php
                                 $domainsWithAssets = $client->domains()->whereNotNull('halo_asset_id')->count();
                             @endphp
+                            <button type="button"
+                                    onclick="linkHaloDomains({{ $client->id }})"
+                                    class="btn-accent"
+                                    style="padding:6px 12px;font-size:13px;margin-bottom:6px;">
+                                🔄 Link HaloPSA Domains
+                            </button>
+                            <div id="halo-link-status" style="margin-top:2px;font-size:13px;"></div>
                             @if($domainsWithAssets > 0)
                                 <p style="font-size:13px;color:#9ca3af;margin-bottom:10px;">
                                     Update HaloPSA asset notes with DNS records ({{ $domainsWithAssets }} domain{{ $domainsWithAssets !== 1 ? 's' : '' }})
@@ -834,6 +841,37 @@
             })
             .finally(() => {
                 clearTimeout(timeoutId);
+            });
+        }
+
+        function linkHaloDomains(clientId) {
+            const statusDiv = document.getElementById('halo-link-status');
+            if (statusDiv) {
+                statusDiv.innerHTML = '<span style="color:#9ca3af;">⏳ Checking HaloPSA assets...</span>';
+            }
+
+            fetch('/admin/clients/' + clientId + '/halo/link-domains', {
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                    'Accept': 'application/json'
+                }
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (statusDiv) {
+                    if (data.success) {
+                        statusDiv.innerHTML = '<div style="color:#34d399;">✓ ' + data.message + '</div>';
+                    } else {
+                        statusDiv.innerHTML = '<div style="color:#f87171;">✗ ' + (data.error || data.message) + '</div>';
+                    }
+                }
+            })
+            .catch(err => {
+                console.error('Linking error:', err);
+                if (statusDiv) {
+                    statusDiv.innerHTML = '<div style="color:#f87171;">✗ Error linking HaloPSA domains</div>';
+                }
             });
         }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,7 @@ Route::middleware(['auth','verified'])->group(function () {
         
         // HaloPSA DNS Sync Routes
         Route::post('/clients/{client}/halo/sync-dns', [ClientsController::class, 'syncDnsToHalo'])->name('admin.clients.halo.syncDns');
+        Route::post('/clients/{client}/halo/link-domains', [ClientsController::class, 'linkHaloDomainAssets'])->name('admin.clients.halo.linkDomains');
         
         // ============================================================================
         // DOMAINS ROUTES


### PR DESCRIPTION
## Summary
- add a HaloPSA relink endpoint that scans domain assets and updates matching DomainDash records
- expose relink buttons in the client list and client form to trigger HaloPSA asset checks
- register routing and UI messaging for the new HaloPSA relink workflow

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932514385d48331a30a2466f2e215bc)