### PR TITLE
Switch ITGlue sync to flexible assets

### DIFF
--- a/app/Http/Controllers/Admin/ClientsController.php
+++ b/app/Http/Controllers/Admin/ClientsController.php
@@ -566,12 +566,12 @@ class ClientsController extends Controller
                     'message' => $result['success'] 
                         ? ucfirst($result['action']) 
                         : ($result['error'] ?? 'Failed'),
-                    'configuration_id' => $result['configuration_id'] ?? null
+                    'flexible_asset_id' => $result['flexible_asset_id'] ?? null
                 ];
                 
-                // Update domain with ITGlue configuration ID
-                if ($result['success'] && isset($result['configuration_id'])) {
-                    $domain->update(['itglue_configuration_id' => $result['configuration_id']]);
+                // Update domain with ITGlue flexible asset ID
+                if ($result['success'] && isset($result['flexible_asset_id'])) {
+                    $domain->update(['itglue_id' => $result['flexible_asset_id']]);
                 }
             }
 

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -18,6 +18,7 @@ class SettingsController extends Controller
             'synergy'  => Setting::get('synergy', []),
             'halo'     => Setting::get('halo', []),
             'itglue'   => Setting::get('itglue', []),
+            'ip2whois' => Setting::get('ip2whois', []),
             'backup'   => Setting::get('backup', ['host'=>'','port'=>22,'username'=>'','password'=>'','path'=>'/','retention'=>7,'time'=>'02:00']),
             'notifications' => Setting::get('notifications', ['disk_threshold_percent'=>90]),
         ];
@@ -32,6 +33,7 @@ class SettingsController extends Controller
             'synergy'       => 'array',
             'halo'          => 'array',
             'itglue'        => 'array',
+            'ip2whois'      => 'array',
             'backup'        => 'array',
             'notifications' => 'array',
             'branding_logo' => 'nullable|file|image|max:2048', // up to 2MB

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -12,13 +12,15 @@ class Domain extends Model
     use HasFactory;
 
     protected $fillable = [
-        'client_id','name','status','expiry_date','auto_renew','name_servers','dns_config','registry_id','transfer_status','halo_asset_id','itglue_id'
+        'client_id','name','status','expiry_date','auto_renew','name_servers','dns_config','registry_id','transfer_status','halo_asset_id','itglue_id','whois_data','whois_synced_at'
     ];
 
     protected $casts = [
         'name_servers' => 'array',
         'auto_renew'   => 'boolean',
-        'expiry_date'  => 'date'
+        'expiry_date'  => 'date',
+        'whois_data'   => 'array',
+        'whois_synced_at' => 'datetime'
     ];
 
     public function client()

--- a/app/Services/Ip2whois/Ip2whoisClient.php
+++ b/app/Services/Ip2whois/Ip2whoisClient.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Ip2whois;
+
+use App\Models\Setting;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class Ip2whoisClient
+{
+    protected string $baseUrl = 'https://api.ip2whois.com/v2';
+    protected ?string $apiKey;
+
+    public function __construct()
+    {
+        $cfg = Setting::get('ip2whois', []);
+        $this->apiKey = $cfg['api_key'] ?? null;
+    }
+
+    /**
+     * Lookup WHOIS details for a domain
+     */
+    public function lookup(string $domain): array
+    {
+        if (!$this->apiKey) {
+            return ['success' => false, 'error' => 'IP2WHOIS API key is not configured'];
+        }
+
+        try {
+            $resp = Http::get($this->baseUrl, [
+                'key' => $this->apiKey,
+                'domain' => $domain,
+                'format' => 'json',
+            ]);
+
+            if (!$resp->successful()) {
+                $body = $resp->json();
+                $error = $body['error_message'] ?? $resp->body();
+                Log::warning('IP2WHOIS lookup failed', [
+                    'domain' => $domain,
+                    'status' => $resp->status(),
+                    'error' => $error,
+                ]);
+                return ['success' => false, 'error' => $error];
+            }
+
+            $data = $resp->json();
+
+            return [
+                'success' => true,
+                'data' => $data,
+            ];
+        } catch (\Exception $e) {
+            Log::error('IP2WHOIS lookup error: ' . $e->getMessage(), [
+                'domain' => $domain,
+            ]);
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+}

--- a/database/migrations/2026_02_26_000001_add_whois_columns_to_domains_table.php
+++ b/database/migrations/2026_02_26_000001_add_whois_columns_to_domains_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('domains', function (Blueprint $table) {
+            if (!Schema::hasColumn('domains', 'whois_data')) {
+                $table->longText('whois_data')->nullable()->after('itglue_id');
+            }
+
+            if (!Schema::hasColumn('domains', 'whois_synced_at')) {
+                $table->timestamp('whois_synced_at')->nullable()->after('whois_data');
+                $table->index('whois_synced_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('domains', function (Blueprint $table) {
+            if (Schema::hasColumn('domains', 'whois_synced_at')) {
+                $table->dropIndex(['whois_synced_at']);
+                $table->dropColumn('whois_synced_at');
+            }
+
+            if (Schema::hasColumn('domains', 'whois_data')) {
+                $table->dropColumn('whois_data');
+            }
+        });
+    }
+};

--- a/resources/views/admin/domains/index.blade.php
+++ b/resources/views/admin/domains/index.blade.php
@@ -203,6 +203,12 @@
                                 <div class="dd-domain-option-label">Password / auth code</div>
                             </a>
 
+                            {{-- WHOIS sync --}}
+                            <button type="button" class="dd-domain-option" onclick="syncDomainWhois({{ $domain->id }}, '{{ $domain->name }}')">
+                                <div class="dd-domain-option-icon">🔍</div>
+                                <div class="dd-domain-option-label">WHOIS sync</div>
+                            </button>
+
                             {{-- Delete placeholder --}}
                             <a href="#" class="dd-domain-option dd-domain-option-danger">
                                 <div class="dd-domain-option-icon">✖️</div>
@@ -338,6 +344,37 @@
                 });
             }
         });
+
+        async function syncDomainWhois(domainId, domainName) {
+            if (!confirm(`Sync WHOIS data for ${domainName}?`)) {
+                return;
+            }
+
+            showGlobalSpinner('Syncing WHOIS…');
+
+            try {
+                const response = await fetch('/admin/sync/ip2whois/domains/sync', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+                    },
+                    body: JSON.stringify({ items: [{ id: domainId }] })
+                });
+
+                const data = await response.json();
+
+                if (data.success) {
+                    alert(`WHOIS sync completed (updated ${data.synced_count} domain${data.synced_count === 1 ? '' : 's'})`);
+                } else {
+                    alert('WHOIS sync failed: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                alert('WHOIS sync failed: ' + error.message);
+            } finally {
+                hideGlobalSpinner();
+            }
+        }
 
         /**
          * Tiny “searchable select” widget.

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -1210,15 +1210,15 @@
                 overlay.innerHTML = `
                     <div style="background:rgba(15,23,42,0.95);border:1px solid rgba(148,163,184,0.3);border-radius:12px;padding:24px;min-width:320px;text-align:center;color:#e2e8f0;box-shadow:0 20px 50px rgba(0,0,0,0.5);">
                         <div style="font-size:18px;font-weight:700;margin-bottom:12px;">Syncing to IT Glue…</div>
-                        <div style="width:100%;background:rgba(148,163,184,0.2);border-radius:9999px;overflow:hidden;">
-                            <div id="itglueProgressBar" style="width:35%;height:10px;background:linear-gradient(135deg,#f59e0b,#d97706);animation:glow 1.2s ease-in-out infinite alternate;"></div>
+                        <div style="display:flex;align-items:center;justify-content:center;margin:12px 0;">
+                            <div style="width:42px;height:42px;border:4px solid rgba(245,158,11,0.35);border-top-color:#f59e0b;border-radius:50%;animation:itglue-spin 1s linear infinite;"></div>
                         </div>
-                        <div style="margin-top:10px;font-size:13px;color:#cbd5e1;">Please keep this tab open while we sync.</div>
+                        <div style="margin-top:6px;font-size:13px;color:#cbd5e1;">Please keep this tab open while we sync.</div>
                     </div>
                     <style>
-                        @keyframes glow {
-                            from { width: 20%; opacity: 0.7; }
-                            to   { width: 80%; opacity: 1; }
+                        @keyframes itglue-spin {
+                            from { transform: rotate(0deg); }
+                            to { transform: rotate(360deg); }
                         }
                     </style>
                 `;

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -1164,6 +1164,8 @@
                 return;
             }
 
+            showItGlueSyncProgress();
+
             try {
                 const response = await fetch('/admin/sync/itglue/configurations/sync', {
                     method: 'POST',
@@ -1185,6 +1187,50 @@
                 }
             } catch (error) {
                 alert('Sync failed: ' + error.message);
+            } finally {
+                hideItGlueSyncProgress();
+            }
+        }
+
+        function showItGlueSyncProgress() {
+            let overlay = document.getElementById('itglueSyncProgress');
+            if (!overlay) {
+                overlay = document.createElement('div');
+                overlay.id = 'itglueSyncProgress';
+                overlay.style.position = 'fixed';
+                overlay.style.top = '0';
+                overlay.style.left = '0';
+                overlay.style.width = '100%';
+                overlay.style.height = '100%';
+                overlay.style.background = 'rgba(0,0,0,0.65)';
+                overlay.style.zIndex = '10000';
+                overlay.style.display = 'flex';
+                overlay.style.alignItems = 'center';
+                overlay.style.justifyContent = 'center';
+                overlay.innerHTML = `
+                    <div style="background:rgba(15,23,42,0.95);border:1px solid rgba(148,163,184,0.3);border-radius:12px;padding:24px;min-width:320px;text-align:center;color:#e2e8f0;box-shadow:0 20px 50px rgba(0,0,0,0.5);">
+                        <div style="font-size:18px;font-weight:700;margin-bottom:12px;">Syncing to IT Glue…</div>
+                        <div style="width:100%;background:rgba(148,163,184,0.2);border-radius:9999px;overflow:hidden;">
+                            <div id="itglueProgressBar" style="width:35%;height:10px;background:linear-gradient(135deg,#f59e0b,#d97706);animation:glow 1.2s ease-in-out infinite alternate;"></div>
+                        </div>
+                        <div style="margin-top:10px;font-size:13px;color:#cbd5e1;">Please keep this tab open while we sync.</div>
+                    </div>
+                    <style>
+                        @keyframes glow {
+                            from { width: 20%; opacity: 0.7; }
+                            to   { width: 80%; opacity: 1; }
+                        }
+                    </style>
+                `;
+                document.body.appendChild(overlay);
+            }
+            overlay.style.display = 'flex';
+        }
+
+        function hideItGlueSyncProgress() {
+            const overlay = document.getElementById('itglueSyncProgress');
+            if (overlay) {
+                overlay.style.display = 'none';
             }
         }
     </script>

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -396,6 +396,46 @@
                 </div>
             </div>
 
+            {{-- IP2WHOIS SECTION --}}
+            <div class="settings-section" style="background:rgba(15,23,42,0.6);border:1px solid rgba(148,163,184,0.1);border-radius:12px;margin-bottom:16px;overflow:hidden;">
+                <div class="settings-header" onclick="toggleSection('ip2whois')" style="padding:16px 20px;cursor:pointer;display:flex;align-items:center;justify-content:space-between;background:rgba(15,23,42,0.4);border-bottom:1px solid rgba(148,163,184,0.1);transition:background 0.2s;">
+                    <div style="display:flex;align-items:center;gap:12px;">
+                        <div style="width:40px;height:40px;background:linear-gradient(135deg,#0ea5e9,#0284c7);border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:20px;">
+                            🌐
+                        </div>
+                        <div>
+                            <h3 style="font-size:16px;font-weight:600;margin:0;color:#f8fafc;">IP2WHOIS</h3>
+                            <p style="font-size:13px;color:#94a3b8;margin:0;">IP2Location.io WHOIS lookups</p>
+                        </div>
+                    </div>
+                    <svg id="ip2whois-icon" style="width:20px;height:20px;transition:transform 0.3s;color:#94a3b8;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                    </svg>
+                </div>
+                <div id="ip2whois-content" class="settings-content" style="padding:20px 24px;display:none;">
+
+                    <div style="margin-bottom:12px;">
+                        <label for="ip2whois_api_key" style="display:block;font-size:14px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">
+                            API Key
+                        </label>
+                        <input id="ip2whois_api_key"
+                               type="text"
+                               name="ip2whois[api_key]"
+                               value="{{ $settings['ip2whois']['api_key'] ?? '' }}"
+                               placeholder="Enter IP2WHOIS API key"
+                               style="width:100%;padding:8px 10px;border-radius:4px;
+                                      border:1px solid #e5e7eb;font-size:14px;">
+                        <small style="display:block;margin-top:4px;font-size:12px;color:#9ca3af;">
+                            Get your key from IP2Location.io &gt; IP2WHOIS.
+                        </small>
+                    </div>
+
+                    <button type="button" class="btn-accent" style="margin-top:12px;" onclick="openIp2whoisModal();">
+                        🔍 Sync WHOIS (select domains)
+                    </button>
+                </div>
+            </div>
+
             {{-- SMTP SECTION --}}
             <div class="settings-section" style="background:rgba(15,23,42,0.6);border:1px solid rgba(148,163,184,0.1);border-radius:12px;margin-bottom:16px;overflow:hidden;">
                 <div class="settings-header" onclick="toggleSection('smtp')" style="padding:16px 20px;cursor:pointer;display:flex;align-items:center;justify-content:space-between;background:rgba(15,23,42,0.4);border-bottom:1px solid rgba(148,163,184,0.1);transition:background 0.2s;">
@@ -702,6 +742,30 @@
         </div>
     </div>
 
+    {{-- IP2WHOIS Sync Modal --}}
+    <div id="ip2whoisSyncModal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);z-index:9999;align-items:center;justify-content:center;">
+        <div style="background:rgba(15,23,42,0.95);border:1px solid rgba(148,163,184,0.2);border-radius:12px;max-width:900px;width:90%;max-height:90vh;overflow:hidden;display:flex;flex-direction:column;">
+            <div style="padding:20px 24px;border-bottom:1px solid rgba(148,163,184,0.1);display:flex;justify-content:space-between;align-items:center;">
+                <h2 style="font-size:20px;font-weight:700;margin:0;color:#f8fafc;">🔍 Sync WHOIS (IP2WHOIS)</h2>
+                <button onclick="closeIp2whoisModal()" style="background:none;border:none;color:#94a3b8;font-size:24px;cursor:pointer;padding:0;line-height:1;">&times;</button>
+            </div>
+            <div style="padding:24px;overflow-y:auto;flex:1;">
+                <div style="margin-bottom:16px;display:flex;justify-content:space-between;align-items:center;">
+                    <h3 style="font-size:16px;font-weight:600;color:#f8fafc;margin:0;">Domains</h3>
+                    <div style="display:flex;gap:8px;">
+                        <button onclick="loadIp2whoisDomains()" class="btn-accent" style="padding:8px 16px;font-size:14px;">🔄 Refresh List</button>
+                        <button onclick="syncIp2whoisDomains()" class="btn-accent" style="padding:8px 16px;font-size:14px;">✓ Sync Selected</button>
+                    </div>
+                </div>
+                <div id="ip2whoisDomainList" style="background:rgba(15,23,42,0.4);border:1px solid rgba(148,163,184,0.1);border-radius:8px;padding:16px;">
+                    <div style="text-align:center;color:#94a3b8;padding:40px;">
+                        Click "Refresh List" to load domains
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script>
         function toggleSection(sectionName) {
             const content = document.getElementById(sectionName + '-content');
@@ -714,6 +778,16 @@
                 content.style.display = 'none';
                 icon.style.transform = 'rotate(0deg)';
             }
+        }
+
+        // IP2WHOIS Modal
+        function openIp2whoisModal() {
+            document.getElementById('ip2whoisSyncModal').style.display = 'flex';
+            loadIp2whoisDomains();
+        }
+
+        function closeIp2whoisModal() {
+            document.getElementById('ip2whoisSyncModal').style.display = 'none';
         }
 
         // Add hover effect to section headers
@@ -1095,6 +1169,99 @@
             }
         }
 
+        async function loadIp2whoisDomains() {
+            const listEl = document.getElementById('ip2whoisDomainList');
+            listEl.innerHTML = '<div style="text-align:center;color:#94a3b8;padding:40px;"><div style="font-size:32px;margin-bottom:12px;">⏳</div>Loading domains…</div>';
+
+            try {
+                const response = await fetch('/admin/sync/ip2whois/domains');
+                const data = await response.json();
+
+                if (data.error) {
+                    listEl.innerHTML = `<div style="text-align:center;color:#ef4444;padding:40px;">${data.error}</div>`;
+                    return;
+                }
+
+                renderIp2whoisDomainList(data.items || []);
+            } catch (error) {
+                listEl.innerHTML = `<div style="text-align:center;color:#ef4444;padding:40px;">Failed to load domains: ${error.message}</div>`;
+            }
+        }
+
+        function renderIp2whoisDomainList(items) {
+            const listEl = document.getElementById('ip2whoisDomainList');
+
+            let html = `
+                <div style="margin-bottom:16px;padding:12px;background:rgba(15,23,42,0.6);border-radius:6px;display:grid;grid-template-columns:40px 1fr 1fr 140px 100px;gap:12px;align-items:center;font-weight:600;color:#94a3b8;font-size:13px;">
+                    <input type="checkbox" id="selectAllIp2whois" onchange="toggleAllIp2whois(this)" style="width:18px;height:18px;cursor:pointer;border-radius:4px;">
+                    <div>Name</div>
+                    <div>Client</div>
+                    <div>Last synced</div>
+                    <div style="text-align:center;">Status</div>
+                </div>
+            `;
+
+            items.forEach(item => {
+                const statusColor = item.has_data ? '#10b981' : '#94a3b8';
+                const statusText = item.has_data ? 'Cached' : 'Not synced';
+                const syncedAt = item.synced_at ? new Date(item.synced_at).toLocaleString() : '—';
+
+                html += `
+                    <div style="padding:12px;background:rgba(15,23,42,0.3);border-radius:6px;margin-bottom:8px;display:grid;grid-template-columns:40px 1fr 1fr 140px 100px;gap:12px;align-items:center;">
+                        <input type="checkbox" class="ip2whois-checkbox" data-item-id="${item.id}" style="width:18px;height:18px;cursor:pointer;border-radius:4px;">
+                        <div style="color:#f8fafc;">${item.name}</div>
+                        <div style="color:#94a3b8;font-size:13px;">${item.client || 'No client'}</div>
+                        <div style="color:#94a3b8;font-size:13px;">${syncedAt}</div>
+                        <div style="text-align:center;color:${statusColor};font-size:13px;">${statusText}</div>
+                    </div>
+                `;
+            });
+
+            listEl.innerHTML = html;
+        }
+
+        function toggleAllIp2whois(checkbox) {
+            document.querySelectorAll('.ip2whois-checkbox').forEach(cb => cb.checked = checkbox.checked);
+        }
+
+        async function syncIp2whoisDomains() {
+            const selected = [];
+            document.querySelectorAll('.ip2whois-checkbox:checked').forEach(cb => {
+                selected.push({ id: cb.dataset.itemId });
+            });
+
+            if (selected.length === 0) {
+                alert('Please select at least one domain to sync');
+                return;
+            }
+
+            showGlobalSpinner('Syncing WHOIS data…');
+
+            try {
+                const response = await fetch('/admin/sync/ip2whois/domains/sync', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content || ''
+                    },
+                    body: JSON.stringify({ items: selected })
+                });
+
+                const data = await response.json();
+
+                if (data.success) {
+                    alert(`Synced ${data.synced_count} domain(s)`);
+                    loadIp2whoisDomains();
+                } else {
+                    alert('Sync failed: ' + (data.error || 'Unknown error'));
+                }
+            } catch (error) {
+                alert('Sync failed: ' + error.message);
+            } finally {
+                hideGlobalSpinner();
+            }
+        }
+
         async function loadItGlueConfigs() {
             const listEl = document.getElementById('itglueConfigList');
             listEl.innerHTML = '<div style="text-align:center;color:#94a3b8;padding:40px;"><div style="font-size:32px;margin-bottom:12px;">⏳</div>Loading configuration items...</div>';
@@ -1193,10 +1360,18 @@
         }
 
         function showItGlueSyncProgress() {
-            let overlay = document.getElementById('itglueSyncProgress');
+            showGlobalSpinner('Syncing to IT Glue…');
+        }
+
+        function hideItGlueSyncProgress() {
+            hideGlobalSpinner();
+        }
+
+        function showGlobalSpinner(message = 'Working…') {
+            let overlay = document.getElementById('globalSpinnerOverlay');
             if (!overlay) {
                 overlay = document.createElement('div');
-                overlay.id = 'itglueSyncProgress';
+                overlay.id = 'globalSpinnerOverlay';
                 overlay.style.position = 'fixed';
                 overlay.style.top = '0';
                 overlay.style.left = '0';
@@ -1209,14 +1384,14 @@
                 overlay.style.justifyContent = 'center';
                 overlay.innerHTML = `
                     <div style="background:rgba(15,23,42,0.95);border:1px solid rgba(148,163,184,0.3);border-radius:12px;padding:24px;min-width:320px;text-align:center;color:#e2e8f0;box-shadow:0 20px 50px rgba(0,0,0,0.5);">
-                        <div style="font-size:18px;font-weight:700;margin-bottom:12px;">Syncing to IT Glue…</div>
+                        <div id="globalSpinnerMessage" style="font-size:18px;font-weight:700;margin-bottom:12px;"></div>
                         <div style="display:flex;align-items:center;justify-content:center;margin:12px 0;">
-                            <div style="width:42px;height:42px;border:4px solid rgba(245,158,11,0.35);border-top-color:#f59e0b;border-radius:50%;animation:itglue-spin 1s linear infinite;"></div>
+                            <div style="width:42px;height:42px;border:4px solid rgba(245,158,11,0.35);border-top-color:#f59e0b;border-radius:50%;animation:global-spin 1s linear infinite;"></div>
                         </div>
-                        <div style="margin-top:6px;font-size:13px;color:#cbd5e1;">Please keep this tab open while we sync.</div>
+                        <div style="margin-top:6px;font-size:13px;color:#cbd5e1;">Please keep this tab open while we process.</div>
                     </div>
                     <style>
-                        @keyframes itglue-spin {
+                        @keyframes global-spin {
                             from { transform: rotate(0deg); }
                             to { transform: rotate(360deg); }
                         }
@@ -1224,11 +1399,15 @@
                 `;
                 document.body.appendChild(overlay);
             }
+            const msgEl = document.getElementById('globalSpinnerMessage');
+            if (msgEl) {
+                msgEl.textContent = message;
+            }
             overlay.style.display = 'flex';
         }
 
-        function hideItGlueSyncProgress() {
-            const overlay = document.getElementById('itglueSyncProgress');
+        function hideGlobalSpinner() {
+            const overlay = document.getElementById('globalSpinnerOverlay');
             if (overlay) {
                 overlay.style.display = 'none';
             }

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -344,6 +344,55 @@
                            style="width:100%;padding:8px 10px;border-radius:4px;
                                   border:1px solid #e5e7eb;font-size:14px;">
                 </div>
+
+                @php
+                    $flexibleAssetTraits = $settings['itglue']['flexible_asset_traits'] ?? [
+                        'domain' => 'domain-name',
+                        'name_servers' => 'name-servers',
+                        'expiry' => 'expiry',
+                        'whois' => 'whois',
+                        'dns' => 'dns',
+                    ];
+                @endphp
+
+                <div style="margin-top:16px;">
+                    <label for="itglue_flexible_asset_type_id" style="display:block;font-size:14px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">
+                        Flexible Asset Type ID
+                    </label>
+                    <input id="itglue_flexible_asset_type_id"
+                           type="text"
+                           name="itglue[flexible_asset_type_id]"
+                           value="{{ $settings['itglue']['flexible_asset_type_id'] ?? '' }}"
+                           placeholder="e.g. 4521154692859938"
+                           style="width:100%;padding:8px 10px;border-radius:4px;
+                                  border:1px solid #e5e7eb;font-size:14px;">
+                    <small style="display:block;margin-top:4px;font-size:12px;color:#9ca3af;">
+                        Required when syncing domains to flexible assets.
+                    </small>
+                </div>
+
+                <div style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;">
+                    <div>
+                        <label style="display:block;font-size:13px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">Domain trait key</label>
+                        <input type="text" name="itglue[flexible_asset_traits][domain]" value="{{ $flexibleAssetTraits['domain'] ?? '' }}" style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;" placeholder="domain-name">
+                    </div>
+                    <div>
+                        <label style="display:block;font-size:13px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">Name servers trait key</label>
+                        <input type="text" name="itglue[flexible_asset_traits][name_servers]" value="{{ $flexibleAssetTraits['name_servers'] ?? '' }}" style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;" placeholder="name-servers">
+                    </div>
+                    <div>
+                        <label style="display:block;font-size:13px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">Expiry trait key</label>
+                        <input type="text" name="itglue[flexible_asset_traits][expiry]" value="{{ $flexibleAssetTraits['expiry'] ?? '' }}" style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;" placeholder="expiry">
+                    </div>
+                    <div>
+                        <label style="display:block;font-size:13px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">WHOIS trait key</label>
+                        <input type="text" name="itglue[flexible_asset_traits][whois]" value="{{ $flexibleAssetTraits['whois'] ?? '' }}" style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;" placeholder="whois">
+                    </div>
+                    <div>
+                        <label style="display:block;font-size:13px;margin-bottom:4px;color:#e2e8f0;font-weight:500;">DNS trait key</label>
+                        <input type="text" name="itglue[flexible_asset_traits][dns]" value="{{ $flexibleAssetTraits['dns'] ?? '' }}" style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;" placeholder="dns">
+                    </div>
+                </div>
                 </div>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,6 +53,8 @@ Route::middleware(['auth','verified'])->group(function () {
         Route::get('/sync/itglue/suggest/{clientId}', [\App\Http\Controllers\Admin\SyncController::class, 'suggestItGlueOrg']);
         Route::get('/sync/itglue/configurations', [\App\Http\Controllers\Admin\SyncController::class, 'getItGlueConfigurations']);
         Route::post('/sync/itglue/configurations/sync', [\App\Http\Controllers\Admin\SyncController::class, 'syncItGlueConfigurations']);
+        Route::get('/sync/ip2whois/domains', [\App\Http\Controllers\Admin\SyncController::class, 'getIp2whoisDomains']);
+        Route::post('/sync/ip2whois/domains/sync', [\App\Http\Controllers\Admin\SyncController::class, 'syncIp2whoisDomains']);
 
         // ============================================================================
         // CLIENTS ROUTES


### PR DESCRIPTION
## Summary
- replace ITGlue configuration sync with flexible asset create/update calls and trait generation for DNS details
- store ITGlue flexible asset identifiers on domains after syncing
- add settings fields to configure the ITGlue flexible asset type and trait keys

## Testing
- php -l app/Services/ItGlue/ItGlueClient.php
- php -l app/Http/Controllers/Admin/ClientsController.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694247d61cbc83318166442c0093e5db)