### PR TITLE
Surface WHOIS data in domain overview and integrations

### DIFF
--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -80,13 +80,16 @@ class DomainController extends Controller
             $nameservers = array_filter(array_map('trim', explode(',', $nameservers)));
         }
 
+        $nameserverDetails = $whoisOverview['nameservers_detail'] ?? [];
+
         return view('admin.domains.show', compact(
             'domain',
             'dnsLabel',
             'clients',
             'whoisOverview',
             'whoisText',
-            'nameservers'
+            'nameservers',
+            'nameserverDetails'
         ));
     }
 

--- a/app/Http/Controllers/Admin/SyncController.php
+++ b/app/Http/Controllers/Admin/SyncController.php
@@ -718,6 +718,16 @@ class SyncController extends Controller
                     $synced++;
                     $results[] = ['id' => $domain->id, 'success' => true];
                 } else {
+                    // Treat "no data found" as a soft warning so bulk sync can proceed
+                    if (!empty($lookup['not_found'])) {
+                        $results[] = [
+                            'id' => $domain->id,
+                            'success' => false,
+                            'warning' => 'No WHOIS data found for this domain',
+                        ];
+                        continue;
+                    }
+
                     $results[] = [
                         'id' => $domain->id,
                         'success' => false,

--- a/app/Http/Controllers/Admin/SyncController.php
+++ b/app/Http/Controllers/Admin/SyncController.php
@@ -10,6 +10,7 @@ use App\Models\Domain;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use App\Services\Ip2whois\Ip2whoisClient;
+use App\Support\WhoisFormatter;
 use SoapClient;
 
 class SyncController extends Controller
@@ -216,18 +217,31 @@ class SyncController extends Controller
                 }
 
                 try {
-                    // Fetch WHOIS data from Synergy
-                    $whoisResponse = $this->fetchWhoisFromSynergy($domain->name);
+                    $whoisData = $domain->whois_data ?? [];
+                    $whoisOverview = WhoisFormatter::overview($whoisData, $domain->name, $domain->whois_synced_at);
+                    $whoisNotes = WhoisFormatter::formatText($whoisData, $domain->name, $domain->whois_synced_at);
 
-                    // Extract nameservers from WHOIS response if not in domain record
-                    $nameservers = '';
-                    if ($domain->name_servers) {
-                        $nameservers = is_array($domain->name_servers)
-                            ? implode(', ', $domain->name_servers)
-                            : $domain->name_servers;
-                    } else {
-                        // Try to extract nameservers from WHOIS data
-                        $nameservers = $this->extractNameserversFromWhois($whoisResponse['nameservers'] ?? []);
+                    // Extract nameservers from the domain record or WHOIS overview
+                    $nameservers = $domain->name_servers;
+                    if (empty($nameservers) && !empty($whoisOverview['nameservers'])) {
+                        $nameservers = $whoisOverview['nameservers'];
+                    }
+
+                    // Fallback to Synergy WHOIS when nothing is available from IP2WHOIS
+                    if (empty($nameservers) || !$whoisOverview['has_data']) {
+                        $whoisResponse = $this->fetchWhoisFromSynergy($domain->name);
+
+                        if (empty($nameservers)) {
+                            $nameservers = $this->extractNameserversFromWhois($whoisResponse['nameservers'] ?? []);
+                        }
+
+                        if (!$whoisOverview['has_data'] && !empty($whoisResponse['formatted'])) {
+                            $whoisNotes = $whoisResponse['formatted'];
+                        }
+                    }
+
+                    if (is_array($nameservers)) {
+                        $nameservers = implode(', ', array_filter($nameservers));
                     }
 
                     // Ensure we have at least something for key_field3 (required field)
@@ -246,8 +260,6 @@ class SyncController extends Controller
                     $expiryDate = $domain->expiry_date instanceof \Illuminate\Support\Carbon
                         ? $domain->expiry_date->toDateString()
                         : (string) $domain->expiry_date;
-
-                    $whoisNotes = $whoisResponse['formatted'] ?? '';
                     $clientHaloId = (int) $domain->client->halopsa_reference;
 
                     // Determine client site (default to "Main" when possible)

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -3,6 +3,7 @@
 namespace App\Services\Halo;
 
 use App\Models\Setting;
+use App\Support\WhoisFormatter;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Facades\Cache;
@@ -409,6 +410,13 @@ class HaloPsaClient
             // Format DNS records
             $dnsNotes = $this->formatDnsRecordsForNotes($dnsRecords ?? []);
 
+            // Format WHOIS details if available
+            $whoisNotes = WhoisFormatter::formatText(
+                $domain->whois_data ?? [],
+                $domain->name,
+                $domain->whois_synced_at
+            );
+
             // Combine with domain info
             $lines = [];
             $lines[] = '=== DomainDash Domain Info ===';
@@ -421,6 +429,11 @@ class HaloPsaClient
             }
             $lines[] = '';
             $lines[] = $dnsNotes;
+
+            if ($whoisNotes) {
+                $lines[] = '';
+                $lines[] = $whoisNotes;
+            }
 
             $newNotes = trim(rtrim((string) $currentNotes) . "\n\n" . implode("\n", $lines));
 

--- a/app/Services/ItGlue/ItGlueClient.php
+++ b/app/Services/ItGlue/ItGlueClient.php
@@ -4,6 +4,7 @@ namespace App\Services\ItGlue;
 
 use App\Models\Domain;
 use App\Models\Setting;
+use App\Support\WhoisFormatter;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Log;
 
@@ -274,7 +275,11 @@ class ItGlueClient
         }
 
         if ($whoisKey = $this->traitKey('whois')) {
-            $traits[$whoisKey] = 'WHOIS data not available from DomainDash at this time.';
+            $traits[$whoisKey] = WhoisFormatter::formatText(
+                $domain->whois_data ?? [],
+                $domain->name,
+                $domain->whois_synced_at
+            );
         }
 
         if ($dnsKey = $this->traitKey('dns')) {

--- a/app/Support/WhoisFormatter.php
+++ b/app/Support/WhoisFormatter.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Carbon;
+
+class WhoisFormatter
+{
+    public static function overview(?array $data, ?string $domain = null, $syncedAt = null): array
+    {
+        $data = $data ?? [];
+
+        $nameservers = [];
+
+        if (!empty($data['name_servers']) && is_array($data['name_servers'])) {
+            $nameservers = $data['name_servers'];
+        } elseif (!empty($data['nameservers']) && is_array($data['nameservers'])) {
+            $nameservers = $data['nameservers'];
+        } elseif (!empty($data['name_server']) && is_string($data['name_server'])) {
+            $nameservers = preg_split('/\s+/', trim($data['name_server']));
+        }
+
+        $nameservers = array_values(array_unique(array_filter(array_map('trim', $nameservers))));
+
+        $registrar = $data['registrar']['name']
+            ?? $data['registrar']
+            ?? null;
+
+        $registrantName = $data['registrant']['name']
+            ?? $data['registrant_name']
+            ?? null;
+
+        $registrantOrg = $data['registrant']['organization']
+            ?? $data['registrant']['organisation']
+            ?? $data['registrant_organization']
+            ?? $data['registrantOrganisation']
+            ?? null;
+
+        $registrantEmail = $data['registrant']['email']
+            ?? $data['registrant_email']
+            ?? null;
+
+        $syncedLabel = null;
+        if ($syncedAt) {
+            $syncedLabel = $syncedAt instanceof Carbon
+                ? $syncedAt->toDayDateTimeString()
+                : (string) $syncedAt;
+        }
+
+        return [
+            'has_data' => !empty($data),
+            'domain' => $data['domain_name'] ?? $domain,
+            'registrar' => $registrar,
+            'status' => $data['status'] ?? null,
+            'created_at' => self::formatDate($data['create_date'] ?? $data['created'] ?? null),
+            'updated_at' => self::formatDate($data['update_date'] ?? $data['updated'] ?? null),
+            'expires_at' => self::formatDate($data['expiry_date'] ?? $data['expires'] ?? null),
+            'registrant' => $registrantOrg && $registrantName
+                ? $registrantName . ' (' . $registrantOrg . ')'
+                : ($registrantName ?? $registrantOrg),
+            'registrant_email' => $registrantEmail,
+            'nameservers' => $nameservers,
+            'synced_at' => $syncedLabel,
+        ];
+    }
+
+    public static function formatText(?array $data, ?string $domain = null, $syncedAt = null): string
+    {
+        $overview = self::overview($data, $domain, $syncedAt);
+
+        if (!$overview['has_data']) {
+            return 'WHOIS data not available. Run an IP2WHOIS sync to pull the latest details.';
+        }
+
+        $lines = [];
+        $heading = '=== WHOIS Information';
+        if ($overview['domain']) {
+            $heading .= ' for ' . $overview['domain'];
+        }
+        $heading .= ' ===';
+
+        $lines[] = $heading;
+
+        if ($overview['registrar']) {
+            $lines[] = 'Registrar: ' . $overview['registrar'];
+        }
+
+        if ($overview['status']) {
+            $lines[] = 'Status: ' . $overview['status'];
+        }
+
+        if ($overview['created_at']) {
+            $lines[] = 'Created: ' . $overview['created_at'];
+        }
+
+        if ($overview['updated_at']) {
+            $lines[] = 'Last Updated: ' . $overview['updated_at'];
+        }
+
+        if ($overview['expires_at']) {
+            $lines[] = 'Expiry: ' . $overview['expires_at'];
+        }
+
+        if ($overview['registrant']) {
+            $lines[] = 'Registrant: ' . $overview['registrant'];
+        }
+
+        if ($overview['registrant_email']) {
+            $lines[] = 'Registrant Email: ' . $overview['registrant_email'];
+        }
+
+        if (!empty($overview['nameservers'])) {
+            $lines[] = 'Nameservers:';
+            foreach ($overview['nameservers'] as $ns) {
+                $lines[] = '  - ' . $ns;
+            }
+        }
+
+        if ($overview['synced_at']) {
+            $lines[] = 'WHOIS last synced: ' . $overview['synced_at'];
+        }
+
+        return implode("\n", array_filter($lines));
+    }
+
+    protected static function formatDate($value): ?string
+    {
+        if (!$value) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->toDateTimeString();
+        } catch (\Throwable $e) {
+            return is_string($value) ? $value : null;
+        }
+    }
+}

--- a/resources/views/admin/domains/show.blade.php
+++ b/resources/views/admin/domains/show.blade.php
@@ -55,15 +55,24 @@
         {{-- Right: Nameservers + transactions placeholder --}}
         <div style="display:flex;flex-direction:column;gap:16px;">
             <div style="background:#020617;border:1px solid #1f2937;border-radius:8px;padding:14px 16px;">
-                <div style="font-weight:600;margin-bottom:8px;">Nameserver information</div>
-                <div style="font-size:14px;opacity:.8;margin-bottom:4px;">Nameservers</div>
-                <div style="font-size:14px;">
-                    {{-- placeholder – later you can pull this from Synergy or your DNS store --}}
-                    <div>ns1.nameserver.net.au</div>
-                    <div>ns2.nameserver.net.au</div>
-                    <div>ns3.nameserver.net.au</div>
-                </div>
+            <div style="font-weight:600;margin-bottom:8px;">Nameserver information</div>
+            <div style="font-size:14px;opacity:.8;margin-bottom:4px;">Nameservers</div>
+            <div style="font-size:14px;">
+                    @php
+                        $nameserverList = collect($nameservers ?? [])
+                            ->filter(fn($ns) => !empty($ns))
+                            ->values();
+                    @endphp
+
+                    @if($nameserverList->isEmpty())
+                        <div style="opacity:.7;">No nameservers available. Sync WHOIS to populate.</div>
+                    @else
+                        @foreach($nameserverList as $ns)
+                            <div>{{ $ns }}</div>
+                        @endforeach
+                    @endif
             </div>
+        </div>
 
             <div style="background:#020617;border:1px solid #1f2937;border-radius:8px;padding:14px 16px;">
                 <div style="font-weight:600;margin-bottom:8px;">Transactions</div>
@@ -72,6 +81,56 @@
                 </div>
             </div>
         </div>
+    </div>
+
+    {{-- WHOIS details --}}
+    <div style="background:#020617;border:1px solid #1f2937;border-radius:8px;padding:14px 16px;margin-bottom:16px;">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px;">
+            <div style="font-weight:600;">WHOIS information</div>
+            <div style="font-size:12px;color:#94a3b8;">
+                {{ $whoisOverview['synced_at'] ? 'Last synced: '.$whoisOverview['synced_at'] : 'No WHOIS sync recorded yet' }}
+            </div>
+        </div>
+
+        @if($whoisOverview['has_data'])
+            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;font-size:14px;">
+                <div>
+                    <div style="opacity:.75;">Registrar</div>
+                    <div>{{ $whoisOverview['registrar'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Registrant</div>
+                    <div>{{ $whoisOverview['registrant'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Registrant email</div>
+                    <div>{{ $whoisOverview['registrant_email'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Created</div>
+                    <div>{{ $whoisOverview['created_at'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Last updated</div>
+                    <div>{{ $whoisOverview['updated_at'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Expires</div>
+                    <div>{{ $whoisOverview['expires_at'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Status</div>
+                    <div>{{ $whoisOverview['status'] ?? '—' }}</div>
+                </div>
+            </div>
+
+            <div style="margin-top:12px;">
+                <div style="opacity:.75;font-size:13px;margin-bottom:4px;">WHOIS text</div>
+                <div style="background:#0f172a;border:1px solid #1f2937;border-radius:8px;padding:10px 12px;font-size:13px;white-space:pre-wrap;overflow:auto;">{!! nl2br(e($whoisText)) !!}</div>
+            </div>
+        @else
+            <div style="font-size:14px;color:#94a3b8;">No WHOIS data available yet. Run an IP2WHOIS sync to populate these details.</div>
+        @endif
     </div>
 
     {{-- Client assignment box --}}

--- a/resources/views/admin/domains/show.blade.php
+++ b/resources/views/admin/domains/show.blade.php
@@ -99,12 +99,34 @@
                     <div>{{ $whoisOverview['registrar'] ?? '—' }}</div>
                 </div>
                 <div>
+                    <div style="opacity:.75;">Domain ID</div>
+                    <div>{{ $whoisOverview['domain_id'] ?? '—' }}</div>
+                </div>
+                <div>
                     <div style="opacity:.75;">Registrant</div>
                     <div>{{ $whoisOverview['registrant'] ?? '—' }}</div>
                 </div>
                 <div>
                     <div style="opacity:.75;">Registrant email</div>
                     <div>{{ $whoisOverview['registrant_email'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Registrant phone</div>
+                    <div>{{ $whoisOverview['registrant_phone'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Registrant location</div>
+                    <div>
+                        @php
+                            $locationParts = array_filter([
+                                $whoisOverview['registrant_city'] ?? null,
+                                $whoisOverview['registrant_state'] ?? null,
+                                $whoisOverview['registrant_postal'] ?? null,
+                                $whoisOverview['registrant_country'] ?? null,
+                            ]);
+                        @endphp
+                        {{ $locationParts ? implode(', ', $locationParts) : '—' }}
+                    </div>
                 </div>
                 <div>
                     <div style="opacity:.75;">Created</div>
@@ -121,6 +143,14 @@
                 <div>
                     <div style="opacity:.75;">Status</div>
                     <div>{{ $whoisOverview['status'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Registrar URL</div>
+                    <div style="word-break:break-all;">{{ $whoisOverview['registrar_url'] ?? '—' }}</div>
+                </div>
+                <div>
+                    <div style="opacity:.75;">Registrar WHOIS</div>
+                    <div style="word-break:break-all;">{{ $whoisOverview['registrar_whois'] ?? '—' }}</div>
                 </div>
             </div>
 

--- a/resources/views/admin/domains/show.blade.php
+++ b/resources/views/admin/domains/show.blade.php
@@ -59,16 +59,36 @@
             <div style="font-size:14px;opacity:.8;margin-bottom:4px;">Nameservers</div>
             <div style="font-size:14px;">
                     @php
-                        $nameserverList = collect($nameservers ?? [])
-                            ->filter(fn($ns) => !empty($ns))
+                        $nameserverList = collect($nameserverDetails ?? [])
+                            ->map(function($ns) {
+                                $host = $ns['host'] ?? '';
+                                $ips = collect($ns['ips'] ?? [])->filter()->values();
+                                return [
+                                    'host' => $host,
+                                    'ips' => $ips,
+                                ];
+                            })
+                            ->filter(fn($ns) => !empty($ns['host']))
                             ->values();
+
+                        if ($nameserverList->isEmpty()) {
+                            $nameserverList = collect($nameservers ?? [])->filter()->map(fn($ns) => [
+                                'host' => $ns,
+                                'ips' => collect(),
+                            ]);
+                        }
                     @endphp
 
                     @if($nameserverList->isEmpty())
                         <div style="opacity:.7;">No nameservers available. Sync WHOIS to populate.</div>
                     @else
                         @foreach($nameserverList as $ns)
-                            <div>{{ $ns }}</div>
+                            <div>
+                                <div>{{ $ns['host'] }}</div>
+                                @if($ns['ips']->isNotEmpty())
+                                    <div style="font-size:12px;opacity:.7;">{{ $ns['ips']->implode(', ') }}</div>
+                                @endif
+                            </div>
                         @endforeach
                     @endif
             </div>


### PR DESCRIPTION
## Summary
- add a shared WHOIS formatter to present synced IP2WHOIS details in the domain overview UI
- include formatted WHOIS text in ITGlue domain flexible asset syncs
- propagate WHOIS notes and nameservers into Halo domain sync flows and asset note updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694316e1f48c8331a04a7d4c24c2ec97)