### PR TITLE
Add Domain Pricing admin page with CSV import and TLD-driven purchase dropdown

### DIFF
--- a/app/Http/Controllers/Admin/DomainPricingController.php
+++ b/app/Http/Controllers/Admin/DomainPricingController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\DomainPricing;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class DomainPricingController extends Controller
+{
+    public function index()
+    {
+        $pricings = DomainPricing::query()->orderBy('tld')->get();
+
+        return view('admin.domains.pricing', compact('pricings'));
+    }
+
+    public function import(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'pricing_csv' => 'required|file|mimes:csv,txt',
+        ]);
+
+        $handle = fopen($request->file('pricing_csv')->getRealPath(), 'r');
+
+        if ($handle === false) {
+            return back()->withErrors(['pricing_csv' => 'Unable to read the CSV file.']);
+        }
+
+        $header = fgetcsv($handle);
+        if ($header === false) {
+            fclose($handle);
+            return back()->withErrors(['pricing_csv' => 'The CSV file is empty.']);
+        }
+
+        $normalizedHeader = array_map(fn ($column) => trim((string) $column), $header);
+
+        $imported = 0;
+
+        while (($row = fgetcsv($handle)) !== false) {
+            if (count(array_filter($row, fn ($value) => trim((string) $value) !== '')) === 0) {
+                continue;
+            }
+
+            $data = array_combine($normalizedHeader, array_pad($row, count($normalizedHeader), null));
+            if ($data === false) {
+                continue;
+            }
+
+            $tld = strtolower(trim((string) ($data['TLD'] ?? '')));
+            if ($tld === '') {
+                continue;
+            }
+
+            DomainPricing::query()->updateOrCreate(
+                ['tld' => ltrim($tld, '.')],
+                [
+                    'registration_price' => $this->parseMoney($data['Registration price'] ?? null),
+                    'renewal_price' => $this->parseMoney($data['Renewal price'] ?? null),
+                    'restore_price' => $this->parseMoney($data['Restore price'] ?? null),
+                    'transfer_price' => $this->parseMoney($data['Transfer price'] ?? null),
+                    'minimum_years' => $this->parseInt($data['Minimum years'] ?? null),
+                    'maximum_years' => $this->parseInt($data['Maximum years'] ?? null),
+                    'id_protection' => $this->parseBool($data['ID protection'] ?? null),
+                    'dnssec' => $this->parseBool($data['DNSSEC'] ?? null),
+                    'sale_registration_1_year_price' => $this->parseMoney($data['Sale registration 1 year price'] ?? null),
+                    'sale_registration_2_year_price' => $this->parseMoney($data['Sale registration 2 year price'] ?? null),
+                    'sale_registration_3_year_price' => $this->parseMoney($data['Sale registration 3 year price'] ?? null),
+                    'sale_registration_4_year_price' => $this->parseMoney($data['Sale registration 4 year price'] ?? null),
+                    'sale_registration_5_year_price' => $this->parseMoney($data['Sale registration 5 year price'] ?? null),
+                    'sale_registration_6_year_price' => $this->parseMoney($data['Sale registration 6 year price'] ?? null),
+                    'sale_registration_7_year_price' => $this->parseMoney($data['Sale registration 7 year price'] ?? null),
+                    'sale_registration_8_year_price' => $this->parseMoney($data['Sale registration 8 year price'] ?? null),
+                    'sale_registration_9_year_price' => $this->parseMoney($data['Sale registration 9 year price'] ?? null),
+                    'sale_registration_10_year_price' => $this->parseMoney($data['Sale registration 10 year price'] ?? null),
+                    'sale_renew_price' => $this->parseMoney($data['Sale renew price'] ?? null),
+                    'sale_transfer_price' => $this->parseMoney($data['Sale transfer price'] ?? null),
+                    'sale_end_date' => $this->parseDate($data['Sale end date'] ?? null),
+                ]
+            );
+
+            $imported++;
+        }
+
+        fclose($handle);
+
+        return back()->with('status', "Imported {$imported} pricing row(s).");
+    }
+
+    public function updateSellPrice(Request $request, DomainPricing $domainPricing): RedirectResponse
+    {
+        $validated = $request->validate([
+            'sell_price' => 'required|numeric|min:0',
+        ]);
+
+        $domainPricing->update([
+            'sell_price' => round((float) $validated['sell_price'], 2),
+        ]);
+
+        return back()->with('status', "Updated sell price for .{$domainPricing->tld}.");
+    }
+
+    public function bulkMarkup(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'markup_percent' => 'required|numeric|min:0',
+        ]);
+
+        $multiplier = 1 + (((float) $validated['markup_percent']) / 100);
+
+        DomainPricing::query()->get()->each(function (DomainPricing $pricing) use ($multiplier): void {
+            $base = $pricing->effective_registration_price;
+            if ($base === null) {
+                return;
+            }
+
+            $pricing->update([
+                'sell_price' => round($base * $multiplier, 2),
+            ]);
+        });
+
+        return back()->with('status', 'Bulk sell pricing updated from current buy prices.');
+    }
+
+    private function parseMoney(mixed $value): ?float
+    {
+        $value = trim((string) $value);
+
+        if ($value === '' || strtoupper($value) === 'N/A') {
+            return null;
+        }
+
+        return round((float) str_replace(['$', ','], '', $value), 2);
+    }
+
+    private function parseInt(mixed $value): ?int
+    {
+        $value = trim((string) $value);
+
+        return $value === '' || strtoupper($value) === 'N/A' ? null : (int) $value;
+    }
+
+    private function parseBool(mixed $value): bool
+    {
+        return strtolower(trim((string) $value)) === 'yes';
+    }
+
+    private function parseDate(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        if ($value === '' || strtoupper($value) === 'N/A') {
+            return null;
+        }
+
+        $timestamp = strtotime($value);
+
+        return $timestamp === false ? null : date('Y-m-d', $timestamp);
+    }
+}

--- a/app/Http/Controllers/Admin/DomainPurchaseController.php
+++ b/app/Http/Controllers/Admin/DomainPurchaseController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Services\Synergy\SynergyWholesaleClient;
 use App\Models\Client;
 use App\Models\Domain;
+use App\Models\DomainPricing;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -26,7 +27,9 @@ class DomainPurchaseController extends Controller
      */
     public function index()
     {
-        return view('admin.domains.purchase');
+        $extensions = DomainPricing::query()->orderBy('tld')->pluck('tld');
+
+        return view('admin.domains.purchase', compact('extensions'));
     }
 
     /**

--- a/app/Http/Controllers/Admin/PermissionsController.php
+++ b/app/Http/Controllers/Admin/PermissionsController.php
@@ -12,8 +12,15 @@ class PermissionsController extends Controller
 {
     public function index()
     {
+        // Ensure recently added permission keys are present in existing environments
+        // where seeders may not have been re-run.
+        foreach (['domain-pricing.view', 'domain-pricing.manage'] as $permissionName) {
+            Permission::findOrCreate($permissionName);
+        }
+
         $roles = Role::orderBy('name')->get();
         $permissions = Permission::orderBy('name')->get();
+
         return view('admin.permissions.index', compact('roles','permissions'));
     }
 

--- a/app/Models/DomainPricing.php
+++ b/app/Models/DomainPricing.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DomainPricing extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tld',
+        'registration_price',
+        'renewal_price',
+        'restore_price',
+        'transfer_price',
+        'minimum_years',
+        'maximum_years',
+        'id_protection',
+        'dnssec',
+        'sale_registration_1_year_price',
+        'sale_registration_2_year_price',
+        'sale_registration_3_year_price',
+        'sale_registration_4_year_price',
+        'sale_registration_5_year_price',
+        'sale_registration_6_year_price',
+        'sale_registration_7_year_price',
+        'sale_registration_8_year_price',
+        'sale_registration_9_year_price',
+        'sale_registration_10_year_price',
+        'sale_renew_price',
+        'sale_transfer_price',
+        'sale_end_date',
+        'sell_price',
+    ];
+
+    protected $casts = [
+        'id_protection' => 'boolean',
+        'dnssec' => 'boolean',
+        'sale_end_date' => 'date',
+    ];
+
+    public function getEffectiveRegistrationPriceAttribute(): ?float
+    {
+        if ($this->sale_registration_1_year_price !== null && $this->sale_end_date !== null && ! $this->sale_end_date->isPast()) {
+            return (float) $this->sale_registration_1_year_price;
+        }
+
+        return $this->registration_price !== null ? (float) $this->registration_price : null;
+    }
+}

--- a/database/migrations/2026_04_08_000000_create_domain_pricings_table.php
+++ b/database/migrations/2026_04_08_000000_create_domain_pricings_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('domain_pricings', function (Blueprint $table) {
+            $table->id();
+            $table->string('tld')->unique();
+            $table->decimal('registration_price', 10, 2)->nullable();
+            $table->decimal('renewal_price', 10, 2)->nullable();
+            $table->decimal('restore_price', 10, 2)->nullable();
+            $table->decimal('transfer_price', 10, 2)->nullable();
+            $table->unsignedTinyInteger('minimum_years')->nullable();
+            $table->unsignedTinyInteger('maximum_years')->nullable();
+            $table->boolean('id_protection')->default(false);
+            $table->boolean('dnssec')->default(false);
+            $table->decimal('sale_registration_1_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_2_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_3_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_4_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_5_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_6_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_7_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_8_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_9_year_price', 10, 2)->nullable();
+            $table->decimal('sale_registration_10_year_price', 10, 2)->nullable();
+            $table->decimal('sale_renew_price', 10, 2)->nullable();
+            $table->decimal('sale_transfer_price', 10, 2)->nullable();
+            $table->date('sale_end_date')->nullable();
+            $table->decimal('sell_price', 10, 2)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('domain_pricings');
+    }
+};

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -18,7 +18,7 @@ class RolePermissionSeeder extends Seeder
             'domains.view','domains.manage','dns.manage','domains.transfer','domains.register','domains.renew',
             'services.view','services.manage','ssl.view','ssl.manage',
             'clients.view','clients.manage','users.view','users.manage','users.impersonate',
-            'settings.manage','apikeys.manage','analytics.view','tickets.create','sync.run'
+            'settings.manage','apikeys.manage','analytics.view','tickets.create','sync.run','domain-pricing.view','domain-pricing.manage'
         ];
 
         foreach ($perms as $p) { Permission::findOrCreate($p); }
@@ -32,7 +32,7 @@ class RolePermissionSeeder extends Seeder
 
         // Technician defaults
         $tech->syncPermissions([
-            'domains.view','dns.manage','domains.transfer','domains.register','services.view','ssl.view','tickets.create'
+            'domains.view','dns.manage','domains.transfer','domains.register','services.view','ssl.view','tickets.create','domain-pricing.view'
         ]);
 
         // Customer defaults (read-only on assigned resources + DNS manage as allowed via checkbox UI)

--- a/resources/views/admin/domains/pricing.blade.php
+++ b/resources/views/admin/domains/pricing.blade.php
@@ -45,7 +45,7 @@
             </div>
             <div class="dd-pricing-filters">
                 <label class="dd-pricing-filter"><input type="checkbox" id="filter-on-sale"> On sale</label>
-                <label class="dd-pricing-filter"><input type="checkbox" id="filter-sale-ended"> End of sale</label>
+                <label class="dd-pricing-filter"><input type="checkbox" id="filter-sale-ended"> Show EoL Domains</label>
             </div>
         </div>
 
@@ -177,13 +177,10 @@
             const onSale = row.dataset.onSale === '1';
             const saleEnded = row.dataset.saleEnded === '1';
 
-            let saleFilterPass = true;
-            if (filterOnSale || filterSaleEnded) {
-                saleFilterPass = (filterOnSale && onSale) || (filterSaleEnded && saleEnded);
-            }
-
+            const saleWindowPass = filterSaleEnded ? true : !saleEnded;
+            const saleTypePass = filterOnSale ? onSale : true;
             const searchPass = search === '' || tld.includes(search);
-            const show = saleFilterPass && searchPass;
+            const show = saleWindowPass && saleTypePass && searchPass;
 
             row.style.display = show ? '' : 'none';
             if (show) {
@@ -235,7 +232,7 @@
     display: flex;
     gap: 1rem;
     align-items: flex-end;
-    justify-content: space-between;
+    justify-content: flex-start;
     flex-wrap: wrap;
     margin-bottom: 1rem;
 }
@@ -266,6 +263,25 @@
     align-items: center;
     gap: 0.35rem;
     font-size: 0.9rem;
+}
+
+.dd-domain-pricing-page .dd-pricing-filter input[type="checkbox"] {
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1px solid var(--dd-border);
+    border-radius: 6px;
+    background: var(--dd-surface, #ffffff);
+    position: relative;
+    cursor: pointer;
+}
+
+.dd-domain-pricing-page .dd-pricing-filter input[type="checkbox"]:checked::after {
+    content: '';
+    position: absolute;
+    inset: 3px;
+    border-radius: 3px;
+    background: var(--dd-accent);
 }
 
 .dd-domain-pricing-page .dd-sort-btn {

--- a/resources/views/admin/domains/pricing.blade.php
+++ b/resources/views/admin/domains/pricing.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="dd-page">
+<div class="dd-page dd-domain-pricing-page">
     <h1 class="dd-page-title">Domain Pricing</h1>
 
     @if(session('status'))
@@ -38,33 +38,60 @@
     </div>
 
     <div class="dd-card">
+        <div class="dd-pricing-toolbar">
+            <div class="dd-pricing-search-wrap">
+                <label for="pricing-search" class="dd-pricing-label">Search TLD</label>
+                <input id="pricing-search" type="text" class="dd-pricing-search" placeholder="Type to filter (e.g. com.au)">
+            </div>
+            <div class="dd-pricing-filters">
+                <label class="dd-pricing-filter"><input type="checkbox" id="filter-on-sale"> On sale</label>
+                <label class="dd-pricing-filter"><input type="checkbox" id="filter-sale-ended"> End of sale</label>
+            </div>
+        </div>
+
         <h2 style="margin-bottom: 1rem;">Current TLD Pricing</h2>
         <div style="overflow:auto;">
-            <table class="dd-table" style="width:100%; min-width:980px;">
+            <table class="dd-table" id="pricing-table" style="width:100%; min-width:980px;">
                 <thead>
                 <tr>
-                    <th>TLD</th>
-                    <th>Buy Price (1y)</th>
-                    <th>Sale 1y</th>
-                    <th>Sale End Date</th>
-                    <th>Effective Buy</th>
-                    <th>Sell Price</th>
-                                    </tr>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="tld">TLD <span class="dd-sort-indicator"></span></button></th>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="buy">Buy Price (1y) <span class="dd-sort-indicator"></span></button></th>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="sale">Sale 1y <span class="dd-sort-indicator"></span></button></th>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="saleEnd">Sale End Date <span class="dd-sort-indicator"></span></button></th>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="effective">Effective Buy <span class="dd-sort-indicator"></span></button></th>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="sell">Sell Price <span class="dd-sort-indicator"></span></button></th>
+                </tr>
                 </thead>
-                <tbody>
+                <tbody id="pricing-table-body">
                 @forelse($pricings as $pricing)
                     @php
                         $saleActive = $pricing->sale_end_date && ! $pricing->sale_end_date->isPast();
+                        $saleEnded = $pricing->sale_end_date && $pricing->sale_end_date->isPast();
+                        $saleOneYear = $pricing->sale_registration_1_year_price;
+                        $buyPrice = $pricing->registration_price;
+                        $effectivePrice = $pricing->effective_registration_price;
+                        $saleEndDate = $pricing->sale_end_date?->format('Y-m-d');
                     @endphp
-                    <tr>
+                    <tr
+                        data-tld="{{ strtolower($pricing->tld) }}"
+                        data-buy="{{ $buyPrice !== null ? number_format((float) $buyPrice, 2, '.', '') : '' }}"
+                        data-sale="{{ $saleOneYear !== null ? number_format((float) $saleOneYear, 2, '.', '') : '' }}"
+                        data-sale-end="{{ $saleEndDate ?? '' }}"
+                        data-effective="{{ $effectivePrice !== null ? number_format((float) $effectivePrice, 2, '.', '') : '' }}"
+                        data-sell="{{ $pricing->sell_price !== null ? number_format((float) $pricing->sell_price, 2, '.', '') : '' }}"
+                        data-on-sale="{{ $saleActive ? '1' : '0' }}"
+                        data-sale-ended="{{ $saleEnded ? '1' : '0' }}"
+                    >
                         <td>.{{ $pricing->tld }}</td>
-                        <td>${{ number_format((float) ($pricing->registration_price ?? 0), 2) }}</td>
-                        <td>{{ $pricing->sale_registration_1_year_price !== null ? '$' . number_format((float) $pricing->sale_registration_1_year_price, 2) : 'N/A' }}</td>
-                        <td>{{ $pricing->sale_end_date?->format('Y-m-d') ?? 'N/A' }}</td>
+                        <td>{{ $buyPrice !== null ? '$' . number_format((float) $buyPrice, 2) : 'N/A' }}</td>
+                        <td>{{ $saleOneYear !== null ? '$' . number_format((float) $saleOneYear, 2) : 'N/A' }}</td>
+                        <td>{{ $saleEndDate ?? 'N/A' }}</td>
                         <td>
-                            ${{ number_format((float) ($pricing->effective_registration_price ?? 0), 2) }}
+                            {{ $effectivePrice !== null ? '$' . number_format((float) $effectivePrice, 2) : 'N/A' }}
                             @if($saleActive)
                                 <span style="font-size:12px; color:#059669;">(sale active)</span>
+                            @elseif($saleEnded)
+                                <span style="font-size:12px; color:#b45309;">(ended)</span>
                             @endif
                         </td>
                         <td>
@@ -77,13 +104,194 @@
                         </td>
                     </tr>
                 @empty
-                    <tr>
+                    <tr id="pricing-empty-row">
                         <td colspan="6" style="text-align:center; color:#6b7280;">No pricing loaded yet. Import a CSV to begin.</td>
                     </tr>
                 @endforelse
                 </tbody>
             </table>
         </div>
+        <p id="pricing-filter-empty" style="display:none; margin-top:0.8rem; color:#6b7280;">No rows match your current search/filter selection.</p>
     </div>
 </div>
+
+<script>
+(function () {
+    const searchInput = document.getElementById('pricing-search');
+    const onSaleCheckbox = document.getElementById('filter-on-sale');
+    const saleEndedCheckbox = document.getElementById('filter-sale-ended');
+    const tableBody = document.getElementById('pricing-table-body');
+    const sortButtons = Array.from(document.querySelectorAll('.dd-sort-btn'));
+    const filterEmpty = document.getElementById('pricing-filter-empty');
+    const staticEmptyRow = document.getElementById('pricing-empty-row');
+
+    let sortState = { key: 'tld', direction: 'asc' };
+
+    function parseSortValue(row, key) {
+        if (key === 'saleEnd') {
+            const value = row.dataset.saleEnd || '';
+            return value === '' ? Number.POSITIVE_INFINITY : Date.parse(value);
+        }
+
+        if (['buy', 'sale', 'effective', 'sell'].includes(key)) {
+            const value = row.dataset[key] || '';
+            return value === '' ? Number.POSITIVE_INFINITY : Number.parseFloat(value);
+        }
+
+        return (row.dataset[key] || '').toLowerCase();
+    }
+
+    function applySort() {
+        const rows = Array.from(tableBody.querySelectorAll('tr[data-tld]'));
+        rows.sort((a, b) => {
+            const aValue = parseSortValue(a, sortState.key);
+            const bValue = parseSortValue(b, sortState.key);
+
+            if (aValue < bValue) return sortState.direction === 'asc' ? -1 : 1;
+            if (aValue > bValue) return sortState.direction === 'asc' ? 1 : -1;
+            return 0;
+        });
+
+        rows.forEach((row) => tableBody.appendChild(row));
+    }
+
+    function updateSortIndicators() {
+        sortButtons.forEach((button) => {
+            const indicator = button.querySelector('.dd-sort-indicator');
+            const isActive = button.dataset.sortKey === sortState.key;
+            if (!indicator) return;
+            indicator.textContent = isActive ? (sortState.direction === 'asc' ? '↑' : '↓') : '';
+        });
+    }
+
+    function applyFilters() {
+        const rows = Array.from(tableBody.querySelectorAll('tr[data-tld]'));
+        const search = (searchInput?.value || '').trim().toLowerCase();
+        const filterOnSale = !!onSaleCheckbox?.checked;
+        const filterSaleEnded = !!saleEndedCheckbox?.checked;
+
+        let visibleCount = 0;
+
+        rows.forEach((row) => {
+            const tld = row.dataset.tld || '';
+            const onSale = row.dataset.onSale === '1';
+            const saleEnded = row.dataset.saleEnded === '1';
+
+            let saleFilterPass = true;
+            if (filterOnSale || filterSaleEnded) {
+                saleFilterPass = (filterOnSale && onSale) || (filterSaleEnded && saleEnded);
+            }
+
+            const searchPass = search === '' || tld.includes(search);
+            const show = saleFilterPass && searchPass;
+
+            row.style.display = show ? '' : 'none';
+            if (show) {
+                visibleCount++;
+            }
+        });
+
+        if (filterEmpty) {
+            filterEmpty.style.display = visibleCount === 0 && rows.length > 0 ? 'block' : 'none';
+        }
+
+        if (staticEmptyRow) {
+            staticEmptyRow.style.display = rows.length === 0 ? '' : 'none';
+        }
+    }
+
+    sortButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const nextKey = button.dataset.sortKey;
+            if (!nextKey) {
+                return;
+            }
+
+            if (sortState.key === nextKey) {
+                sortState.direction = sortState.direction === 'asc' ? 'desc' : 'asc';
+            } else {
+                sortState.key = nextKey;
+                sortState.direction = 'asc';
+            }
+
+            applySort();
+            updateSortIndicators();
+            applyFilters();
+        });
+    });
+
+    searchInput?.addEventListener('input', applyFilters);
+    onSaleCheckbox?.addEventListener('change', applyFilters);
+    saleEndedCheckbox?.addEventListener('change', applyFilters);
+
+    applySort();
+    updateSortIndicators();
+    applyFilters();
+})();
+</script>
+
+<style>
+.dd-domain-pricing-page .dd-pricing-toolbar {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.dd-domain-pricing-page .dd-pricing-label {
+    display: block;
+    font-size: 0.85rem;
+    color: #6b7280;
+    margin-bottom: 0.35rem;
+}
+
+.dd-domain-pricing-page .dd-pricing-search {
+    min-width: 260px;
+    border: 1px solid var(--dd-border);
+    border-radius: 10px;
+    padding: 0.65rem 0.75rem;
+}
+
+.dd-domain-pricing-page .dd-pricing-filters {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.dd-domain-pricing-page .dd-pricing-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.9rem;
+}
+
+.dd-domain-pricing-page .dd-sort-btn {
+    border: 0;
+    background: transparent;
+    font: inherit;
+    font-weight: 700;
+    color: inherit;
+    padding: 0;
+    cursor: pointer;
+}
+
+.dd-domain-pricing-page .dd-sort-indicator {
+    display: inline-block;
+    min-width: 0.75rem;
+}
+
+@media (max-width: 768px) {
+    .dd-domain-pricing-page .dd-pricing-search {
+        min-width: 100%;
+        width: 100%;
+    }
+
+    .dd-domain-pricing-page .dd-pricing-search-wrap {
+        width: 100%;
+    }
+}
+</style>
 @endsection

--- a/resources/views/admin/domains/pricing.blade.php
+++ b/resources/views/admin/domains/pricing.blade.php
@@ -20,21 +20,29 @@
 
     <div class="dd-card" style="margin-bottom: 1rem;">
         <h2 style="margin-bottom: 0.8rem;">Import CSV</h2>
+        @can('domain-pricing.manage')
         <form method="POST" action="{{ route('admin.domains.pricing.import') }}" enctype="multipart/form-data" style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
             @csrf
             <input type="file" name="pricing_csv" accept=".csv,text/csv" required>
             <button type="submit" class="btn-accent">Import Pricing</button>
         </form>
+        @else
+        <p style="margin:0; color:#6b7280;">You have view access only. Import is disabled.</p>
+        @endcan
         <p style="margin-top:0.75rem; color:#6b7280;">Imports from Synergy CSV and upserts by TLD. Sale prices are used until sale end date.</p>
     </div>
 
     <div class="dd-card" style="margin-bottom: 1rem;">
         <h2 style="margin-bottom: 0.8rem;">Bulk Sell Price Markup</h2>
+        @can('domain-pricing.manage')
         <form method="POST" action="{{ route('admin.domains.pricing.bulk-markup') }}" style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
             @csrf
             <input type="number" step="0.01" min="0" name="markup_percent" placeholder="Markup %" required style="max-width:170px;">
             <button type="submit" class="btn-accent">Apply Markup</button>
         </form>
+        @else
+        <p style="margin:0; color:#6b7280;">You have view access only. Bulk markup is disabled.</p>
+        @endcan
     </div>
 
     <div class="dd-card">
@@ -95,12 +103,16 @@
                             @endif
                         </td>
                         <td>
+                            @can('domain-pricing.manage')
                             <form method="POST" action="{{ route('admin.domains.pricing.sell-price', $pricing) }}" style="display:flex; align-items:center; gap:0.5rem;">
                                 @csrf
                                 @method('PUT')
                                 <input type="number" name="sell_price" step="0.01" min="0" value="{{ $pricing->sell_price }}" style="max-width:130px;" required>
                                 <button type="submit" class="dd-account-password-btn">Save</button>
                             </form>
+                            @else
+                            <span>{{ $pricing->sell_price !== null ? '$' . number_format((float) $pricing->sell_price, 2) : 'N/A' }}</span>
+                            @endcan
                         </td>
                     </tr>
                 @empty
@@ -274,14 +286,24 @@
     background: var(--dd-surface, #ffffff);
     position: relative;
     cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.dd-domain-pricing-page .dd-pricing-filter input[type="checkbox"]:checked {
+    background: #16a34a;
+    border-color: #16a34a;
 }
 
 .dd-domain-pricing-page .dd-pricing-filter input[type="checkbox"]:checked::after {
     content: '';
     position: absolute;
-    inset: 3px;
-    border-radius: 3px;
-    background: var(--dd-accent);
+    left: 4px;
+    top: 1px;
+    width: 4px;
+    height: 8px;
+    border: solid #ffffff;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
 }
 
 .dd-domain-pricing-page .dd-sort-btn {

--- a/resources/views/admin/domains/pricing.blade.php
+++ b/resources/views/admin/domains/pricing.blade.php
@@ -1,0 +1,89 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="dd-page">
+    <h1 class="dd-page-title">Domain Pricing</h1>
+
+    @if(session('status'))
+        <div class="dd-alert dd-alert-success" style="margin-bottom: 1rem;">{{ session('status') }}</div>
+    @endif
+
+    @if($errors->any())
+        <div class="dd-alert dd-alert-error" style="margin-bottom: 1rem;">
+            <ul style="margin:0; padding-left:1.2rem;">
+                @foreach($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <div class="dd-card" style="margin-bottom: 1rem;">
+        <h2 style="margin-bottom: 0.8rem;">Import CSV</h2>
+        <form method="POST" action="{{ route('admin.domains.pricing.import') }}" enctype="multipart/form-data" style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
+            @csrf
+            <input type="file" name="pricing_csv" accept=".csv,text/csv" required>
+            <button type="submit" class="btn-accent">Import Pricing</button>
+        </form>
+        <p style="margin-top:0.75rem; color:#6b7280;">Imports from Synergy CSV and upserts by TLD. Sale prices are used until sale end date.</p>
+    </div>
+
+    <div class="dd-card" style="margin-bottom: 1rem;">
+        <h2 style="margin-bottom: 0.8rem;">Bulk Sell Price Markup</h2>
+        <form method="POST" action="{{ route('admin.domains.pricing.bulk-markup') }}" style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
+            @csrf
+            <input type="number" step="0.01" min="0" name="markup_percent" placeholder="Markup %" required style="max-width:170px;">
+            <button type="submit" class="btn-accent">Apply Markup</button>
+        </form>
+    </div>
+
+    <div class="dd-card">
+        <h2 style="margin-bottom: 1rem;">Current TLD Pricing</h2>
+        <div style="overflow:auto;">
+            <table class="dd-table" style="width:100%; min-width:980px;">
+                <thead>
+                <tr>
+                    <th>TLD</th>
+                    <th>Buy Price (1y)</th>
+                    <th>Sale 1y</th>
+                    <th>Sale End Date</th>
+                    <th>Effective Buy</th>
+                    <th>Sell Price</th>
+                                    </tr>
+                </thead>
+                <tbody>
+                @forelse($pricings as $pricing)
+                    @php
+                        $saleActive = $pricing->sale_end_date && ! $pricing->sale_end_date->isPast();
+                    @endphp
+                    <tr>
+                        <td>.{{ $pricing->tld }}</td>
+                        <td>${{ number_format((float) ($pricing->registration_price ?? 0), 2) }}</td>
+                        <td>{{ $pricing->sale_registration_1_year_price !== null ? '$' . number_format((float) $pricing->sale_registration_1_year_price, 2) : 'N/A' }}</td>
+                        <td>{{ $pricing->sale_end_date?->format('Y-m-d') ?? 'N/A' }}</td>
+                        <td>
+                            ${{ number_format((float) ($pricing->effective_registration_price ?? 0), 2) }}
+                            @if($saleActive)
+                                <span style="font-size:12px; color:#059669;">(sale active)</span>
+                            @endif
+                        </td>
+                        <td>
+                            <form method="POST" action="{{ route('admin.domains.pricing.sell-price', $pricing) }}" style="display:flex; align-items:center; gap:0.5rem;">
+                                @csrf
+                                @method('PUT')
+                                <input type="number" name="sell_price" step="0.01" min="0" value="{{ $pricing->sell_price }}" style="max-width:130px;" required>
+                                <button type="submit" class="dd-account-password-btn">Save</button>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6" style="text-align:center; color:#6b7280;">No pricing loaded yet. Import a CSV to begin.</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/domains/purchase.blade.php
+++ b/resources/views/admin/domains/purchase.blade.php
@@ -15,17 +15,11 @@
                 <div class="fancy-select-wrapper dd-search-extension-wrap" style="min-width: 200px;">
                     <select id="extension" class="fancy-select dd-search-extension">
                         <option value="">Select an Extension</option>
-                        <option value="com">com</option>
-                        <option value="net">net</option>
-                        <option value="org">org</option>
-                        <option value="com.au">com.au</option>
-                        <option value="net.au">net.au</option>
-                        <option value="org.au">org.au</option>
-                        <option value="au">au</option>
-                        <option value="io">io</option>
-                        <option value="co">co</option>
-                        <option value="biz">biz</option>
-                        <option value="info">info</option>
+                        @forelse(($extensions ?? collect()) as $extension)
+                            <option value="{{ $extension }}">{{ $extension }}</option>
+                        @empty
+                            <option value="com">com</option>
+                        @endforelse
                     </select>
                 </div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -688,13 +688,6 @@
                                 Purchase New Domain
                             </a>
                         </li>
-                        @role('Administrator')
-                        <li class="nav-item">
-                            <a href="{{ route('admin.domains.pricing') }}" class="nav-link {{ request()->routeIs('admin.domains.pricing*') ? 'active' : '' }}">
-                                Domain Pricing
-                            </a>
-                        </li>
-                        @endrole
                     </ul>
                 </li>
 
@@ -742,7 +735,7 @@
 
                 <!-- Admin Section (hidden for non-admin users) -->
                 @role('Administrator')
-                    <li class="nav-item nav-section {{ request()->routeIs('admin.clients*') || request()->routeIs('admin.users*') || request()->routeIs('admin.settings') || request()->routeIs('admin.apikeys') ? 'expanded' : '' }}">
+                    <li class="nav-item nav-section {{ request()->routeIs('admin.clients*') || request()->routeIs('admin.users*') || request()->routeIs('admin.settings') || request()->routeIs('admin.apikeys') || request()->routeIs('admin.domains.pricing*') ? 'expanded' : '' }}">
                         <div class="nav-link nav-toggle" onclick="toggleNav(this)">
                             <span class="icon">⚙️</span>
                             <span class="text">Admin</span>
@@ -774,6 +767,13 @@
                                     Settings
                                 </a>
                             </li>
+                            @can('domain-pricing.view')
+                            <li class="nav-item"> 
+                                <a href="{{ route('admin.domains.pricing') }}" class="nav-link {{ request()->routeIs('admin.domains.pricing*') ? 'active' : '' }}"> 
+                                    Domain Pricing
+                                </a>
+                            </li>
+                            @endcan
                         </ul>
                     </li>
                 @endrole

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -688,6 +688,13 @@
                                 Purchase New Domain
                             </a>
                         </li>
+                        @role('Administrator')
+                        <li class="nav-item">
+                            <a href="{{ route('admin.domains.pricing') }}" class="nav-link {{ request()->routeIs('admin.domains.pricing*') ? 'active' : '' }}">
+                                Domain Pricing
+                            </a>
+                        </li>
+                        @endrole
                     </ul>
                 </li>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\TicketController;
 use App\Http\Controllers\Admin\UsersController;
 use App\Http\Controllers\Admin\ServicesController;
 use App\Http\Controllers\Admin\ClientsController;
+use App\Http\Controllers\Admin\DomainPricingController;
 
 
 Route::get('/', fn() => redirect()->route('dashboard'))->middleware(['auth','verified']);
@@ -123,6 +124,10 @@ Route::middleware(['auth','verified'])->group(function () {
         Route::post('/domains/purchase/search', [\App\Http\Controllers\Admin\DomainPurchaseController::class,'search'])->name('admin.domains.purchase.search');
         Route::post('/domains/purchase/validate-au', [\App\Http\Controllers\Admin\DomainPurchaseController::class,'validateAu'])->name('admin.domains.purchase.validateAu');
         Route::post('/domains/purchase/complete', [\App\Http\Controllers\Admin\DomainPurchaseController::class,'complete'])->name('admin.domains.purchase.complete');
+        Route::get('/domains/pricing', [DomainPricingController::class, 'index'])->name('admin.domains.pricing');
+        Route::post('/domains/pricing/import', [DomainPricingController::class, 'import'])->name('admin.domains.pricing.import');
+        Route::post('/domains/pricing/bulk-markup', [DomainPricingController::class, 'bulkMarkup'])->name('admin.domains.pricing.bulk-markup');
+        Route::put('/domains/pricing/{domainPricing}/sell-price', [DomainPricingController::class, 'updateSellPrice'])->name('admin.domains.pricing.sell-price');
         Route::get('/domains/transfer/create', [\App\Http\Controllers\Admin\DomainTransferController::class,'create'])->name('admin.domains.transfer.create');
         Route::post('/domains/transfer/validate', [\App\Http\Controllers\Admin\DomainTransferController::class,'validateTransfer'])->name('admin.domains.transfer.validate');
         Route::post('/domains/transfer/complete', [\App\Http\Controllers\Admin\DomainTransferController::class,'complete'])->name('admin.domains.transfer.complete');

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,6 +62,19 @@ Route::middleware(['auth','verified'])->group(function () {
                 ->middleware('permission:domains.transfer')
                 ->whereNumber('domain')
                 ->name('admin.domains.auth-code');
+
+            Route::get('/domains/pricing', [DomainPricingController::class, 'index'])
+                ->middleware('permission:domain-pricing.view')
+                ->name('admin.domains.pricing');
+            Route::post('/domains/pricing/import', [DomainPricingController::class, 'import'])
+                ->middleware('permission:domain-pricing.manage')
+                ->name('admin.domains.pricing.import');
+            Route::post('/domains/pricing/bulk-markup', [DomainPricingController::class, 'bulkMarkup'])
+                ->middleware('permission:domain-pricing.manage')
+                ->name('admin.domains.pricing.bulk-markup');
+            Route::put('/domains/pricing/{domainPricing}/sell-price', [DomainPricingController::class, 'updateSellPrice'])
+                ->middleware('permission:domain-pricing.manage')
+                ->name('admin.domains.pricing.sell-price');
         });
 
         // Admin area
@@ -124,10 +137,6 @@ Route::middleware(['auth','verified'])->group(function () {
         Route::post('/domains/purchase/search', [\App\Http\Controllers\Admin\DomainPurchaseController::class,'search'])->name('admin.domains.purchase.search');
         Route::post('/domains/purchase/validate-au', [\App\Http\Controllers\Admin\DomainPurchaseController::class,'validateAu'])->name('admin.domains.purchase.validateAu');
         Route::post('/domains/purchase/complete', [\App\Http\Controllers\Admin\DomainPurchaseController::class,'complete'])->name('admin.domains.purchase.complete');
-        Route::get('/domains/pricing', [DomainPricingController::class, 'index'])->name('admin.domains.pricing');
-        Route::post('/domains/pricing/import', [DomainPricingController::class, 'import'])->name('admin.domains.pricing.import');
-        Route::post('/domains/pricing/bulk-markup', [DomainPricingController::class, 'bulkMarkup'])->name('admin.domains.pricing.bulk-markup');
-        Route::put('/domains/pricing/{domainPricing}/sell-price', [DomainPricingController::class, 'updateSellPrice'])->name('admin.domains.pricing.sell-price');
         Route::get('/domains/transfer/create', [\App\Http\Controllers\Admin\DomainTransferController::class,'create'])->name('admin.domains.transfer.create');
         Route::post('/domains/transfer/validate', [\App\Http\Controllers\Admin\DomainTransferController::class,'validateTransfer'])->name('admin.domains.transfer.validate');
         Route::post('/domains/transfer/complete', [\App\Http\Controllers\Admin\DomainTransferController::class,'complete'])->name('admin.domains.transfer.complete');


### PR DESCRIPTION
### Motivation

- Provide administrators a way to import Synergy-provided domain pricing CSVs into the app and persist those prices for lookups and sale handling.
- Allow admins to set the public `sell_price` per-TLD (individually or via bulk markup %) while honoring `sale_end_date` from supplier data for effective buy prices.
- Use the canonical TLD list from imported pricing data to populate the domain purchase extension dropdown so the purchase form always reflects available TLDs.

### Description

- Added a new `domain_pricings` migration to persist supplier fields, sale prices, `sale_end_date`, and an internal `sell_price` column (`database/migrations/2026_04_08_000000_create_domain_pricings_table.php`).
- Introduced `DomainPricing` model with casts and an accessor `effective_registration_price` that prefers the 1-year sale price when `sale_end_date` is today or in the future (`app/Models/DomainPricing.php`).
- Implemented `DomainPricingController` with endpoints to view pricing, import CSVs (upsert by `tld` with parsing helpers), update a single `sell_price`, and apply a bulk markup percent (`app/Http/Controllers/Admin/DomainPricingController.php`).
- Added admin routes for pricing management (`/admin/domains/pricing`, CSV import, bulk-markup and sell-price update) in `routes/web.php`.
- Created admin UI `resources/views/admin/domains/pricing.blade.php` with CSV upload, bulk-markup form, and editable per-TLD sell price table (shows buy, sale, effective buy and sale end date).
- Wired the domain purchase page to load extensions from `domain_pricings.tld` and pass them to the purchase view instead of the prior hard-coded list (`app/Http/Controllers/Admin/DomainPurchaseController.php` and `resources/views/admin/domains/purchase.blade.php`).
- Added a sidebar link (Administrator-only) to the new Domain Pricing page (`resources/views/layouts/app.blade.php`).
- CSV import normalizes headers and parses money/date/boolean values robustly and uses `updateOrCreate` to update existing TLD rows or insert new ones.

### Testing

- Ran PHP lint checks on modified files with `php -l` which reported no syntax errors for `app/Http/Controllers/Admin/DomainPricingController.php`, `app/Http/Controllers/Admin/DomainPurchaseController.php`, `app/Models/DomainPricing.php`, and `routes/web.php` (all passed).
- Attempted to run the test suite with `php artisan test --filter=Domain --stop-on-failure`, but it could not run in this environment because the application dependencies are not installed (`vendor/autoload.php` missing), so automated Laravel tests were not executed here.
- Performed local validations of created files (route additions, blade template changes) and ensured controller logic compiles under `php -l` (success).

If you want, I can next add a feature test for CSV import and the bulk-markup behavior and run it once `composer install`/test dependencies are available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d5e0daf3408330a15c3f57dbaab642)