### PR TITLE
Revamp admin system status dashboard

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -4,11 +4,12 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Domain;
+use App\Services\Synergy\SynergyWholesaleClient;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
 {
-    public function index()
+    public function index(SynergyWholesaleClient $synergy)
     {
         [$diskTotal, $diskFree, $diskUsed] = $this->diskMetrics();
         [$memTotalKB, $memUsedKB] = $this->memoryMetrics();
@@ -19,6 +20,9 @@ class DashboardController extends Controller
             'clients' => DB::table('clients')->count(),
             'users' => DB::table('users')->count(),
         ];
+
+        $balanceResponse = $synergy->balanceQuery();
+        [$availableBalance, $balanceCurrency, $balanceStatus] = $this->balanceMetrics($balanceResponse);
 
         $domainsWithoutClient = Domain::query()
             ->whereNull('client_id')
@@ -52,10 +56,31 @@ class DashboardController extends Controller
             'memUsedKB',
             'cpuUsage',
             'counts',
+            'availableBalance',
+            'balanceCurrency',
+            'balanceStatus',
             'domainsWithoutClient',
             'domainsNotSyncedHalo',
             'domainsNotSyncedItglue'
         ));
+    }
+
+    private function balanceMetrics(array $balanceResponse): array
+    {
+        $balanceValue = $balanceResponse['balance']
+            ?? $balanceResponse['availableBalance']
+            ?? $balanceResponse['accountBalance']
+            ?? null;
+
+        $currency = strtoupper((string) ($balanceResponse['currency']
+            ?? $balanceResponse['currencyCode']
+            ?? 'AUD'));
+
+        $status = $balanceResponse['status']
+            ?? $balanceResponse['errorMessage']
+            ?? 'Unknown';
+
+        return [$balanceValue, $currency, (string) $status];
     }
 
     private function diskMetrics(): array

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -3,35 +3,94 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Services\Synergy\SynergyWholesaleClient;
+use App\Models\Domain;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
 {
-    public function index(SynergyWholesaleClient $synergy)
+    public function index()
     {
-        // system metrics
-        $diskTotal = @disk_total_space('/') ?: 0;
-        $diskFree = @disk_free_space('/') ?: 0;
-        $diskUsed = $diskTotal - $diskFree;
-        $meminfo = @file_get_contents('/proc/meminfo') ?: '';
-        preg_match('/MemTotal:\s+(\d+)/',$meminfo,$m1); preg_match('/MemAvailable:\s+(\d+)/',$meminfo,$m2);
-        $memTotalKB = (int)($m1[1] ?? 0); $memAvailKB = (int)($m2[1] ?? 0);
-        $memUsedKB = max(0, $memTotalKB - $memAvailKB);
-
-        // database size (MySQL)
-        $dbName = DB::getDatabaseName();
-        $dbSize = DB::selectOne("SELECT ROUND(SUM(data_length+index_length)/1024/1024,2) size_mb FROM information_schema.tables WHERE table_schema = ?", [$dbName])->size_mb ?? 0;
+        [$diskTotal, $diskFree, $diskUsed] = $this->diskMetrics();
+        [$memTotalKB, $memUsedKB] = $this->memoryMetrics();
+        $cpuUsage = $this->cpuUsage();
 
         $counts = [
             'domains' => DB::table('domains')->count(),
             'clients' => DB::table('clients')->count(),
-            'users'   => DB::table('users')->count(),
+            'users' => DB::table('users')->count(),
         ];
 
-        $balance = null;
-        try { $balance = $synergy->balanceQuery(); } catch (\Throwable $e) { $balance = ['status'=>'error','errorMessage'=>$e->getMessage()]; }
+        $domainsWithoutClient = Domain::query()
+            ->whereNull('client_id')
+            ->orderBy('name')
+            ->limit(100)
+            ->get(['id', 'name', 'status', 'expiry_date']);
 
-        return view('admin.dashboard.index', compact('diskTotal','diskUsed','memTotalKB','memUsedKB','dbSize','counts','balance'));
+        $domainsNotSyncedHalo = Domain::query()
+            ->where(function ($query) {
+                $query->whereNull('halo_asset_id')
+                    ->orWhere('halo_asset_id', '');
+            })
+            ->orderBy('name')
+            ->limit(100)
+            ->get(['id', 'name', 'client_id', 'status']);
+
+        $domainsNotSyncedItglue = Domain::query()
+            ->where(function ($query) {
+                $query->whereNull('itglue_id')
+                    ->orWhere('itglue_id', '');
+            })
+            ->orderBy('name')
+            ->limit(100)
+            ->get(['id', 'name', 'client_id', 'status']);
+
+        return view('admin.dashboard.index', compact(
+            'diskTotal',
+            'diskFree',
+            'diskUsed',
+            'memTotalKB',
+            'memUsedKB',
+            'cpuUsage',
+            'counts',
+            'domainsWithoutClient',
+            'domainsNotSyncedHalo',
+            'domainsNotSyncedItglue'
+        ));
+    }
+
+    private function diskMetrics(): array
+    {
+        $diskTotal = disk_total_space('/') ?: 0;
+        $diskFree = disk_free_space('/') ?: 0;
+        $diskUsed = max(0, $diskTotal - $diskFree);
+
+        return [$diskTotal, $diskFree, $diskUsed];
+    }
+
+    private function memoryMetrics(): array
+    {
+        $meminfo = file_get_contents('/proc/meminfo') ?: '';
+        preg_match('/MemTotal:\s+(\d+)/', $meminfo, $memTotalMatch);
+        preg_match('/MemAvailable:\s+(\d+)/', $meminfo, $memAvailableMatch);
+
+        $memTotalKB = (int) ($memTotalMatch[1] ?? 0);
+        $memAvailKB = (int) ($memAvailableMatch[1] ?? 0);
+
+        return [$memTotalKB, max(0, $memTotalKB - $memAvailKB)];
+    }
+
+    private function cpuUsage(): float
+    {
+        $loads = sys_getloadavg();
+        $oneMinuteLoad = is_array($loads) ? (float) ($loads[0] ?? 0) : 0.0;
+
+        $cpuCores = (int) trim((string) shell_exec('nproc 2>/dev/null'));
+        if ($cpuCores <= 0) {
+            $cpuCores = 1;
+        }
+
+        $percent = ($oneMinuteLoad / $cpuCores) * 100;
+
+        return round(max(0, min(100, $percent)), 1);
     }
 }

--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -1,15 +1,334 @@
 @extends('layouts.app')
+
 @section('content')
-<h1>Admin Dashboard</h1>
-<div style="display:flex; gap:16px; flex-wrap:wrap;">
-    <div>Disk: {{ number_format($diskUsed/1024/1024/1024,2) }} / {{ number_format($diskTotal/1024/1024/1024,2) }} GB</div>
-    <div>Memory: {{ number_format($memUsedKB/1024/1024,2) }} / {{ number_format($memTotalKB/1024/1024,2) }} GB</div>
-    <div>DB Size: {{ number_format($dbSize,2) }} MB</div>
-</div>
-<table border="1" cellpadding="6" cellspacing="0" style="margin-top:12px;">
-    <tr><th>Domains</th><th>Clients</th><th>Users</th></tr>
-    <tr><td>{{ $counts['domains'] }}</td><td>{{ $counts['clients'] }}</td><td>{{ $counts['users'] }}</td></tr>
-</table>
-<h3 style="margin-top:16px;">Synergy Balance</h3>
-<pre style="background:#f9fafb; padding:8px;">{{ json_encode($balance) }}</pre>
+    @php
+        $cpuValue = number_format($cpuUsage, 1);
+        $diskUsedGb = $diskUsed / 1024 / 1024 / 1024;
+        $diskFreeGb = $diskFree / 1024 / 1024 / 1024;
+        $diskTotalGb = $diskTotal / 1024 / 1024 / 1024;
+        $memoryUsedGb = $memUsedKB / 1024 / 1024;
+        $memoryTotalGb = $memTotalKB / 1024 / 1024;
+
+        $diskUsedPercent = $diskTotal > 0 ? ($diskUsed / $diskTotal) * 100 : 0;
+        $memoryUsedPercent = $memTotalKB > 0 ? ($memUsedKB / $memTotalKB) * 100 : 0;
+
+        $statusCards = [
+            [
+                'label' => 'CPU Usage',
+                'value' => $cpuValue.'%',
+                'sub' => '1 minute load adjusted by core count',
+                'meter' => $cpuUsage,
+            ],
+            [
+                'label' => 'RAM Usage',
+                'value' => number_format($memoryUsedGb, 2).' / '.number_format($memoryTotalGb, 2).' GB',
+                'sub' => number_format($memoryUsedPercent, 1).'% used',
+                'meter' => $memoryUsedPercent,
+            ],
+            [
+                'label' => 'Free Disk Space',
+                'value' => number_format($diskFreeGb, 2).' GB',
+                'sub' => number_format($diskUsedGb, 2).' / '.number_format($diskTotalGb, 2).' GB used',
+                'meter' => $diskUsedPercent,
+            ],
+            [
+                'label' => 'Domains',
+                'value' => number_format($counts['domains']),
+                'sub' => number_format($domainsWithoutClient->count()).' need client links',
+                'meter' => min(100, $counts['domains'] > 0 ? ($domainsWithoutClient->count() / $counts['domains']) * 100 : 0),
+            ],
+            [
+                'label' => 'Clients',
+                'value' => number_format($counts['clients']),
+                'sub' => number_format($counts['users']).' users in platform',
+                'meter' => min(100, $counts['clients'] > 0 ? ($counts['users'] / $counts['clients']) * 100 : 0),
+            ],
+        ];
+    @endphp
+
+    <style>
+        .status-shell {
+            background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+            border: 1px solid #dbe3ef;
+            border-radius: 16px;
+            padding: 20px;
+        }
+
+        .status-title {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .status-title h1 {
+            margin: 0;
+            font-size: 1.8rem;
+            color: #0f172a;
+        }
+
+        .status-title p {
+            margin: 6px 0 0;
+            color: #475569;
+            font-size: 0.95rem;
+        }
+
+        .status-cards {
+            display: grid;
+            gap: 12px;
+            grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+            margin-bottom: 18px;
+        }
+
+        .status-card {
+            border: 1px solid #d8e1ed;
+            background: #ffffff;
+            border-radius: 12px;
+            padding: 14px;
+        }
+
+        .status-card-label {
+            color: #64748b;
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        .status-card-value {
+            margin: 6px 0;
+            font-size: 1.4rem;
+            font-weight: 700;
+            color: #0f172a;
+        }
+
+        .status-card-sub {
+            color: #334155;
+            font-size: 0.84rem;
+            margin-bottom: 8px;
+        }
+
+        .status-meter {
+            width: 100%;
+            height: 8px;
+            border-radius: 999px;
+            background: #e2e8f0;
+            overflow: hidden;
+        }
+
+        .status-meter-fill {
+            height: 100%;
+            background: linear-gradient(90deg, #0284c7 0%, #16a34a 100%);
+        }
+
+        .status-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
+            gap: 14px;
+        }
+
+        .status-panel {
+            background: #ffffff;
+            border: 1px solid #d8e1ed;
+            border-radius: 12px;
+            overflow: hidden;
+        }
+
+        .status-panel-head {
+            padding: 12px 14px;
+            border-bottom: 1px solid #e2e8f0;
+            background: #f8fafc;
+        }
+
+        .status-panel-head h2 {
+            margin: 0;
+            font-size: 1rem;
+            color: #0f172a;
+        }
+
+        .status-panel-head p {
+            margin: 4px 0 0;
+            font-size: 0.82rem;
+            color: #64748b;
+        }
+
+        .status-table-wrap {
+            max-height: 340px;
+            overflow: auto;
+        }
+
+        .status-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+
+        .status-table th,
+        .status-table td {
+            padding: 10px 12px;
+            border-bottom: 1px solid #edf2f7;
+            text-align: left;
+        }
+
+        .status-table th {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            background: #f8fafc;
+            color: #334155;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .status-table tbody tr:hover {
+            background: #f8fafc;
+        }
+
+        .status-domain-link {
+            color: #0369a1;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .status-domain-link:hover {
+            text-decoration: underline;
+        }
+
+        .status-pill {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 999px;
+            background: #e2e8f0;
+            color: #334155;
+            font-size: 0.72rem;
+        }
+
+        @media (max-width: 768px) {
+            .status-shell {
+                padding: 14px;
+            }
+
+            .status-title h1 {
+                font-size: 1.45rem;
+            }
+        }
+    </style>
+
+    <div class="status-shell">
+        <div class="status-title">
+            <div>
+                <h1>System Status Dashboard</h1>
+                <p>Infrastructure health, account totals, and domain cleanup queues.</p>
+            </div>
+        </div>
+
+        <div class="status-cards">
+            @foreach($statusCards as $card)
+                <div class="status-card">
+                    <div class="status-card-label">{{ $card['label'] }}</div>
+                    <div class="status-card-value">{{ $card['value'] }}</div>
+                    <div class="status-card-sub">{{ $card['sub'] }}</div>
+                    <div class="status-meter">
+                        <div class="status-meter-fill" style="width: {{ number_format(max(0, min(100, $card['meter'])), 1) }}%;"></div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+        <div class="status-grid">
+            <section class="status-panel">
+                <div class="status-panel-head">
+                    <h2>Domains Not Connected to a Client</h2>
+                    <p>Click a domain to assign a client on its domain overview page.</p>
+                </div>
+                <div class="status-table-wrap">
+                    <table class="status-table">
+                        <thead>
+                        <tr>
+                            <th>Domain</th>
+                            <th>Status</th>
+                            <th>Expiry</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse($domainsWithoutClient as $domain)
+                            <tr>
+                                <td><a class="status-domain-link" href="{{ route('admin.domains.show', $domain) }}">{{ $domain->name }}</a></td>
+                                <td><span class="status-pill">{{ $domain->status ?? 'Unknown' }}</span></td>
+                                <td>{{ $domain->expiry_date ? \Illuminate\Support\Carbon::parse($domain->expiry_date)->toDateString() : '—' }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3">Every domain currently has a linked client.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="status-panel">
+                <div class="status-panel-head">
+                    <h2>Domains Not Synced to Halo</h2>
+                    <p>Domains missing Halo asset IDs and ready for sync/linking work.</p>
+                </div>
+                <div class="status-table-wrap">
+                    <table class="status-table">
+                        <thead>
+                        <tr>
+                            <th>Domain</th>
+                            <th>Client</th>
+                            <th>Status</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse($domainsNotSyncedHalo as $domain)
+                            <tr>
+                                <td><a class="status-domain-link" href="{{ route('admin.domains.show', $domain) }}">{{ $domain->name }}</a></td>
+                                <td>{{ $domain->client_id ? '#'.$domain->client_id : 'Unlinked' }}</td>
+                                <td><span class="status-pill">{{ $domain->status ?? 'Unknown' }}</span></td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3">All domains currently have Halo links.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="status-panel">
+                <div class="status-panel-head">
+                    <h2>Domains Not Synced to ITGlue</h2>
+                    <p>Domains missing ITGlue IDs and waiting for sync completion.</p>
+                </div>
+                <div class="status-table-wrap">
+                    <table class="status-table">
+                        <thead>
+                        <tr>
+                            <th>Domain</th>
+                            <th>Client</th>
+                            <th>Status</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse($domainsNotSyncedItglue as $domain)
+                            <tr>
+                                <td><a class="status-domain-link" href="{{ route('admin.domains.show', $domain) }}">{{ $domain->name }}</a></td>
+                                <td>{{ $domain->client_id ? '#'.$domain->client_id : 'Unlinked' }}</td>
+                                <td><span class="status-pill">{{ $domain->status ?? 'Unknown' }}</span></td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3">All domains currently have ITGlue links.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+    </div>
 @endsection

--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -12,46 +12,85 @@
         $diskUsedPercent = $diskTotal > 0 ? ($diskUsed / $diskTotal) * 100 : 0;
         $memoryUsedPercent = $memTotalKB > 0 ? ($memUsedKB / $memTotalKB) * 100 : 0;
 
+        $hasBalance = is_numeric($availableBalance);
+        $balanceValue = $hasBalance
+            ? $balanceCurrency.' '.number_format((float) $availableBalance, 2)
+            : 'Unavailable';
+
         $statusCards = [
+            [
+                'label' => 'Available Balance',
+                'value' => $balanceValue,
+                'sub' => 'Synergy status: '.$balanceStatus,
+                'meter' => $hasBalance ? 100 : 0,
+                'tone' => 'balance',
+            ],
             [
                 'label' => 'CPU Usage',
                 'value' => $cpuValue.'%',
                 'sub' => '1 minute load adjusted by core count',
                 'meter' => $cpuUsage,
+                'tone' => 'default',
             ],
             [
                 'label' => 'RAM Usage',
                 'value' => number_format($memoryUsedGb, 2).' / '.number_format($memoryTotalGb, 2).' GB',
                 'sub' => number_format($memoryUsedPercent, 1).'% used',
                 'meter' => $memoryUsedPercent,
+                'tone' => 'default',
             ],
             [
                 'label' => 'Free Disk Space',
                 'value' => number_format($diskFreeGb, 2).' GB',
                 'sub' => number_format($diskUsedGb, 2).' / '.number_format($diskTotalGb, 2).' GB used',
                 'meter' => $diskUsedPercent,
+                'tone' => 'default',
             ],
             [
                 'label' => 'Domains',
                 'value' => number_format($counts['domains']),
                 'sub' => number_format($domainsWithoutClient->count()).' need client links',
                 'meter' => min(100, $counts['domains'] > 0 ? ($domainsWithoutClient->count() / $counts['domains']) * 100 : 0),
+                'tone' => 'default',
             ],
             [
                 'label' => 'Clients',
                 'value' => number_format($counts['clients']),
                 'sub' => number_format($counts['users']).' users in platform',
                 'meter' => min(100, $counts['clients'] > 0 ? ($counts['users'] / $counts['clients']) * 100 : 0),
+                'tone' => 'default',
             ],
         ];
     @endphp
 
     <style>
         .status-shell {
-            background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
-            border: 1px solid #dbe3ef;
+            --status-bg: color-mix(in srgb, var(--bg) 94%, #cbd5e1 6%);
+            --status-card: color-mix(in srgb, var(--bg) 89%, #ffffff 11%);
+            --status-border: color-mix(in srgb, var(--text) 12%, transparent);
+            --status-title: color-mix(in srgb, var(--text) 90%, #000000 10%);
+            --status-soft: color-mix(in srgb, var(--text) 70%, transparent);
+            --status-meter: color-mix(in srgb, var(--text) 15%, transparent);
+            --status-row-hover: color-mix(in srgb, var(--accent) 12%, transparent);
+            --status-link: color-mix(in srgb, var(--accent) 85%, #0f172a 15%);
+            --status-header: color-mix(in srgb, var(--bg) 84%, #e2e8f0 16%);
+            background: radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--accent) 18%, transparent) 0%, transparent 42%), var(--status-bg);
+            border: 1px solid var(--status-border);
             border-radius: 16px;
             padding: 20px;
+            color: var(--status-title);
+            animation: status-fade-in 260ms ease-out;
+        }
+
+        html.dark .status-shell {
+            --status-bg: color-mix(in srgb, var(--bg) 90%, #0f172a 10%);
+            --status-card: color-mix(in srgb, var(--bg) 82%, #0f172a 18%);
+            --status-border: color-mix(in srgb, #cbd5e1 18%, transparent);
+            --status-soft: color-mix(in srgb, #e2e8f0 70%, transparent);
+            --status-meter: color-mix(in srgb, #cbd5e1 20%, transparent);
+            --status-header: color-mix(in srgb, var(--bg) 72%, #1e293b 28%);
+            --status-row-hover: color-mix(in srgb, var(--accent) 16%, transparent);
+            --status-link: color-mix(in srgb, var(--accent) 78%, #ffffff 22%);
         }
 
         .status-title {
@@ -65,12 +104,12 @@
         .status-title h1 {
             margin: 0;
             font-size: 1.8rem;
-            color: #0f172a;
+            color: var(--status-title);
         }
 
         .status-title p {
             margin: 6px 0 0;
-            color: #475569;
+            color: var(--status-soft);
             font-size: 0.95rem;
         }
 
@@ -82,14 +121,23 @@
         }
 
         .status-card {
-            border: 1px solid #d8e1ed;
-            background: #ffffff;
+            border: 1px solid var(--status-border);
+            background: var(--status-card);
             border-radius: 12px;
             padding: 14px;
+            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+        }
+
+        html.dark .status-card {
+            box-shadow: 0 8px 24px rgba(2, 6, 23, 0.45);
+        }
+
+        .status-card.is-balance {
+            background: linear-gradient(145deg, color-mix(in srgb, var(--accent) 16%, var(--status-card) 84%), var(--status-card));
         }
 
         .status-card-label {
-            color: #64748b;
+            color: var(--status-soft);
             font-size: 0.78rem;
             text-transform: uppercase;
             letter-spacing: 0.04em;
@@ -99,11 +147,11 @@
             margin: 6px 0;
             font-size: 1.4rem;
             font-weight: 700;
-            color: #0f172a;
+            color: var(--status-title);
         }
 
         .status-card-sub {
-            color: #334155;
+            color: var(--status-soft);
             font-size: 0.84rem;
             margin-bottom: 8px;
         }
@@ -112,13 +160,13 @@
             width: 100%;
             height: 8px;
             border-radius: 999px;
-            background: #e2e8f0;
+            background: var(--status-meter);
             overflow: hidden;
         }
 
         .status-meter-fill {
             height: 100%;
-            background: linear-gradient(90deg, #0284c7 0%, #16a34a 100%);
+            background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 65%, #0284c7 35%), #16a34a);
         }
 
         .status-grid {
@@ -128,28 +176,29 @@
         }
 
         .status-panel {
-            background: #ffffff;
-            border: 1px solid #d8e1ed;
+            background: var(--status-card);
+            border: 1px solid var(--status-border);
             border-radius: 12px;
             overflow: hidden;
+            animation: status-slide 220ms ease-out;
         }
 
         .status-panel-head {
             padding: 12px 14px;
-            border-bottom: 1px solid #e2e8f0;
-            background: #f8fafc;
+            border-bottom: 1px solid var(--status-border);
+            background: var(--status-header);
         }
 
         .status-panel-head h2 {
             margin: 0;
             font-size: 1rem;
-            color: #0f172a;
+            color: var(--status-title);
         }
 
         .status-panel-head p {
             margin: 4px 0 0;
             font-size: 0.82rem;
-            color: #64748b;
+            color: var(--status-soft);
         }
 
         .status-table-wrap {
@@ -166,7 +215,7 @@
         .status-table th,
         .status-table td {
             padding: 10px 12px;
-            border-bottom: 1px solid #edf2f7;
+            border-bottom: 1px solid var(--status-border);
             text-align: left;
         }
 
@@ -174,19 +223,19 @@
             position: sticky;
             top: 0;
             z-index: 1;
-            background: #f8fafc;
-            color: #334155;
+            background: var(--status-header);
+            color: var(--status-soft);
             font-size: 0.8rem;
             text-transform: uppercase;
             letter-spacing: 0.03em;
         }
 
         .status-table tbody tr:hover {
-            background: #f8fafc;
+            background: var(--status-row-hover);
         }
 
         .status-domain-link {
-            color: #0369a1;
+            color: var(--status-link);
             text-decoration: none;
             font-weight: 600;
         }
@@ -199,9 +248,33 @@
             display: inline-block;
             padding: 2px 8px;
             border-radius: 999px;
-            background: #e2e8f0;
-            color: #334155;
+            background: color-mix(in srgb, var(--status-header) 78%, var(--accent) 22%);
+            color: var(--status-title);
             font-size: 0.72rem;
+        }
+
+        @keyframes status-fade-in {
+            from {
+                opacity: 0;
+                transform: translateY(6px);
+            }
+
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes status-slide {
+            from {
+                opacity: 0;
+                transform: translateY(8px);
+            }
+
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
         }
 
         @media (max-width: 768px) {
@@ -225,7 +298,7 @@
 
         <div class="status-cards">
             @foreach($statusCards as $card)
-                <div class="status-card">
+                <div class="status-card {{ $card['tone'] === 'balance' ? 'is-balance' : '' }}">
                     <div class="status-card-label">{{ $card['label'] }}</div>
                     <div class="status-card-value">{{ $card['value'] }}</div>
                     <div class="status-card-sub">{{ $card['sub'] }}</div>
@@ -256,7 +329,7 @@
                             <tr>
                                 <td><a class="status-domain-link" href="{{ route('admin.domains.show', $domain) }}">{{ $domain->name }}</a></td>
                                 <td><span class="status-pill">{{ $domain->status ?? 'Unknown' }}</span></td>
-                                <td>{{ $domain->expiry_date ? \Illuminate\Support\Carbon::parse($domain->expiry_date)->toDateString() : '—' }}</td>
+                                <td>{{ $domain->expiry_date ? \Illuminate\Support\Carbon::parse($domain->expiry_date)->toDateString() : '-' }}</td>
                             </tr>
                         @empty
                             <tr>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -735,7 +735,7 @@
 
                 <!-- Admin Section (hidden for non-admin users) -->
                 @role('Administrator')
-                    <li class="nav-item nav-section {{ request()->routeIs('admin.clients*') || request()->routeIs('admin.users*') || request()->routeIs('admin.settings') || request()->routeIs('admin.apikeys') || request()->routeIs('admin.domains.pricing*') ? 'expanded' : '' }}">
+                    <li class="nav-item nav-section {{ request()->routeIs('admin.clients*') || request()->routeIs('admin.users*') || request()->routeIs('admin.settings') || request()->routeIs('admin.apikeys') || request()->routeIs('admin.dashboard') || request()->routeIs('admin.domains.pricing*') ? 'expanded' : '' }}">
                         <div class="nav-link nav-toggle" onclick="toggleNav(this)">
                             <span class="icon">⚙️</span>
                             <span class="text">Admin</span>
@@ -765,6 +765,11 @@
                             <li class="nav-item">
                                 <a href="{{ route('admin.settings') }}" class="nav-link {{ request()->routeIs('admin.settings') ? 'active' : '' }}">
                                     Settings
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('admin.dashboard') }}" class="nav-link {{ request()->routeIs('admin.dashboard') ? 'active' : '' }}">
+                                    System Status
                                 </a>
                             </li>
                             @can('domain-pricing.view')


### PR DESCRIPTION
### Motivation
- Provide a discoverable, admin-facing system status page that surfaces infrastructure metrics (CPU, RAM, disk), account totals, and domain cleanup/sync queues so operators can quickly act on outstanding domain linking/sync tasks.
- Make lists actionable by linking domains to their overview pages so admins can complete linking/sync work (Halo/ITGlue) and assign clients directly from follow-up screens.

### Description
- Replaced the simple admin dashboard view with a dedicated status board and KPI cards in `resources/views/admin/dashboard/index.blade.php` that show CPU, RAM, and disk metrics plus domain/client/user counts and three domain queues (unlinked, not-synced to Halo, not-synced to ITGlue).
- Added metrics and domain-queue queries to `app/Http/Controllers/Admin/DashboardController.php`, including helper methods `diskMetrics()`, `memoryMetrics()`, and `cpuUsage()` to encapsulate system sampling logic and limited (100 row) domain lists.
- Made domain rows clickable and routed them to the existing domain overview (`admin.domains.show`) so admins can perform linking/sync actions there.
- Added a visible `System Status` entry to the admin sidebar and adjusted the sidebar expansion logic in `resources/views/layouts/app.blade.php` so the page is reachable from the navigation.

### Testing
- Ran `php -l app/Http/Controllers/Admin/DashboardController.php` and received no syntax errors.
- Attempted `php artisan test --filter=ExampleTest` but it failed in this environment because `vendor/autoload.php` is missing, so full test suite could not be executed.
- Confirmed files updated: `app/Http/Controllers/Admin/DashboardController.php`, `resources/views/admin/dashboard/index.blade.php`, and `resources/views/layouts/app.blade.php` (local lint and quick inspections performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d89b9e15f48330a0d55da274d36003)