### PR TITLE
Add Sync Scheduler UI and scheduled sync runner (Halo/Hosting/ITGlue)

### DIFF
--- a/app/Console/Commands/RunSyncTaskCommand.php
+++ b/app/Console/Commands/RunSyncTaskCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\Admin\ServicesController;
+use App\Http\Controllers\Admin\SyncController;
+use App\Models\Client;
+use App\Models\Domain;
+use App\Services\Synergy\SynergyWholesaleClient;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class RunSyncTaskCommand extends Command
+{
+    protected $signature = 'domaindash:sync-task {task : sync-domains|sync-hosting-services|sync-halo-assets|sync-itglue}';
+
+    protected $description = 'Runs a configured DomainDash sync task for scheduler automation';
+
+    public function handle(): int
+    {
+        $task = $this->argument('task');
+
+        return match ($task) {
+            'sync-domains' => $this->runHaloDomainSync(),
+            'sync-hosting-services' => $this->runHostingServiceSync(),
+            'sync-halo-assets' => $this->runHaloAssetSync(),
+            'sync-itglue' => $this->runItGlueSync(),
+            default => self::INVALID,
+        };
+    }
+
+    private function runHaloDomainSync(): int
+    {
+        $domainIds = Domain::whereNotNull('client_id')->pluck('id')->all();
+
+        if (empty($domainIds)) {
+            $this->info('No client-linked domains found for Halo domain sync.');
+            return self::SUCCESS;
+        }
+
+        $controller = app(SyncController::class);
+        $response = $controller->syncHaloDomains(new Request(['domain_ids' => $domainIds]));
+        $payload = $response->getData(true);
+
+        if (!empty($payload['error'])) {
+            $this->error('Halo domain sync failed: ' . $payload['error']);
+            Log::error('Scheduled halo domain sync failed', $payload);
+            return self::FAILURE;
+        }
+
+        $this->info('Halo domain sync complete. Synced: ' . ($payload['synced_count'] ?? 0));
+
+        return self::SUCCESS;
+    }
+
+    private function runHostingServiceSync(): int
+    {
+        $controller = app(ServicesController::class);
+        $synergy = app(SynergyWholesaleClient::class);
+
+        $controller->sync(Request::create('/admin/services/hosting/sync', 'POST'), $synergy);
+        $this->info('Hosting service sync triggered successfully.');
+
+        return self::SUCCESS;
+    }
+
+    private function runHaloAssetSync(): int
+    {
+        $mappings = Client::whereNotNull('halopsa_reference')
+            ->get(['id', 'halopsa_reference'])
+            ->map(fn ($client) => [
+                'halo_id' => (string) $client->halopsa_reference,
+                'dash_client_id' => $client->id,
+            ])
+            ->all();
+
+        $controller = app(SyncController::class);
+
+        if (!empty($mappings)) {
+            $clientSyncResponse = $controller->syncHaloClients(new Request(['clients' => $mappings]));
+            $clientSyncPayload = $clientSyncResponse->getData(true);
+
+            if (!empty($clientSyncPayload['error'])) {
+                $this->error('Halo client sync failed: ' . $clientSyncPayload['error']);
+                Log::error('Scheduled halo client sync failed', $clientSyncPayload);
+                return self::FAILURE;
+            }
+        }
+
+        return $this->runHaloDomainSync();
+    }
+
+    private function runItGlueSync(): int
+    {
+        $items = Domain::query()
+            ->whereHas('client', function ($query) {
+                $query->whereNotNull('itglue_org_id');
+            })
+            ->get(['id'])
+            ->map(fn ($domain) => [
+                'id' => $domain->id,
+                'type' => 'domain',
+            ])
+            ->all();
+
+        if (empty($items)) {
+            $this->info('No IT Glue-linked domains found for sync.');
+            return self::SUCCESS;
+        }
+
+        $controller = app(SyncController::class);
+        $response = $controller->syncItGlueConfigurations(new Request(['items' => $items]));
+        $payload = $response->getData(true);
+
+        if (!empty($payload['error'])) {
+            $this->error('IT Glue sync failed: ' . $payload['error']);
+            Log::error('Scheduled IT Glue sync failed', $payload);
+            return self::FAILURE;
+        }
+
+        $this->info('IT Glue configuration sync complete. Synced: ' . ($payload['synced_count'] ?? 0));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Models\Setting;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -11,6 +12,12 @@ class Kernel extends ConsoleKernel
     {
         // Nightly domain/hosting/SSL sync
         $schedule->job(new \App\Jobs\SyncSynergyDomainsJob())->dailyAt('02:30');
+
+        $syncSchedule = Setting::get('sync_schedule', []);
+        $this->scheduleSyncTask($schedule, $syncSchedule['sync_domains'] ?? [], 'sync-domains', 'domaindash:sync-task sync-domains');
+        $this->scheduleSyncTask($schedule, $syncSchedule['sync_hosting_services'] ?? [], 'sync-hosting-services', 'domaindash:sync-task sync-hosting-services');
+        $this->scheduleSyncTask($schedule, $syncSchedule['sync_halo_assets'] ?? [], 'sync-halo-assets', 'domaindash:sync-task sync-halo-assets');
+        $this->scheduleSyncTask($schedule, $syncSchedule['sync_itglue'] ?? [], 'sync-itglue', 'domaindash:sync-task sync-itglue');
 
         // Backup
         $schedule->command('domaindash:backup-run')->dailyAt('03:00');
@@ -22,5 +29,24 @@ class Kernel extends ConsoleKernel
     protected function commands(): void
     {
         $this->load(__DIR__.'/Commands');
+    }
+
+    private function scheduleSyncTask(Schedule $schedule, array $taskConfig, string $taskName, string $command): void
+    {
+        $enabled = filter_var($taskConfig['enabled'] ?? false, FILTER_VALIDATE_BOOL);
+        if (!$enabled) {
+            return;
+        }
+
+        $frequency = $taskConfig['frequency'] ?? 'daily';
+        $time = $taskConfig['time'] ?? '02:00';
+
+        $event = match ($frequency) {
+            'hourly' => $schedule->command($command)->hourlyAt((int) substr($time, 3, 2)),
+            'weekly' => $schedule->command($command)->weeklyOn(1, $time),
+            default => $schedule->command($command)->dailyAt($time),
+        };
+
+        $event->name("scheduled-{$taskName}");
     }
 }

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -19,6 +19,12 @@ class SettingsController extends Controller
             'halo'     => Setting::get('halo', []),
             'itglue'   => Setting::get('itglue', []),
             'ip2whois' => Setting::get('ip2whois', []),
+            'sync_schedule' => Setting::get('sync_schedule', [
+                'sync_domains' => ['enabled' => false, 'frequency' => 'daily', 'time' => '01:30'],
+                'sync_hosting_services' => ['enabled' => false, 'frequency' => 'daily', 'time' => '02:00'],
+                'sync_halo_assets' => ['enabled' => false, 'frequency' => 'daily', 'time' => '02:30'],
+                'sync_itglue' => ['enabled' => false, 'frequency' => 'daily', 'time' => '03:00'],
+            ]),
             'backup'   => Setting::get('backup', ['host'=>'','port'=>22,'username'=>'','password'=>'','path'=>'/','retention'=>7,'time'=>'02:00']),
             'notifications' => Setting::get('notifications', ['disk_threshold_percent'=>90]),
         ];
@@ -34,6 +40,11 @@ class SettingsController extends Controller
             'halo'          => 'array',
             'itglue'        => 'array',
             'ip2whois'      => 'array',
+            'sync_schedule' => 'array',
+            'sync_schedule.*' => 'array',
+            'sync_schedule.*.enabled' => 'nullable|boolean',
+            'sync_schedule.*.frequency' => 'nullable|in:hourly,daily,weekly',
+            'sync_schedule.*.time' => 'nullable|date_format:H:i',
             'backup'        => 'array',
             'notifications' => 'array',
             'branding_logo' => 'nullable|file|image|max:2048', // up to 2MB

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -252,14 +252,61 @@ body {
     background: color-mix(in srgb, var(--dd-surface-soft) 84%, var(--dd-surface) 16%);
 }
 
+.dd-settings-page .dd-sync-scheduler-grid {
+    display: grid;
+    grid-template-columns: minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr);
+    gap: 14px;
+    align-items: end;
+}
+
+.dd-settings-page .dd-sync-scheduler-task {
+    min-height: 42px;
+    display: flex;
+    align-items: center;
+}
+
 .dd-settings-page .dd-sync-scheduler-toggle {
     color: var(--dd-text) !important;
 }
 
 .dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
     border-radius: 6px !important;
     border: 1px solid var(--dd-border) !important;
     background: var(--dd-surface-soft) !important;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+}
+
+.dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox:checked {
+    background: var(--dd-accent-strong) !important;
+    border-color: var(--dd-accent-strong) !important;
+}
+
+.dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox:checked::after {
+    content: '';
+    width: 7px;
+    height: 4px;
+    border-left: 2px solid #ffffff;
+    border-bottom: 2px solid #ffffff;
+    transform: rotate(-45deg) translateY(-1px);
+}
+
+@media (max-width: 900px) {
+    .dd-settings-page .dd-sync-scheduler-grid {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .dd-settings-page .dd-sync-scheduler-task {
+        min-height: 0;
+    }
 }
 
 #dd-global-loader {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -289,31 +289,10 @@ body {
 
 .dd-settings-page .dd-sync-scheduler-time {
     border-radius: 10px !important;
-}
-
-html.dark .dd-settings-page .dd-sync-scheduler-time {
-    color-scheme: dark;
     background: var(--dd-surface-soft) !important;
     color: var(--dd-text) !important;
     border-color: var(--dd-border) !important;
-}
-
-html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-calendar-picker-indicator {
-    filter: invert(1) brightness(1.2);
-    opacity: 0.85;
-}
-
-html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit,
-html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-fields-wrapper,
-html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-hour-field,
-html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-minute-field,
-html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-ampm-field {
-    color: var(--dd-text);
-    background: transparent;
-}
-
-html:not(.dark) .dd-settings-page .dd-sync-scheduler-time {
-    color-scheme: light;
+    letter-spacing: 0.02em;
 }
 
 #dd-global-loader {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -256,11 +256,11 @@ body {
     color: var(--dd-text) !important;
 }
 
-.dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox {
-    appearance: none;
-    -webkit-appearance: none;
-    width: 16px;
-    height: 16px;
+.dd-settings-page .dd-sync-scheduler-check {
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    width: 18px !important;
+    height: 18px !important;
     border-radius: 6px !important;
     border: 1px solid var(--dd-border) !important;
     background: var(--dd-surface-soft) !important;
@@ -269,14 +269,16 @@ body {
     align-items: center;
     justify-content: center;
     margin: 0;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--dd-surface) 50%, transparent);
 }
 
-.dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox:checked {
+.dd-settings-page .dd-sync-scheduler-check:checked {
     background: var(--dd-accent-strong) !important;
     border-color: var(--dd-accent-strong) !important;
+    box-shadow: none;
 }
 
-.dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox:checked::after {
+.dd-settings-page .dd-sync-scheduler-check:checked::after {
     content: '';
     width: 7px;
     height: 4px;
@@ -285,19 +287,32 @@ body {
     transform: rotate(-45deg) translateY(-1px);
 }
 
-html.dark .dd-settings-page input[type='time'] {
+.dd-settings-page .dd-sync-scheduler-time {
+    border-radius: 10px !important;
+}
+
+html.dark .dd-settings-page .dd-sync-scheduler-time {
     color-scheme: dark;
+    background: var(--dd-surface-soft) !important;
+    color: var(--dd-text) !important;
+    border-color: var(--dd-border) !important;
 }
 
-html.dark .dd-settings-page input[type='time']::-webkit-calendar-picker-indicator {
+html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-calendar-picker-indicator {
     filter: invert(1) brightness(1.2);
+    opacity: 0.85;
 }
 
-html.dark .dd-settings-page input[type='time']::-webkit-datetime-edit {
+html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit,
+html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-fields-wrapper,
+html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-hour-field,
+html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-minute-field,
+html.dark .dd-settings-page .dd-sync-scheduler-time::-webkit-datetime-edit-ampm-field {
     color: var(--dd-text);
+    background: transparent;
 }
 
-html:not(.dark) .dd-settings-page input[type='time'] {
+html:not(.dark) .dd-settings-page .dd-sync-scheduler-time {
     color-scheme: light;
 }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -252,19 +252,6 @@ body {
     background: color-mix(in srgb, var(--dd-surface-soft) 84%, var(--dd-surface) 16%);
 }
 
-.dd-settings-page .dd-sync-scheduler-grid {
-    display: grid;
-    grid-template-columns: minmax(220px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr);
-    gap: 14px;
-    align-items: end;
-}
-
-.dd-settings-page .dd-sync-scheduler-task {
-    min-height: 42px;
-    display: flex;
-    align-items: center;
-}
-
 .dd-settings-page .dd-sync-scheduler-toggle {
     color: var(--dd-text) !important;
 }
@@ -298,15 +285,20 @@ body {
     transform: rotate(-45deg) translateY(-1px);
 }
 
-@media (max-width: 900px) {
-    .dd-settings-page .dd-sync-scheduler-grid {
-        grid-template-columns: 1fr;
-        gap: 10px;
-    }
+html.dark .dd-settings-page input[type='time'] {
+    color-scheme: dark;
+}
 
-    .dd-settings-page .dd-sync-scheduler-task {
-        min-height: 0;
-    }
+html.dark .dd-settings-page input[type='time']::-webkit-calendar-picker-indicator {
+    filter: invert(1) brightness(1.2);
+}
+
+html.dark .dd-settings-page input[type='time']::-webkit-datetime-edit {
+    color: var(--dd-text);
+}
+
+html:not(.dark) .dd-settings-page input[type='time'] {
+    color-scheme: light;
 }
 
 #dd-global-loader {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -246,6 +246,22 @@ body {
     border-radius: 12px !important;
 }
 
+.dd-settings-page .dd-sync-scheduler-row {
+    border: 1px solid var(--dd-border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--dd-surface-soft) 84%, var(--dd-surface) 16%);
+}
+
+.dd-settings-page .dd-sync-scheduler-toggle {
+    color: var(--dd-text) !important;
+}
+
+.dd-settings-page .dd-sync-scheduler-row input[type='checkbox'].dd-checkbox {
+    border-radius: 6px !important;
+    border: 1px solid var(--dd-border) !important;
+    background: var(--dd-surface-soft) !important;
+}
+
 #dd-global-loader {
     position: fixed;
     inset: 0;

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -579,9 +579,8 @@
                         'sync_halo_assets' => 'Sync Client Domain Assets to/from HaloPSA',
                         'sync_itglue' => 'Sync IT Glue Domain Assets',
                     ] as $key => $label)
-                        <div class="dd-sync-scheduler-row" style="margin-bottom:12px;padding:12px;">
-                            <div class="dd-sync-scheduler-grid">
-                            <div class="dd-sync-scheduler-task">
+                        <div class="dd-sync-scheduler-row" style="display:grid;grid-template-columns:180px 160px 120px;gap:12px;align-items:end;margin-bottom:12px;padding:12px;">
+                            <div>
                                 <input type="hidden" name="sync_schedule[{{ $key }}][enabled]" value="0">
                                 <label class="dd-sync-scheduler-toggle" style="display:flex;align-items:center;gap:8px;font-size:14px;font-weight:500;cursor:pointer;">
                                     <input type="checkbox"
@@ -593,7 +592,7 @@
                                     {{ $label }}
                                 </label>
                             </div>
-                            <div class="dd-sync-scheduler-field">
+                            <div>
                                 <label style="display:block;font-size:12px;margin-bottom:4px;">Frequency</label>
                                 <select name="sync_schedule[{{ $key }}][frequency]" class="dd-field"
                                         style="width:100%;font-size:13px;">
@@ -602,13 +601,12 @@
                                     @endforeach
                                 </select>
                             </div>
-                            <div class="dd-sync-scheduler-field">
+                            <div>
                                 <label style="display:block;font-size:12px;margin-bottom:4px;">Run time</label>
                                 <input type="time" class="dd-field"
                                        name="sync_schedule[{{ $key }}][time]"
                                        value="{{ $syncSchedule[$key]['time'] ?? '02:00' }}"
                                        style="width:100%;font-size:13px;">
-                            </div>
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -584,7 +584,7 @@
                                 <input type="hidden" name="sync_schedule[{{ $key }}][enabled]" value="0">
                                 <label class="dd-sync-scheduler-toggle" style="display:flex;align-items:center;gap:8px;font-size:14px;font-weight:500;cursor:pointer;">
                                     <input type="checkbox"
-                                           class="dd-checkbox"
+                                           class="dd-checkbox dd-sync-scheduler-check"
                                            name="sync_schedule[{{ $key }}][enabled]"
                                            value="1"
                                            {{ !empty($syncSchedule[$key]['enabled']) ? 'checked' : '' }}
@@ -603,7 +603,7 @@
                             </div>
                             <div>
                                 <label style="display:block;font-size:12px;margin-bottom:4px;">Run time</label>
-                                <input type="time" class="dd-field"
+                                <input type="time" class="dd-field dd-sync-scheduler-time"
                                        name="sync_schedule[{{ $key }}][time]"
                                        value="{{ $syncSchedule[$key]['time'] ?? '02:00' }}"
                                        style="width:100%;font-size:13px;">

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -579,8 +579,9 @@
                         'sync_halo_assets' => 'Sync Client Domain Assets to/from HaloPSA',
                         'sync_itglue' => 'Sync IT Glue Domain Assets',
                     ] as $key => $label)
-                        <div class="dd-sync-scheduler-row" style="display:grid;grid-template-columns:180px 160px 120px;gap:12px;align-items:end;margin-bottom:12px;padding:12px;">
-                            <div>
+                        <div class="dd-sync-scheduler-row" style="margin-bottom:12px;padding:12px;">
+                            <div class="dd-sync-scheduler-grid">
+                            <div class="dd-sync-scheduler-task">
                                 <input type="hidden" name="sync_schedule[{{ $key }}][enabled]" value="0">
                                 <label class="dd-sync-scheduler-toggle" style="display:flex;align-items:center;gap:8px;font-size:14px;font-weight:500;cursor:pointer;">
                                     <input type="checkbox"
@@ -592,21 +593,22 @@
                                     {{ $label }}
                                 </label>
                             </div>
-                            <div>
+                            <div class="dd-sync-scheduler-field">
                                 <label style="display:block;font-size:12px;margin-bottom:4px;">Frequency</label>
-                                <select name="sync_schedule[{{ $key }}][frequency]"
-                                        style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;">
+                                <select name="sync_schedule[{{ $key }}][frequency]" class="dd-field"
+                                        style="width:100%;font-size:13px;">
                                     @foreach($syncFrequencies as $value => $text)
                                         <option value="{{ $value }}" {{ ($syncSchedule[$key]['frequency'] ?? 'daily') === $value ? 'selected' : '' }}>{{ $text }}</option>
                                     @endforeach
                                 </select>
                             </div>
-                            <div>
+                            <div class="dd-sync-scheduler-field">
                                 <label style="display:block;font-size:12px;margin-bottom:4px;">Run time</label>
-                                <input type="time"
+                                <input type="time" class="dd-field"
                                        name="sync_schedule[{{ $key }}][time]"
                                        value="{{ $syncSchedule[$key]['time'] ?? '02:00' }}"
-                                       style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;">
+                                       style="width:100%;font-size:13px;">
+                            </div>
                             </div>
                         </div>
                     @endforeach

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -552,6 +552,69 @@
                 </div>
             </div>
 
+            {{-- SYNC SCHEDULER SECTION --}}
+            @php
+                $syncSchedule = $settings['sync_schedule'] ?? [];
+                $syncFrequencies = ['hourly' => 'Hourly', 'daily' => 'Daily', 'weekly' => 'Weekly'];
+            @endphp
+            <div class="settings-section" style="background:rgba(15,23,42,0.6);border:1px solid rgba(148,163,184,0.1);border-radius:12px;margin-bottom:16px;overflow:hidden;">
+                <div class="settings-header" onclick="toggleSection('sync-scheduler')" style="padding:16px 20px;cursor:pointer;display:flex;align-items:center;justify-content:space-between;background:rgba(15,23,42,0.4);border-bottom:1px solid rgba(148,163,184,0.1);transition:background 0.2s;">
+                    <div style="display:flex;align-items:center;gap:12px;">
+                        <div style="width:40px;height:40px;background:linear-gradient(135deg,#22c55e,#16a34a);border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:20px;">
+                            ⏱️
+                        </div>
+                        <div>
+                            <h3 style="font-size:16px;font-weight:600;margin:0;color:#f8fafc;">Sync Scheduler</h3>
+                            <p style="font-size:13px;color:#94a3b8;margin:0;">Configure recurring integration sync jobs</p>
+                        </div>
+                    </div>
+                    <svg id="sync-scheduler-icon" style="width:20px;height:20px;transition:transform 0.3s;color:#94a3b8;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                    </svg>
+                </div>
+                <div id="sync-scheduler-content" class="settings-content" style="padding:20px 24px;display:none;">
+                    @foreach([
+                        'sync_domains' => 'Sync Domains to HaloPSA',
+                        'sync_hosting_services' => 'Sync Hosting Services',
+                        'sync_halo_assets' => 'Sync Client Domain Assets to/from HaloPSA',
+                        'sync_itglue' => 'Sync IT Glue Domain Assets',
+                    ] as $key => $label)
+                        <div style="display:grid;grid-template-columns:180px 160px 120px;gap:12px;align-items:end;margin-bottom:12px;padding:12px;border:1px solid rgba(148,163,184,0.1);border-radius:8px;background:rgba(15,23,42,0.35);">
+                            <div>
+                                <input type="hidden" name="sync_schedule[{{ $key }}][enabled]" value="0">
+                                <label style="display:flex;align-items:center;gap:8px;color:#e2e8f0;font-size:14px;font-weight:500;cursor:pointer;">
+                                    <input type="checkbox"
+                                           name="sync_schedule[{{ $key }}][enabled]"
+                                           value="1"
+                                           {{ !empty($syncSchedule[$key]['enabled']) ? 'checked' : '' }}
+                                           style="width:16px;height:16px;">
+                                    {{ $label }}
+                                </label>
+                            </div>
+                            <div>
+                                <label style="display:block;font-size:12px;color:#94a3b8;margin-bottom:4px;">Frequency</label>
+                                <select name="sync_schedule[{{ $key }}][frequency]"
+                                        style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;background:#0b1120;color:#f8fafc;">
+                                    @foreach($syncFrequencies as $value => $text)
+                                        <option value="{{ $value }}" {{ ($syncSchedule[$key]['frequency'] ?? 'daily') === $value ? 'selected' : '' }}>{{ $text }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <label style="display:block;font-size:12px;color:#94a3b8;margin-bottom:4px;">Run time</label>
+                                <input type="time"
+                                       name="sync_schedule[{{ $key }}][time]"
+                                       value="{{ $syncSchedule[$key]['time'] ?? '02:00' }}"
+                                       style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;">
+                            </div>
+                        </div>
+                    @endforeach
+                    <small style="display:block;margin-top:8px;font-size:12px;color:#9ca3af;">
+                        Hourly sync uses the minutes from "Run time"; weekly sync runs every Monday at the selected time.
+                    </small>
+                </div>
+            </div>
+
             {{-- Action buttons --}}
             <div class="dd-settings-panel" style="padding:20px;">
                 <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -587,8 +587,7 @@
                                            class="dd-checkbox dd-sync-scheduler-check"
                                            name="sync_schedule[{{ $key }}][enabled]"
                                            value="1"
-                                           {{ !empty($syncSchedule[$key]['enabled']) ? 'checked' : '' }}
-                                           style="width:16px;height:16px;">
+                                           {{ !empty($syncSchedule[$key]['enabled']) ? 'checked' : '' }}>
                                     {{ $label }}
                                 </label>
                             </div>
@@ -603,9 +602,14 @@
                             </div>
                             <div>
                                 <label style="display:block;font-size:12px;margin-bottom:4px;">Run time</label>
-                                <input type="time" class="dd-field dd-sync-scheduler-time"
+                                <input type="text" class="dd-field dd-sync-scheduler-time"
                                        name="sync_schedule[{{ $key }}][time]"
                                        value="{{ $syncSchedule[$key]['time'] ?? '02:00' }}"
+                                       inputmode="numeric"
+                                       maxlength="5"
+                                       pattern="^([01]\d|2[0-3]):[0-5]\d$"
+                                       title="Use 24-hour format HH:MM"
+                                       placeholder="HH:MM"
                                        style="width:100%;font-size:13px;">
                             </div>
                         </div>

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -579,11 +579,12 @@
                         'sync_halo_assets' => 'Sync Client Domain Assets to/from HaloPSA',
                         'sync_itglue' => 'Sync IT Glue Domain Assets',
                     ] as $key => $label)
-                        <div style="display:grid;grid-template-columns:180px 160px 120px;gap:12px;align-items:end;margin-bottom:12px;padding:12px;border:1px solid rgba(148,163,184,0.1);border-radius:8px;background:rgba(15,23,42,0.35);">
+                        <div class="dd-sync-scheduler-row" style="display:grid;grid-template-columns:180px 160px 120px;gap:12px;align-items:end;margin-bottom:12px;padding:12px;">
                             <div>
                                 <input type="hidden" name="sync_schedule[{{ $key }}][enabled]" value="0">
-                                <label style="display:flex;align-items:center;gap:8px;color:#e2e8f0;font-size:14px;font-weight:500;cursor:pointer;">
+                                <label class="dd-sync-scheduler-toggle" style="display:flex;align-items:center;gap:8px;font-size:14px;font-weight:500;cursor:pointer;">
                                     <input type="checkbox"
+                                           class="dd-checkbox"
                                            name="sync_schedule[{{ $key }}][enabled]"
                                            value="1"
                                            {{ !empty($syncSchedule[$key]['enabled']) ? 'checked' : '' }}
@@ -592,16 +593,16 @@
                                 </label>
                             </div>
                             <div>
-                                <label style="display:block;font-size:12px;color:#94a3b8;margin-bottom:4px;">Frequency</label>
+                                <label style="display:block;font-size:12px;margin-bottom:4px;">Frequency</label>
                                 <select name="sync_schedule[{{ $key }}][frequency]"
-                                        style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;background:#0b1120;color:#f8fafc;">
+                                        style="width:100%;padding:8px 10px;border-radius:4px;border:1px solid #e5e7eb;font-size:13px;">
                                     @foreach($syncFrequencies as $value => $text)
                                         <option value="{{ $value }}" {{ ($syncSchedule[$key]['frequency'] ?? 'daily') === $value ? 'selected' : '' }}>{{ $text }}</option>
                                     @endforeach
                                 </select>
                             </div>
                             <div>
-                                <label style="display:block;font-size:12px;color:#94a3b8;margin-bottom:4px;">Run time</label>
+                                <label style="display:block;font-size:12px;margin-bottom:4px;">Run time</label>
                                 <input type="time"
                                        name="sync_schedule[{{ $key }}][time]"
                                        value="{{ $syncSchedule[$key]['time'] ?? '02:00' }}"


### PR DESCRIPTION
### Motivation
- Provide administrators a way to configure recurring sync jobs for domains, hosting services, HaloPSA assets and IT Glue from the Admin > Settings UI so integrations can be run automatically. 

### Description
- Added a new "Sync Scheduler" section in the admin settings UI with per-task `enabled`, `frequency`, and `time` controls for `sync_domains`, `sync_hosting_services`, `sync_halo_assets`, and `sync_itglue` (`resources/views/admin/settings/index.blade.php`).
- Persisted scheduler configuration via a new `sync_schedule` settings payload with sensible defaults and validation in `Admin\SettingsController` (`app/Http/Controllers/Admin/SettingsController.php`).
- Implemented a scheduled runner Artisan command `domaindash:sync-task` (`app/Console/Commands/RunSyncTaskCommand.php`) that executes the existing Sync workflows (`SyncController` / `ServicesController`) for the supported tasks in automation mode.
- Updated `App\Console\Kernel` to dynamically register scheduled command events based on saved `sync_schedule` settings (supports `hourly`, `daily`, and `weekly`), with a small helper `scheduleSyncTask` to centralise scheduling logic (`app/Console/Kernel.php`).

### Testing
- Static checks: `php -l` on `app/Console/Commands/RunSyncTaskCommand.php`, `app/Console/Kernel.php`, and `app/Http/Controllers/Admin/SettingsController.php` all passed with no syntax errors. 
- Functional test run: `php artisan test --filter=ExampleTest` could not run in this environment because `vendor/autoload.php` is missing, causing the test run to fail; this is an environment issue rather than a code error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69da2cde68c88330a640b455ad152647)