### PR TITLE
Wire email templates into reset and expiry notifications

### DIFF
--- a/app/Console/Commands/NotifyExpiringCommand.php
+++ b/app/Console/Commands/NotifyExpiringCommand.php
@@ -2,29 +2,106 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
 use App\Models\Domain;
 use App\Models\SslCertificate;
-use Illuminate\Support\Facades\Notification;
+use App\Services\EmailTemplateMailer;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 
 class NotifyExpiringCommand extends Command
 {
     protected $signature = 'domaindash:notify-expiring';
     protected $description = 'Notify customers/admins of expiring domains and SSLs';
 
-    public function handle(): int
+    public function handle(EmailTemplateMailer $mailer): int
     {
-        $domains = Domain::whereNotNull('expiry_date')->where('expiry_date','<=', now()->addDays(30))->get();
-        $ssls = SslCertificate::whereNotNull('expire_date')->where('expire_date','<=', now()->addDays(30))->get();
+        $domainCount = 0;
+        $sslCount = 0;
 
-        // Simplified: in real app, group by client and send to assigned users
-        foreach ($domains as $d) {
-            // dispatch email using Blade templates
+        $domains = Domain::query()
+            ->with('client')
+            ->whereNotNull('expiry_date')
+            ->whereDate('expiry_date', '>=', now()->startOfDay())
+            ->whereDate('expiry_date', '<=', now()->addDays(30)->endOfDay())
+            ->get();
+
+        foreach ($domains as $domain) {
+            $daysBefore = now()->startOfDay()->diffInDays($domain->expiry_date->startOfDay(), false);
+            if ($daysBefore < 0) {
+                continue;
+            }
+
+            $lockKey = sprintf('notify:domain:%d:%d:%s', $domain->id, $daysBefore, now()->toDateString());
+            if (! Cache::add($lockKey, true, now()->endOfDay())) {
+                continue;
+            }
+
+            $sent = $mailer->sendForEvent(
+                'domain_expiring',
+                [
+                    'client' => [
+                        'name' => $domain->client?->business_name ?: $domain->client?->primary_contact_name,
+                        'email' => $domain->client?->email,
+                    ],
+                    'company' => [
+                        'name' => config('app.name', 'DomainDash'),
+                    ],
+                    'domain' => [
+                        'name' => $domain->name,
+                        'expiry_date' => $domain->expiry_date?->toDateString(),
+                        'renewal_price' => 'TBC',
+                    ],
+                ],
+                $domain->client?->email,
+                $daysBefore,
+            );
+
+            $domainCount += $sent ? 1 : 0;
         }
-        foreach ($ssls as $s) {
-            // dispatch email using Blade templates
+
+        $ssls = SslCertificate::query()
+            ->with('client')
+            ->whereNotNull('expire_date')
+            ->whereDate('expire_date', '>=', now()->startOfDay())
+            ->whereDate('expire_date', '<=', now()->addDays(30)->endOfDay())
+            ->get();
+
+        foreach ($ssls as $ssl) {
+            $daysBefore = now()->startOfDay()->diffInDays($ssl->expire_date->startOfDay(), false);
+            if ($daysBefore < 0) {
+                continue;
+            }
+
+            $lockKey = sprintf('notify:ssl:%d:%d:%s', $ssl->id, $daysBefore, now()->toDateString());
+            if (! Cache::add($lockKey, true, now()->endOfDay())) {
+                continue;
+            }
+
+            $sent = $mailer->sendForEvent(
+                'ssl_expiring',
+                [
+                    'client' => [
+                        'name' => $ssl->client?->business_name ?: $ssl->client?->primary_contact_name,
+                        'email' => $ssl->client?->email,
+                    ],
+                    'company' => [
+                        'name' => config('app.name', 'DomainDash'),
+                    ],
+                    'ssl' => [
+                        'common_name' => $ssl->common_name,
+                        'expiry_date' => $ssl->expire_date?->toDateString(),
+                        'issuer' => $ssl->product_name,
+                    ],
+                ],
+                $ssl->client?->email,
+                $daysBefore,
+            );
+
+            $sslCount += $sent ? 1 : 0;
         }
-        $this->info('Notifications enqueued.');
-        return 0;
+
+        $this->info("Expiry notification run completed. Domain emails sent: {$domainCount}; SSL emails sent: {$sslCount}.");
+
+        return self::SUCCESS;
     }
 }

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Models\Setting;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
+use App\Support\MailSettings;
 
 class SettingsController extends Controller
 {
@@ -131,33 +132,17 @@ class SettingsController extends Controller
         $smtp = Setting::get('smtp', []);
 
         // Validate that SMTP settings are configured
-        if (empty($smtp['host']) || empty($smtp['port']) || empty($smtp['from'])) {
+        if (! MailSettings::isConfigured($smtp)) {
             return back()->withErrors(['smtp' => 'SMTP settings are not fully configured. Please configure host, port, and from address.']);
         }
 
-        try {
-            // Temporarily configure mail settings using database values
-            config([
-                'mail.default' => 'smtp',
-                'mail.mailers.smtp.transport' => 'smtp',
-                'mail.mailers.smtp.host' => $smtp['host'],
-                'mail.mailers.smtp.port' => $smtp['port'],
-                'mail.mailers.smtp.username' => $smtp['username'] ?? null,
-                'mail.mailers.smtp.password' => $smtp['password'] ?? null,
-                'mail.mailers.smtp.encryption' => $smtp['encryption'] ?? null,
-                'mail.from.address' => $smtp['from'],
-                'mail.from.name' => $smtp['from_name'] ?? 'DomainDash',
-            ]);
+        MailSettings::apply($smtp);
 
-            // Send test email
-            Mail::raw('This is a test email from DomainDash. If you received this, your SMTP configuration is working correctly!', function($m) use ($request) {
-                $m->to($request->to)
-                  ->subject('DomainDash SMTP Test');
-            });
+        Mail::raw('This is a test email from DomainDash. If you received this, your SMTP configuration is working correctly!', function ($m) use ($request) {
+            $m->to($request->to)
+                ->subject('DomainDash SMTP Test');
+        });
 
-            return back()->with('status', 'Test email sent successfully to ' . $request->to);
-        } catch (\Exception $e) {
-            return back()->withErrors(['smtp' => 'Failed to send test email: ' . $e->getMessage()]);
-        }
+        return back()->with('status', 'Test email sent successfully to ' . $request->to);
     }
 }

--- a/app/Http/Controllers/Admin/UsersController.php
+++ b/app/Http/Controllers/Admin/UsersController.php
@@ -53,6 +53,7 @@ class UsersController extends Controller
             'client_ids.*' => 'integer|exists:clients,id',
             'password'     => 'nullable|string|min:8|confirmed',
             'mfa_preference' => 'required|in:disabled,enabled,enforced',
+            'is_active' => 'nullable|boolean',
         ]);
 
         $password = $data['password'] ?: Str::random(12);
@@ -62,6 +63,7 @@ class UsersController extends Controller
             'email'    => $data['email'],
             'password' => Hash::make($password),
             'mfa_preference' => $data['mfa_preference'],
+            'is_active' => $request->boolean('is_active', true),
         ]);
 
         // assign role (Spatie)
@@ -115,12 +117,14 @@ class UsersController extends Controller
             'client_ids'   => 'array',
             'client_ids.*' => 'integer|exists:clients,id',
             'mfa_preference' => 'required|in:disabled,enabled,enforced',
+            'is_active' => 'nullable|boolean',
         ]);
 
         $user->update([
             'name'  => trim($data['first_name'].' '.$data['last_name']),
             'email' => $data['email'],
             'mfa_preference' => $data['mfa_preference'],
+            'is_active' => $request->boolean('is_active', true),
         ]);
 
         $user->syncRoles([$data['role']]);
@@ -184,6 +188,27 @@ class UsersController extends Controller
         ])->save();
 
         return back()->with('status', 'MFA reset for '.$user->email.'. They will need to re-enrol.');
+    }
+
+
+
+    /**
+     * Delete a user account.
+     */
+    public function destroy(Request $request, User $user)
+    {
+        if ($request->user() && $request->user()->is($user)) {
+            return back()->withErrors(['user' => 'You cannot delete your own account while logged in.']);
+        }
+
+        $email = $user->email;
+        $user->clients()->detach();
+        $user->syncRoles([]);
+        $user->delete();
+
+        return redirect()
+            ->route('admin.users')
+            ->with('status', 'User deleted: ' . $email);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Log;
+use App\Services\EmailTemplateMailer;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
@@ -71,6 +74,44 @@ class User extends Authenticatable
             'mfa_preference'    => 'string',
             'mfa_prompted_at'    => 'datetime',
         ];
+    }
+
+
+    public function sendPasswordResetNotification($token): void
+    {
+        $broker = config('auth.defaults.passwords', 'users');
+        $expiresInMinutes = (int) config("auth.passwords.{$broker}.expire", 60);
+        $resetUrl = url(route('password.reset', [
+            'token' => $token,
+            'email' => $this->getEmailForPasswordReset(),
+        ], false));
+
+        $sent = app(EmailTemplateMailer::class)->sendForEvent(
+            'password_reset',
+            [
+                'client' => [
+                    'name' => $this->name ?: $this->email,
+                    'email' => $this->email,
+                ],
+                'company' => [
+                    'name' => config('app.name', 'DomainDash'),
+                ],
+                'auth' => [
+                    'reset_link' => $resetUrl,
+                    'reset_expires_at' => now()->addMinutes($expiresInMinutes)->toDateTimeString(),
+                ],
+            ],
+            $this->email
+        );
+
+        if (! $sent) {
+            Log::info('Falling back to default Laravel reset password notification.', [
+                'user_id' => $this->id,
+                'email' => $this->email,
+            ]);
+
+            $this->notify(new ResetPassword($token));
+        }
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -37,6 +37,7 @@ class User extends Authenticatable
         'email',
         'password',
         'mfa_preference',
+        'is_active',
     ];
 
     /**
@@ -73,6 +74,7 @@ class User extends Authenticatable
             'dark_mode'         => 'boolean',
             'mfa_preference'    => 'string',
             'mfa_prompted_at'    => 'datetime',
+            'is_active'          => 'boolean',
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Support\MailSettings;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if (Schema::hasTable('settings')) {
+            MailSettings::applyFromDatabase();
+        }
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -3,15 +3,18 @@
 namespace App\Providers;
 
 use App\Actions\Fortify\CreateNewUser;
+use App\Models\User;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -34,6 +37,22 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
         Fortify::redirectUserForTwoFactorAuthenticationUsing(RedirectIfTwoFactorAuthenticatable::class);
+
+        Fortify::authenticateUsing(function (Request $request) {
+            $user = User::query()->where('email', $request->string('email')->toString())->first();
+
+            if (! $user || ! Hash::check($request->string('password')->toString(), $user->password)) {
+                return null;
+            }
+
+            if (! $user->is_active) {
+                throw ValidationException::withMessages([
+                    Fortify::username() => 'This user is disabled. Please contact the system administrator.',
+                ]);
+            }
+
+            return $user;
+        });
 
         RateLimiter::for('login', function (Request $request) {
             $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());

--- a/app/Services/EmailTemplateMailer.php
+++ b/app/Services/EmailTemplateMailer.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EmailTemplate;
+use App\Models\NotificationTrigger;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class EmailTemplateMailer
+{
+    public function sendForEvent(
+        string $eventKey,
+        array $context,
+        ?string $customerRecipient,
+        ?int $daysBefore = null
+    ): bool {
+        $template = $this->resolveTemplate($eventKey, $daysBefore);
+
+        if (! $template) {
+            Log::warning('No email template configured for event.', [
+                'event' => $eventKey,
+                'days_before' => $daysBefore,
+            ]);
+
+            return false;
+        }
+
+        $recipient = $this->resolveRecipient($template, $customerRecipient);
+        if (! $recipient) {
+            Log::warning('Unable to send templated email because recipient is missing.', [
+                'event' => $eventKey,
+                'template_id' => $template->id,
+                'template_slug' => $template->slug,
+            ]);
+
+            return false;
+        }
+
+        [$subject, $body] = $this->renderTemplate($template, $context);
+
+        Mail::raw($body, function ($message) use ($recipient, $subject) {
+            $message->to($recipient)->subject($subject);
+        });
+
+        Log::info('Templated email dispatched.', [
+            'event' => $eventKey,
+            'days_before' => $daysBefore,
+            'template_id' => $template->id,
+            'recipient' => $recipient,
+            'subject' => $subject,
+        ]);
+
+        return true;
+    }
+
+    public function renderTemplate(EmailTemplate $template, array $context): array
+    {
+        $tokens = [];
+
+        foreach (Arr::dot($context) as $key => $value) {
+            $tokens['{{' . $key . '}}'] = is_scalar($value) || $value === null
+                ? (string) ($value ?? '')
+                : json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        return [
+            strtr($template->subject, $tokens),
+            strtr($template->body, $tokens),
+        ];
+    }
+
+    private function resolveTemplate(string $eventKey, ?int $daysBefore = null): ?EmailTemplate
+    {
+        $triggerTemplate = NotificationTrigger::query()
+            ->with('emailTemplate')
+            ->where('event_key', $eventKey)
+            ->when($daysBefore !== null, function ($query) use ($daysBefore) {
+                $query->where(function ($inner) use ($daysBefore) {
+                    $inner->where('days_before', $daysBefore)
+                        ->orWhereNull('days_before');
+                });
+            })
+            ->orderByRaw('CASE WHEN days_before IS NULL THEN 1 ELSE 0 END')
+            ->latest('id')
+            ->first()?->emailTemplate;
+
+        if ($triggerTemplate) {
+            return $triggerTemplate;
+        }
+
+        return EmailTemplate::query()
+            ->where('trigger_event', $eventKey)
+            ->latest('id')
+            ->first();
+    }
+
+    private function resolveRecipient(EmailTemplate $template, ?string $customerRecipient): ?string
+    {
+        if ($template->audience === 'admin') {
+            return $template->admin_recipient_email;
+        }
+
+        return $customerRecipient;
+    }
+}

--- a/app/Support/MailSettings.php
+++ b/app/Support/MailSettings.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Setting;
+
+class MailSettings
+{
+    public static function apply(array $smtp): void
+    {
+        config([
+            'mail.default' => 'smtp',
+            'mail.mailers.smtp.transport' => 'smtp',
+            'mail.mailers.smtp.host' => $smtp['host'],
+            'mail.mailers.smtp.port' => (int) $smtp['port'],
+            'mail.mailers.smtp.username' => $smtp['username'] ?? null,
+            'mail.mailers.smtp.password' => $smtp['password'] ?? null,
+            'mail.mailers.smtp.encryption' => $smtp['encryption'] ?? null,
+            'mail.from.address' => $smtp['from'],
+            'mail.from.name' => $smtp['from_name'] ?? config('app.name', 'DomainDash'),
+        ]);
+    }
+
+    public static function applyFromDatabase(): bool
+    {
+        $smtp = Setting::get('smtp', []);
+
+        if (! self::isConfigured($smtp)) {
+            return false;
+        }
+
+        self::apply($smtp);
+
+        return true;
+    }
+
+    public static function isConfigured(array $smtp): bool
+    {
+        return ! empty($smtp['host'])
+            && ! empty($smtp['port'])
+            && ! empty($smtp['from']);
+    }
+}

--- a/database/migrations/2026_04_18_000100_add_is_active_to_users_table.php
+++ b/database/migrations/2026_04_18_000100_add_is_active_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('mfa_preference');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -9,7 +9,7 @@
             </header>
 
             <div class="dd-account-grid">
-                <form id="user-create-form" method="POST" action="{{ route('admin.users.store') }}">
+                <form id="user-create-form" method="POST" action="{{ route('admin.users.store') }}" class="dd-account-main-form">
                     @csrf
 
                     <h2 class="dd-account-section-title">Personal Information</h2>
@@ -82,7 +82,7 @@
                                     @forelse($clients as $client)
                                         @php $label = $client->business_name ?? $client->name ?? ('Client #'.$client->id); @endphp
                                         <label class="client-picker-item" data-label="{{ Str::lower($label) }}">
-                                            <input type="checkbox" name="client_ids[]" value="{{ $client->id }}" {{ in_array($client->id, old('client_ids', [])) ? 'checked' : '' }}>
+                                            <input class="client-picker-checkbox" type="checkbox" name="client_ids[]" value="{{ $client->id }}" {{ in_array($client->id, old('client_ids', [])) ? 'checked' : '' }}>
                                             {{ $label }}
                                         </label>
                                     @empty
@@ -270,6 +270,24 @@
             gap: 14px !important;
         }
 
+        .dd-account-main-form {
+            display: grid !important;
+            gap: 14px !important;
+        }
+
+        .dd-account-section-title {
+            margin: 0 0 4px 0 !important;
+        }
+
+        .dd-account-subtitle {
+            margin: 6px 0 2px !important;
+        }
+
+        .dd-account-field {
+            display: grid !important;
+            gap: 6px !important;
+        }
+
         .dd-account-input,
         .dd-account-field select {
             width: 100% !important;
@@ -302,6 +320,53 @@
 
         .client-picker-arrow {
             display: none !important;
+        }
+
+        .client-picker-list {
+            display: grid !important;
+            gap: 8px !important;
+            max-height: 220px !important;
+            overflow-y: auto !important;
+            padding-right: 2px !important;
+        }
+
+        .client-picker-item {
+            display: flex !important;
+            align-items: center !important;
+            gap: 10px !important;
+            padding: 8px 10px !important;
+            border: 1px solid var(--border-subtle) !important;
+            border-radius: 10px !important;
+            background: color-mix(in srgb, var(--bg) 86%, var(--primary) 14%) !important;
+            line-height: 1.3 !important;
+        }
+
+        .client-picker-checkbox {
+            appearance: none !important;
+            width: 16px !important;
+            height: 16px !important;
+            border-radius: 5px !important;
+            border: 1px solid var(--border-subtle) !important;
+            background: color-mix(in srgb, var(--bg) 84%, var(--primary) 16%) !important;
+            display: inline-grid !important;
+            place-content: center !important;
+            flex-shrink: 0 !important;
+            margin: 0 !important;
+        }
+
+        .client-picker-checkbox:checked {
+            background: var(--accent) !important;
+            border-color: var(--accent) !important;
+        }
+
+        .client-picker-checkbox:checked::before {
+            content: "";
+            width: 4px;
+            height: 8px;
+            border: solid #ffffff;
+            border-width: 0 2px 2px 0;
+            transform: rotate(45deg);
+            margin-top: -1px;
         }
 
 

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -48,13 +48,13 @@
                     </div>
 
 
-                    <div class="dd-account-field" style="margin-bottom:12px;">
-                        <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
-                            <input type="hidden" name="is_active" value="0">
-                            <input type="checkbox" name="is_active" value="1" {{ old('is_active', 1) ? 'checked' : '' }}>
+                    <div class="dd-account-field dd-account-toggle-field">
+                        <input type="hidden" name="is_active" value="0">
+                        <label class="dd-account-checkbox-row">
+                            <input class="dd-account-checkbox" type="checkbox" name="is_active" value="1" {{ old('is_active', 1) ? 'checked' : '' }}>
                             <span>Enable user account</span>
                         </label>
-                        <small style="color:var(--text-muted);display:block;margin-top:6px;">Disabled users cannot log in.</small>
+                        <small class="dd-account-help-text">Disabled users cannot log in.</small>
                         @error('is_active')<div style="color:#dc2626;font-size:12px;margin-top:4px;">{{ $message }}</div>@enderror
                     </div>
 
@@ -302,6 +302,58 @@
 
         .client-picker-arrow {
             display: none !important;
+        }
+
+
+        .dd-account-toggle-field {
+            margin-bottom: 16px !important;
+            padding: 12px 14px !important;
+            border: 1px solid var(--border-subtle) !important;
+            border-radius: 12px !important;
+            background: color-mix(in srgb, var(--bg) 88%, var(--primary) 12%) !important;
+        }
+
+        .dd-account-checkbox-row {
+            display: flex !important;
+            align-items: center !important;
+            gap: 10px !important;
+            margin: 0 !important;
+            cursor: pointer !important;
+            font-weight: 600 !important;
+        }
+
+        .dd-account-checkbox {
+            appearance: none !important;
+            width: 18px !important;
+            height: 18px !important;
+            border-radius: 6px !important;
+            border: 1px solid var(--border-subtle) !important;
+            background: color-mix(in srgb, var(--bg) 84%, var(--primary) 16%) !important;
+            display: inline-grid !important;
+            place-content: center !important;
+            flex-shrink: 0 !important;
+        }
+
+        .dd-account-checkbox:checked {
+            background: var(--accent) !important;
+            border-color: var(--accent) !important;
+        }
+
+        .dd-account-checkbox:checked::before {
+            content: "";
+            width: 5px;
+            height: 9px;
+            border: solid #ffffff;
+            border-width: 0 2px 2px 0;
+            transform: rotate(45deg);
+            margin-top: -1px;
+        }
+
+        .dd-account-help-text {
+            color: var(--text-muted) !important;
+            display: block !important;
+            margin-top: 8px !important;
+            line-height: 1.35 !important;
         }
 
         .dd-account-header h1,

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -47,6 +47,17 @@
                         @error('role')<div style="color:#dc2626;font-size:12px;margin-top:4px;">{{ $message }}</div>@enderror
                     </div>
 
+
+                    <div class="dd-account-field" style="margin-bottom:12px;">
+                        <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                            <input type="hidden" name="is_active" value="0">
+                            <input type="checkbox" name="is_active" value="1" {{ old('is_active', 1) ? 'checked' : '' }}>
+                            <span>Enable user account</span>
+                        </label>
+                        <small style="color:var(--text-muted);display:block;margin-top:6px;">Disabled users cannot log in.</small>
+                        @error('is_active')<div style="color:#dc2626;font-size:12px;margin-top:4px;">{{ $message }}</div>@enderror
+                    </div>
+
                     <div class="dd-account-field">
                         <label for="mfa_preference">MFA Policy</label>
                         <select class="dd-account-input" id="mfa_preference" name="mfa_preference" required>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -48,6 +48,17 @@
                         @error('role')<div style="color:#dc2626;font-size:12px;margin-top:4px;">{{ $message }}</div>@enderror
                     </div>
 
+
+                    <div class="dd-account-field" style="margin-bottom:12px;">
+                        <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
+                            <input type="hidden" name="is_active" value="0">
+                            <input type="checkbox" name="is_active" value="1" {{ old('is_active', (int) $user->is_active) ? 'checked' : '' }}>
+                            <span>Enable user account</span>
+                        </label>
+                        <small style="color:var(--text-muted);display:block;margin-top:6px;">If disabled, this user cannot log in and will be told to contact the system administrator.</small>
+                        @error('is_active')<div style="color:#dc2626;font-size:12px;margin-top:4px;">{{ $message }}</div>@enderror
+                    </div>
+
                     <div class="dd-account-field">
                         <label for="mfa_preference">MFA Policy</label>
                         <select class="dd-account-input" id="mfa_preference" name="mfa_preference" required>
@@ -99,6 +110,15 @@
                         <li>Reset MFA if needed.</li>
                     </ul>
                     <button type="button" class="dd-account-password-btn" id="openPasswordControls">Reset Password</button>
+
+                    <hr style="margin:14px 0;border-color:var(--border-subtle);">
+                    <h3 style="margin-top:0;">Danger Zone</h3>
+                    <p style="font-size:13px;color:var(--text-muted);">Delete this user account permanently.</p>
+                    <form method="POST" action="{{ route('admin.users.destroy', $user) }}" onsubmit="return confirm('Delete this user account permanently?');">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="dd-account-secondary" style="border-color:var(--danger-text);color:var(--danger-text);">Delete User</button>
+                    </form>
                 </aside>
             </div>
         </section>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -9,7 +9,7 @@
             </header>
 
             <div class="dd-account-grid">
-                <form method="POST" action="{{ route('admin.users.update', $user) }}">
+                <form method="POST" action="{{ route('admin.users.update', $user) }}" class="dd-account-main-form">
                     @csrf
                     @method('PUT')
 
@@ -83,7 +83,7 @@
                                     @forelse($clients as $client)
                                         @php $label = $client->business_name ?? $client->name ?? ('Client #'.$client->id); @endphp
                                         <label class="client-picker-item" data-label="{{ Str::lower($label) }}">
-                                            <input type="checkbox" name="client_ids[]" value="{{ $client->id }}" {{ in_array($client->id, old('client_ids', $currentClientIds)) ? 'checked' : '' }}>
+                                            <input class="client-picker-checkbox" type="checkbox" name="client_ids[]" value="{{ $client->id }}" {{ in_array($client->id, old('client_ids', $currentClientIds)) ? 'checked' : '' }}>
                                             {{ $label }}
                                         </label>
                                     @empty
@@ -297,6 +297,24 @@
             gap: 14px !important;
         }
 
+        .dd-account-main-form {
+            display: grid !important;
+            gap: 14px !important;
+        }
+
+        .dd-account-section-title {
+            margin: 0 0 4px 0 !important;
+        }
+
+        .dd-account-subtitle {
+            margin: 6px 0 2px !important;
+        }
+
+        .dd-account-field {
+            display: grid !important;
+            gap: 6px !important;
+        }
+
         .dd-account-input,
         .dd-account-field select {
             width: 100% !important;
@@ -329,6 +347,53 @@
 
         .client-picker-arrow {
             display: none !important;
+        }
+
+        .client-picker-list {
+            display: grid !important;
+            gap: 8px !important;
+            max-height: 220px !important;
+            overflow-y: auto !important;
+            padding-right: 2px !important;
+        }
+
+        .client-picker-item {
+            display: flex !important;
+            align-items: center !important;
+            gap: 10px !important;
+            padding: 8px 10px !important;
+            border: 1px solid var(--border-subtle) !important;
+            border-radius: 10px !important;
+            background: color-mix(in srgb, var(--bg) 86%, var(--primary) 14%) !important;
+            line-height: 1.3 !important;
+        }
+
+        .client-picker-checkbox {
+            appearance: none !important;
+            width: 16px !important;
+            height: 16px !important;
+            border-radius: 5px !important;
+            border: 1px solid var(--border-subtle) !important;
+            background: color-mix(in srgb, var(--bg) 84%, var(--primary) 16%) !important;
+            display: inline-grid !important;
+            place-content: center !important;
+            flex-shrink: 0 !important;
+            margin: 0 !important;
+        }
+
+        .client-picker-checkbox:checked {
+            background: var(--accent) !important;
+            border-color: var(--accent) !important;
+        }
+
+        .client-picker-checkbox:checked::before {
+            content: "";
+            width: 4px;
+            height: 8px;
+            border: solid #ffffff;
+            border-width: 0 2px 2px 0;
+            transform: rotate(45deg);
+            margin-top: -1px;
         }
 
 

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -49,13 +49,13 @@
                     </div>
 
 
-                    <div class="dd-account-field" style="margin-bottom:12px;">
-                        <label style="display:flex;align-items:center;gap:10px;cursor:pointer;">
-                            <input type="hidden" name="is_active" value="0">
-                            <input type="checkbox" name="is_active" value="1" {{ old('is_active', (int) $user->is_active) ? 'checked' : '' }}>
+                    <div class="dd-account-field dd-account-toggle-field">
+                        <input type="hidden" name="is_active" value="0">
+                        <label class="dd-account-checkbox-row">
+                            <input class="dd-account-checkbox" type="checkbox" name="is_active" value="1" {{ old('is_active', (int) $user->is_active) ? 'checked' : '' }}>
                             <span>Enable user account</span>
                         </label>
-                        <small style="color:var(--text-muted);display:block;margin-top:6px;">If disabled, this user cannot log in and will be told to contact the system administrator.</small>
+                        <small class="dd-account-help-text">If disabled, this user cannot log in and will be told to contact the system administrator.</small>
                         @error('is_active')<div style="color:#dc2626;font-size:12px;margin-top:4px;">{{ $message }}</div>@enderror
                     </div>
 
@@ -329,6 +329,58 @@
 
         .client-picker-arrow {
             display: none !important;
+        }
+
+
+        .dd-account-toggle-field {
+            margin-bottom: 16px !important;
+            padding: 12px 14px !important;
+            border: 1px solid var(--border-subtle) !important;
+            border-radius: 12px !important;
+            background: color-mix(in srgb, var(--bg) 88%, var(--primary) 12%) !important;
+        }
+
+        .dd-account-checkbox-row {
+            display: flex !important;
+            align-items: center !important;
+            gap: 10px !important;
+            margin: 0 !important;
+            cursor: pointer !important;
+            font-weight: 600 !important;
+        }
+
+        .dd-account-checkbox {
+            appearance: none !important;
+            width: 18px !important;
+            height: 18px !important;
+            border-radius: 6px !important;
+            border: 1px solid var(--border-subtle) !important;
+            background: color-mix(in srgb, var(--bg) 84%, var(--primary) 16%) !important;
+            display: inline-grid !important;
+            place-content: center !important;
+            flex-shrink: 0 !important;
+        }
+
+        .dd-account-checkbox:checked {
+            background: var(--accent) !important;
+            border-color: var(--accent) !important;
+        }
+
+        .dd-account-checkbox:checked::before {
+            content: "";
+            width: 5px;
+            height: 9px;
+            border: solid #ffffff;
+            border-width: 0 2px 2px 0;
+            transform: rotate(45deg);
+            margin-top: -1px;
+        }
+
+        .dd-account-help-text {
+            color: var(--text-muted) !important;
+            display: block !important;
+            margin-top: 8px !important;
+            line-height: 1.35 !important;
         }
 
         .dd-account-header h1,

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -33,6 +33,7 @@
                     <th>Email</th>
                     <th>Role</th>
                     <th>Client Organisation</th>
+                    <th>Status</th>
                     <th>MFA</th>
                     <th style="width:260px;">Actions</th>
                 </tr>
@@ -53,6 +54,9 @@
                             {{ $user->clients->pluck('business_name')->implode(', ')
                                 ?: $user->clients->pluck('name')->implode(', ')
                                 ?: '—' }}
+                        </td>
+                        <td>
+                            <span class="{{ $user->is_active ? 'dd-status-success' : 'dd-status-muted' }}">{{ $user->is_active ? 'Enabled' : 'Disabled' }}</span>
                         </td>
                         <td>
                             {{ ucfirst($user->mfa_preference ?? 'enabled') }} / {{ $user->two_factor_confirmed_at ? 'Configured' : 'Not configured' }}
@@ -93,6 +97,19 @@
                                             title="Impersonate user"
                                             style="display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:999px;border:1px solid var(--dd-border);background:color-mix(in srgb, var(--dd-accent) 15%, transparent);">
                                         👤
+                                    </button>
+                                </form>
+
+                                {{-- Delete user (trash icon) --}}
+                                <form method="POST"
+                                      action="{{ route('admin.users.destroy', $user) }}"
+                                      onsubmit="return confirm('Delete this user account permanently?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit"
+                                            title="Delete user"
+                                            style="display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:999px;border:1px solid var(--dd-border);background:color-mix(in srgb, var(--dd-danger) 18%, transparent);">
+                                        🗑️
                                     </button>
                                 </form>
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -166,6 +166,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::post('/users', [UsersController::class, 'store'])->name('admin.users.store');
         Route::get('/users/{user}/edit', [UsersController::class, 'edit'])->name('admin.users.edit');
         Route::put('/users/{user}', [UsersController::class, 'update'])->name('admin.users.update');
+        Route::delete('/users/{user}', [UsersController::class, 'destroy'])->name('admin.users.destroy');
         Route::get('/users/{user}/password', [UsersController::class, 'editPassword'])->name('admin.users.password.edit');
         Route::put('/users/{user}/password', [UsersController::class, 'updatePassword'])->name('admin.users.password.update');
         Route::post('/users/{user}/password-link', [UsersController::class, 'sendPasswordLink'])->name('admin.users.password.link');


### PR DESCRIPTION
### Motivation
- The system had templates and triggers in the database but key workflows (password reset and expiry notifications) were not wired to actually dispatch templated emails, so users saw no mail in the logs.

### Description
- Add a new service `app/Services/EmailTemplateMailer.php` that resolves the template for an event/trigger (honouring `days_before`), renders placeholder tokens from a context, sends mail via Laravel `Mail`, and logs results.
- Wire password reset delivery through `User::sendPasswordResetNotification()` in `app/Models/User.php` to use the `password_reset` template with a fallback to Laravel's default `ResetPassword` notification if templated delivery fails.
- Implement real delivery in the expiry job `app/Console/Commands/NotifyExpiringCommand.php` so domain and SSL expiry reminders call the new mailer and use per-day cache locks to avoid duplicate hourly sends.
- Add defensive logging and recipient checks so missing templates or recipients are reported and failover behavior is explicit.

### Testing
- Syntax checks passed for `app/Models/User.php`, `app/Services/EmailTemplateMailer.php`, and `app/Console/Commands/NotifyExpiringCommand.php` via `php -l`, all with no syntax errors.  
- Running the project's PHPUnit feature tests via `php artisan test` could not be completed in this environment because `vendor/autoload.php` is missing, so tests were not executed here (test runner failed to bootstrap).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1d8f03c908330bd341f5d8a436bb0)