### PR TITLE
Add configurable common TLDs and prioritize them in purchase dropdown

### DIFF
--- a/app/Console/Commands/PruneAuditLogsCommand.php
+++ b/app/Console/Commands/PruneAuditLogsCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Setting;
+use App\Services\AuditLogger;
+use Illuminate\Console\Command;
+
+class PruneAuditLogsCommand extends Command
+{
+    protected $signature = 'domaindash:audit-prune';
+
+    protected $description = 'Prunes audit logs based on configured retention settings';
+
+    public function handle(): int
+    {
+        $auditSettings = Setting::get('audit', ['retention_days' => 90]);
+        $retentionDays = (int) ($auditSettings['retention_days'] ?? 90);
+
+        $deleted = AuditLogger::pruneOlderThanDays($retentionDays);
+        $this->info("Pruned {$deleted} audit log row(s) using {$retentionDays}-day retention.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RunSyncTaskCommand.php
+++ b/app/Console/Commands/RunSyncTaskCommand.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\ServicesController;
 use App\Http\Controllers\Admin\SyncController;
 use App\Models\Client;
 use App\Models\Domain;
+use App\Services\AuditLogger;
 use App\Services\Synergy\SynergyWholesaleClient;
 use Illuminate\Console\Command;
 use Illuminate\Http\Request;
@@ -32,6 +33,11 @@ class RunSyncTaskCommand extends Command
 
     private function runSynergyDomainSync(): int
     {
+        AuditLogger::logSystem('sync.started', 'Scheduled Synergy domain sync started.', [
+            'service' => 'synergy',
+            'function' => 'sync-domains',
+        ]);
+
         $synergy = app(SynergyWholesaleClient::class);
 
         $page = 1;
@@ -45,6 +51,12 @@ class RunSyncTaskCommand extends Command
                 $error = $response['errorMessage'] ?? 'Unknown error from Synergy listDomains';
                 $this->error('Synergy domain sync failed: ' . $error);
                 Log::error('Scheduled Synergy domain sync failed', ['error' => $error, 'response' => $response]);
+                AuditLogger::logSystem('sync.failed', 'Scheduled Synergy domain sync failed.', [
+                    'service' => 'synergy',
+                    'function' => 'sync-domains',
+                ], [
+                    'new_values' => ['error' => $error],
+                ]);
 
                 return self::FAILURE;
             }
@@ -84,12 +96,23 @@ class RunSyncTaskCommand extends Command
         } while ($hasMore && $page < 1000);
 
         $this->info("Synergy domain sync complete. Imported/updated {$imported} domain records.");
+        AuditLogger::logSystem('sync.completed', "Scheduled Synergy domain sync completed ({$imported} records).", [
+            'service' => 'synergy',
+            'function' => 'sync-domains',
+        ], [
+            'new_values' => ['imported' => $imported],
+        ]);
 
         return self::SUCCESS;
     }
 
     private function runHaloDomainSync(): int
     {
+        AuditLogger::logSystem('sync.started', 'Scheduled Halo domain sync started.', [
+            'service' => 'halo',
+            'function' => 'sync-halo-domains',
+        ]);
+
         $domainIds = Domain::whereNotNull('client_id')->pluck('id')->all();
 
         if (empty($domainIds)) {
@@ -104,21 +127,42 @@ class RunSyncTaskCommand extends Command
         if (!empty($payload['error'])) {
             $this->error('Halo domain sync failed: ' . $payload['error']);
             Log::error('Scheduled halo domain sync failed', $payload);
+            AuditLogger::logSystem('sync.failed', 'Scheduled Halo domain sync failed.', [
+                'service' => 'halo',
+                'function' => 'sync-halo-domains',
+            ], [
+                'new_values' => ['error' => $payload['error']],
+            ]);
             return self::FAILURE;
         }
 
         $this->info('Halo domain sync complete. Synced: ' . ($payload['synced_count'] ?? 0));
+        AuditLogger::logSystem('sync.completed', 'Scheduled Halo domain sync completed.', [
+            'service' => 'halo',
+            'function' => 'sync-halo-domains',
+        ], [
+            'new_values' => ['synced_count' => $payload['synced_count'] ?? 0],
+        ]);
 
         return self::SUCCESS;
     }
 
     private function runHostingServiceSync(): int
     {
+        AuditLogger::logSystem('sync.started', 'Scheduled hosting service sync started.', [
+            'service' => 'synergy',
+            'function' => 'sync-hosting-services',
+        ]);
+
         $controller = app(ServicesController::class);
         $synergy = app(SynergyWholesaleClient::class);
 
         $controller->sync(Request::create('/admin/services/hosting/sync', 'POST'), $synergy);
         $this->info('Hosting service sync triggered successfully.');
+        AuditLogger::logSystem('sync.completed', 'Scheduled hosting service sync completed.', [
+            'service' => 'synergy',
+            'function' => 'sync-hosting-services',
+        ]);
 
         return self::SUCCESS;
     }
@@ -151,6 +195,11 @@ class RunSyncTaskCommand extends Command
 
     private function runItGlueSync(): int
     {
+        AuditLogger::logSystem('sync.started', 'Scheduled IT Glue sync started.', [
+            'service' => 'itglue',
+            'function' => 'sync-itglue',
+        ]);
+
         $items = Domain::query()
             ->whereHas('client', function ($query) {
                 $query->whereNotNull('itglue_org_id');
@@ -174,10 +223,22 @@ class RunSyncTaskCommand extends Command
         if (!empty($payload['error'])) {
             $this->error('IT Glue sync failed: ' . $payload['error']);
             Log::error('Scheduled IT Glue sync failed', $payload);
+            AuditLogger::logSystem('sync.failed', 'Scheduled IT Glue sync failed.', [
+                'service' => 'itglue',
+                'function' => 'sync-itglue',
+            ], [
+                'new_values' => ['error' => $payload['error']],
+            ]);
             return self::FAILURE;
         }
 
         $this->info('IT Glue configuration sync complete. Synced: ' . ($payload['synced_count'] ?? 0));
+        AuditLogger::logSystem('sync.completed', 'Scheduled IT Glue sync completed.', [
+            'service' => 'itglue',
+            'function' => 'sync-itglue',
+        ], [
+            'new_values' => ['synced_count' => $payload['synced_count'] ?? 0],
+        ]);
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/RunSyncTaskCommand.php
+++ b/app/Console/Commands/RunSyncTaskCommand.php
@@ -22,12 +22,70 @@ class RunSyncTaskCommand extends Command
         $task = $this->argument('task');
 
         return match ($task) {
-            'sync-domains' => $this->runHaloDomainSync(),
+            'sync-domains' => $this->runSynergyDomainSync(),
             'sync-hosting-services' => $this->runHostingServiceSync(),
             'sync-halo-assets' => $this->runHaloAssetSync(),
             'sync-itglue' => $this->runItGlueSync(),
             default => self::INVALID,
         };
+    }
+
+    private function runSynergyDomainSync(): int
+    {
+        $synergy = app(SynergyWholesaleClient::class);
+
+        $page = 1;
+        $limit = 500;
+        $imported = 0;
+
+        do {
+            $response = $synergy->listDomains($page, $limit);
+
+            if (($response['status'] ?? null) !== 'OK') {
+                $error = $response['errorMessage'] ?? 'Unknown error from Synergy listDomains';
+                $this->error('Synergy domain sync failed: ' . $error);
+                Log::error('Scheduled Synergy domain sync failed', ['error' => $error, 'response' => $response]);
+
+                return self::FAILURE;
+            }
+
+            $list = $response['domainList'] ?? [];
+
+            foreach ($list as $entry) {
+                if (($entry->status ?? '') === 'ERR_DOMAIN_NOT_FOUND') {
+                    continue;
+                }
+
+                $name = $entry->domainName ?? null;
+                if (! $name) {
+                    continue;
+                }
+
+                Domain::updateOrCreate(
+                    ['name' => $name],
+                    [
+                        'status' => $entry->domainStatus ?? $entry->domain_status ?? null,
+                        'expiry_date' => isset($entry->domain_expiry) ? substr($entry->domain_expiry, 0, 10) : null,
+                        'name_servers' => $entry->nameServers ?? [],
+                        'dns_config' => $entry->dnsConfig ?? null,
+                        'auto_renew' => isset($entry->autoRenew)
+                            ? in_array(strtolower((string) $entry->autoRenew), ['on', 'true', '1'], true)
+                            : null,
+                        'transfer_status' => $entry->transfer_status ?? null,
+                    ]
+                );
+
+                $imported++;
+            }
+
+            $received = count($list);
+            $page++;
+            $hasMore = $received >= $limit;
+        } while ($hasMore && $page < 1000);
+
+        $this->info("Synergy domain sync complete. Imported/updated {$imported} domain records.");
+
+        return self::SUCCESS;
     }
 
     private function runHaloDomainSync(): int

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,6 +22,9 @@ class Kernel extends ConsoleKernel
         // Backup
         $schedule->command('domaindash:backup-run')->dailyAt('03:00');
 
+        // Audit retention housekeeping
+        $schedule->command('domaindash:audit-prune')->dailyAt('03:30');
+
         // Expiry notifications
         $schedule->command('domaindash:notify-expiring')->hourly();
     }

--- a/app/Http/Controllers/Admin/AuditLogController.php
+++ b/app/Http/Controllers/Admin/AuditLogController.php
@@ -44,9 +44,8 @@ class AuditLogController extends Controller
 
         if ($filters['function'] !== '') {
             $query->where(function ($builder) use ($filters) {
-                $builder->where('auditable_type', 'like', '%'.$filters['function'].'%')
-                    ->orWhere('description', 'like', '%'.$filters['function'].'%')
-                    ->orWhere('context', 'like', '%'.$filters['function'].'%');
+                $builder->where('context->function', $filters['function'])
+                    ->orWhere('description', 'like', '%'.$filters['function'].'%');
             });
         }
 
@@ -66,6 +65,15 @@ class AuditLogController extends Controller
 
         $logs = $query->paginate(50)->withQueryString();
         $actionOptions = AuditLog::query()->select('action')->distinct()->orderBy('action')->pluck('action');
+        $functionOptions = AuditLog::query()
+            ->whereNotNull('context')
+            ->get(['context'])
+            ->pluck('context')
+            ->map(fn ($context) => $context['function'] ?? null)
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
         $users = User::query()->orderBy('name')->get(['id', 'name', 'email']);
         $clients = Client::query()->orderBy('business_name')->get(['id', 'business_name']);
 
@@ -81,6 +89,7 @@ class AuditLogController extends Controller
             'logs',
             'filters',
             'actionOptions',
+            'functionOptions',
             'users',
             'clients',
             'retentionDays',

--- a/app/Http/Controllers/Admin/AuditLogController.php
+++ b/app/Http/Controllers/Admin/AuditLogController.php
@@ -51,8 +51,8 @@ class AuditLogController extends Controller
 
         if ($filters['service'] !== '') {
             $query->where(function ($builder) use ($filters) {
-                $builder->where('description', 'like', '%'.$filters['service'].'%')
-                    ->orWhere('context', 'like', '%'.$filters['service'].'%');
+                $builder->where('context->service', $filters['service'])
+                    ->orWhere('description', 'like', '%'.$filters['service'].'%');
             });
         }
 
@@ -74,6 +74,15 @@ class AuditLogController extends Controller
             ->unique()
             ->sort()
             ->values();
+        $serviceOptions = AuditLog::query()
+            ->whereNotNull('context')
+            ->get(['context'])
+            ->pluck('context')
+            ->map(fn ($context) => $context['service'] ?? null)
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values();
         $users = User::query()->orderBy('name')->get(['id', 'name', 'email']);
         $clients = Client::query()->orderBy('business_name')->get(['id', 'business_name']);
 
@@ -90,6 +99,7 @@ class AuditLogController extends Controller
             'filters',
             'actionOptions',
             'functionOptions',
+            'serviceOptions',
             'users',
             'clients',
             'retentionDays',

--- a/app/Http/Controllers/Admin/AuditLogController.php
+++ b/app/Http/Controllers/Admin/AuditLogController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Models\Client;
+use App\Models\Setting;
+use App\Models\User;
+use App\Services\AuditLogger;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class AuditLogController extends Controller
+{
+    public function index(Request $request)
+    {
+        $filters = [
+            'action' => (string) $request->query('action', ''),
+            'user_id' => (string) $request->query('user_id', ''),
+            'client_id' => (string) $request->query('client_id', ''),
+            'function' => trim((string) $request->query('function', '')),
+            'service' => trim((string) $request->query('service', '')),
+            'failed_only' => (bool) $request->boolean('failed_only'),
+        ];
+
+        $query = AuditLog::query()->with('user')->latest();
+
+        if ($filters['action'] !== '') {
+            $query->where('action', $filters['action']);
+        }
+
+        if ($filters['user_id'] !== '') {
+            $query->where('user_id', $filters['user_id']);
+        }
+
+        if ($filters['client_id'] !== '') {
+            $query->where(function ($builder) use ($filters) {
+                $builder->where('context->client_id', (int) $filters['client_id'])
+                    ->orWhere('old_values->client_id', (int) $filters['client_id'])
+                    ->orWhere('new_values->client_id', (int) $filters['client_id']);
+            });
+        }
+
+        if ($filters['function'] !== '') {
+            $query->where(function ($builder) use ($filters) {
+                $builder->where('auditable_type', 'like', '%'.$filters['function'].'%')
+                    ->orWhere('description', 'like', '%'.$filters['function'].'%')
+                    ->orWhere('context', 'like', '%'.$filters['function'].'%');
+            });
+        }
+
+        if ($filters['service'] !== '') {
+            $query->where(function ($builder) use ($filters) {
+                $builder->where('description', 'like', '%'.$filters['service'].'%')
+                    ->orWhere('context', 'like', '%'.$filters['service'].'%');
+            });
+        }
+
+        if ($filters['failed_only']) {
+            $query->where(function ($builder) {
+                $builder->where('action', 'like', '%failed%')
+                    ->orWhere('description', 'like', '%failed%');
+            });
+        }
+
+        $logs = $query->paginate(50)->withQueryString();
+        $actionOptions = AuditLog::query()->select('action')->distinct()->orderBy('action')->pluck('action');
+        $users = User::query()->orderBy('name')->get(['id', 'name', 'email']);
+        $clients = Client::query()->orderBy('business_name')->get(['id', 'business_name']);
+
+        $auditSettings = Setting::get('audit', [
+            'retention_days' => 90,
+        ]);
+        $retentionDays = (int) ($auditSettings['retention_days'] ?? 90);
+
+        $dbBytes = $this->estimateAuditDatabaseSizeBytes();
+        $logFileBytes = $this->logFileSizeBytes();
+
+        return view('admin.audit.index', compact(
+            'logs',
+            'filters',
+            'actionOptions',
+            'users',
+            'clients',
+            'retentionDays',
+            'dbBytes',
+            'logFileBytes'
+        ));
+    }
+
+    public function updateRetention(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'retention_days' => 'required|integer|min:1|max:3650',
+            'prune_now' => 'nullable|boolean',
+        ]);
+
+        Setting::put('audit', [
+            'retention_days' => (int) $validated['retention_days'],
+        ]);
+
+        $deleted = 0;
+        if ($request->boolean('prune_now')) {
+            $deleted = AuditLogger::pruneOlderThanDays((int) $validated['retention_days']);
+        }
+
+        return back()->with('status', $deleted > 0
+            ? "Audit retention saved. Pruned {$deleted} older log entries."
+            : 'Audit retention saved.');
+    }
+
+    private function estimateAuditDatabaseSizeBytes(): int
+    {
+        return (int) AuditLog::query()->get()->reduce(function (int $carry, AuditLog $log): int {
+            $row = json_encode([
+                $log->id,
+                $log->user_id,
+                $log->user_email,
+                $log->action,
+                $log->auditable_type,
+                $log->auditable_id,
+                $log->description,
+                $log->old_values,
+                $log->new_values,
+                $log->context,
+                $log->ip_address,
+                $log->user_agent,
+                $log->created_at,
+            ]);
+
+            return $carry + strlen((string) $row);
+        }, 0);
+    }
+
+    private function logFileSizeBytes(): int
+    {
+        $path = storage_path('logs/laravel.log');
+
+        return is_file($path) ? (int) filesize($path) : 0;
+    }
+}

--- a/app/Http/Controllers/Admin/DomainController.php
+++ b/app/Http/Controllers/Admin/DomainController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Domain;
 use App\Models\Client;
 use Illuminate\Http\Request;
+use App\Services\AuditLogger;
 use App\Services\Synergy\SynergyWholesaleClient;
 use App\Support\WhoisFormatter;
 
@@ -111,6 +112,11 @@ class DomainController extends Controller
         $domain->client_id = $data['client_id'] ?: null;
         $domain->save();
 
+        AuditLogger::logAction('domain.assign-client', $domain, "Updated client assignment for {$domain->name}.", [
+            'new_values' => ['client_id' => $domain->client_id],
+            'context' => ['service' => 'domains', 'function' => 'assign-client', 'client_id' => $domain->client_id],
+        ]);
+
         return back()->with('status', 'Client assignment updated for '.$domain->name);
     }
 
@@ -147,6 +153,12 @@ public function authCode(Domain $domain, SynergyWholesaleClient $synergy)
         if (($response['status'] ?? null) !== 'OK') {
             // If Synergy returned an error, show it to the admin
             $msg = $response['errorMessage'] ?? 'Unknown error from Synergy listDomains';
+            AuditLogger::logSystem('sync.failed', 'Manual domain bulk sync failed.', [
+                'service' => 'synergy',
+                'function' => 'domains.bulk-sync',
+            ], [
+                'new_values' => ['error' => $msg],
+            ]);
             return back()->with('status', 'Bulk sync failed: ' . $msg);
         }
 
@@ -192,6 +204,13 @@ public function authCode(Domain $domain, SynergyWholesaleClient $synergy)
 
     } while ($hasMore && $page < 1000); // hard safety cap
 
+    AuditLogger::logSystem('sync.completed', "Manual domain bulk sync completed ({$imported} domains).", [
+        'service' => 'synergy',
+        'function' => 'domains.bulk-sync',
+    ], [
+        'new_values' => ['imported' => $imported],
+    ]);
+
     return back()->with('status', "Bulk sync complete. Imported/updated {$imported} domains.");
 }
 
@@ -207,6 +226,10 @@ public function authCode(Domain $domain, SynergyWholesaleClient $synergy)
     {
         $request->validate(['years'=>'required|integer|min:1|max:10']);
         $res = $synergy->renewDomain($domain->name, (int)$request->years);
+        AuditLogger::logAction('domain.renew', $domain, "Renewal requested for {$domain->name}.", [
+            'new_values' => ['years' => (int) $request->years, 'response' => $res],
+            'context' => ['service' => 'domains', 'function' => 'renew', 'client_id' => $domain->client_id],
+        ]);
         return back()->with('status','Renewal requested')->with('renewal', $res);
     }
 
@@ -229,6 +252,12 @@ public function authCode(Domain $domain, SynergyWholesaleClient $synergy)
             'idProtect'=>'required',
         ]);
         $res = $synergy->transferDomain($payload);
+        AuditLogger::logSystem('domain.transfer', "Domain transfer requested for {$payload['domainName']}.", [
+            'service' => 'domains',
+            'function' => 'transfer',
+        ], [
+            'new_values' => ['domain' => $payload['domainName'], 'response' => $res],
+        ]);
         return back()->with('status','Transfer initiated')->with('transfer', $res);
     }
     

--- a/app/Http/Controllers/Admin/DomainPricingController.php
+++ b/app/Http/Controllers/Admin/DomainPricingController.php
@@ -101,6 +101,19 @@ class DomainPricingController extends Controller
         return back()->with('status', "Updated sell price for .{$domainPricing->tld}.");
     }
 
+    public function updateCommonDomain(Request $request, DomainPricing $domainPricing): RedirectResponse
+    {
+        $validated = $request->validate([
+            'is_common' => 'nullable|boolean',
+        ]);
+
+        $domainPricing->update([
+            'is_common' => (bool) ($validated['is_common'] ?? false),
+        ]);
+
+        return back()->with('status', "Updated common domain flag for .{$domainPricing->tld}.");
+    }
+
     public function bulkMarkup(Request $request): RedirectResponse
     {
         $validated = $request->validate([

--- a/app/Http/Controllers/Admin/DomainPricingController.php
+++ b/app/Http/Controllers/Admin/DomainPricingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\DomainPricing;
+use App\Services\AuditLogger;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -85,6 +86,13 @@ class DomainPricingController extends Controller
 
         fclose($handle);
 
+        AuditLogger::logSystem('pricing.import', "Imported {$imported} domain pricing row(s).", [
+            'service' => 'domains',
+            'function' => 'pricing-import',
+        ], [
+            'new_values' => ['imported' => $imported],
+        ]);
+
         return back()->with('status', "Imported {$imported} pricing row(s).");
     }
 
@@ -98,6 +106,11 @@ class DomainPricingController extends Controller
             'sell_price' => round((float) $validated['sell_price'], 2),
         ]);
 
+        AuditLogger::logAction('pricing.sell-price-update', $domainPricing, "Updated sell price for .{$domainPricing->tld}.", [
+            'context' => ['service' => 'domains', 'function' => 'pricing-sell-price'],
+            'new_values' => ['sell_price' => $domainPricing->sell_price],
+        ]);
+
         return back()->with('status', "Updated sell price for .{$domainPricing->tld}.");
     }
 
@@ -109,6 +122,11 @@ class DomainPricingController extends Controller
 
         $domainPricing->update([
             'is_common' => (bool) ($validated['is_common'] ?? false),
+        ]);
+
+        AuditLogger::logAction('pricing.common-flag-update', $domainPricing, "Updated common domain flag for .{$domainPricing->tld}.", [
+            'context' => ['service' => 'domains', 'function' => 'pricing-common-flag'],
+            'new_values' => ['is_common' => $domainPricing->is_common],
         ]);
 
         return back()->with('status', "Updated common domain flag for .{$domainPricing->tld}.");
@@ -132,6 +150,13 @@ class DomainPricingController extends Controller
                 'sell_price' => round($base * $multiplier, 2),
             ]);
         });
+
+        AuditLogger::logSystem('pricing.bulk-markup', 'Bulk sell pricing updated from current buy prices.', [
+            'service' => 'domains',
+            'function' => 'pricing-bulk-markup',
+        ], [
+            'new_values' => ['multiplier' => $multiplier],
+        ]);
 
         return back()->with('status', 'Bulk sell pricing updated from current buy prices.');
     }

--- a/app/Http/Controllers/Admin/DomainPurchaseController.php
+++ b/app/Http/Controllers/Admin/DomainPurchaseController.php
@@ -27,9 +27,19 @@ class DomainPurchaseController extends Controller
      */
     public function index()
     {
-        $extensions = DomainPricing::query()->orderBy('tld')->pluck('tld');
+        $commonExtensions = DomainPricing::query()
+            ->where('is_common', true)
+            ->orderBy('tld')
+            ->pluck('tld');
 
-        return view('admin.domains.purchase', compact('extensions'));
+        $otherExtensions = DomainPricing::query()
+            ->where(function ($query) {
+                $query->where('is_common', false)->orWhereNull('is_common');
+            })
+            ->orderBy('tld')
+            ->pluck('tld');
+
+        return view('admin.domains.purchase', compact('commonExtensions', 'otherExtensions'));
     }
 
     /**

--- a/app/Http/Controllers/Admin/DomainPurchaseController.php
+++ b/app/Http/Controllers/Admin/DomainPurchaseController.php
@@ -8,6 +8,7 @@ use App\Models\Client;
 use App\Models\Domain;
 use App\Models\DomainPricing;
 use App\Models\User;
+use App\Services\AuditLogger;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -244,6 +245,20 @@ class DomainPurchaseController extends Controller
 
                 DB::commit();
 
+                AuditLogger::logAction('domain.purchase', $domain, "Domain {$request->domain} purchased.", [
+                    'context' => [
+                        'service' => 'domains',
+                        'function' => 'purchase',
+                        'client_id' => $client->id,
+                    ],
+                    'new_values' => [
+                        'domain' => $request->domain,
+                        'years' => (int) $request->years,
+                        'client_id' => $client->id,
+                        'registry_id' => $result['domainID'] ?? null,
+                    ],
+                ]);
+
                 return response()->json([
                     'success' => true,
                     'message' => "Domain {$request->domain} registered successfully!",
@@ -251,6 +266,13 @@ class DomainPurchaseController extends Controller
                 ]);
             } else {
                 DB::rollBack();
+                AuditLogger::logSystem('purchase.failed', "Domain purchase failed for {$request->domain}.", [
+                    'service' => 'domains',
+                    'function' => 'purchase',
+                    'client_id' => $request->client_id,
+                ], [
+                    'new_values' => ['error' => $result['errorMessage'] ?? 'Unknown error'],
+                ]);
                 return response()->json([
                     'success' => false,
                     'message' => 'Domain registration failed: ' . ($result['errorMessage'] ?? 'Unknown error'),
@@ -258,6 +280,13 @@ class DomainPurchaseController extends Controller
             }
         } catch (\Exception $e) {
             DB::rollBack();
+            AuditLogger::logSystem('purchase.failed', "Domain purchase exception for {$request->domain}.", [
+                'service' => 'domains',
+                'function' => 'purchase',
+                'client_id' => $request->client_id,
+            ], [
+                'new_values' => ['error' => $e->getMessage()],
+            ]);
             return response()->json([
                 'success' => false,
                 'message' => 'Error registering domain: ' . $e->getMessage(),

--- a/app/Http/Controllers/Admin/ServicesController.php
+++ b/app/Http/Controllers/Admin/ServicesController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use App\Models\HostingService;
 use App\Models\HostingPackage;
 use App\Models\Client;
+use App\Services\AuditLogger;
 use App\Services\Synergy\SynergyWholesaleClient;
 
 class ServicesController extends Controller
@@ -137,6 +138,12 @@ class ServicesController extends Controller
 
             if (($res['status'] ?? null) !== 'OK') {
                 $message = $res['errorMessage'] ?? 'Unknown error';
+                AuditLogger::logSystem('sync.failed', 'Hosting service sync from Synergy failed.', [
+                    'service' => 'synergy',
+                    'function' => 'hosting-sync',
+                ], [
+                    'new_values' => ['error' => $message],
+                ]);
                 return redirect()
                     ->route('admin.services.hosting')
                     ->with('status', 'Synergy listHosting failed: ' . $message);
@@ -215,6 +222,13 @@ class ServicesController extends Controller
 
             $page++;
         } while (!empty($res['items']) && count($res['items']) === $limit);
+
+        AuditLogger::logSystem('sync.completed', "Hosting service sync from Synergy completed ({$totalImported} records).", [
+            'service' => 'synergy',
+            'function' => 'hosting-sync',
+        ], [
+            'new_values' => ['imported' => $totalImported],
+        ]);
 
         return redirect()
             ->route('admin.services.hosting')

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -8,6 +8,7 @@ use App\Models\Setting;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use App\Support\MailSettings;
+use App\Services\AuditLogger;
 
 class SettingsController extends Controller
 {
@@ -35,6 +36,9 @@ class SettingsController extends Controller
                 'remember_browser' => true,
                 'issuer' => config('app.name', 'DomainDash'),
             ]),
+            'audit' => Setting::get('audit', [
+                'retention_days' => 90,
+            ]),
         ];
         return view('admin.settings.index', compact('settings'));
     }
@@ -61,6 +65,8 @@ class SettingsController extends Controller
             'mfa.allow_recovery_codes' => 'nullable|boolean',
             'mfa.remember_browser' => 'nullable|boolean',
             'mfa.issuer' => 'nullable|string|max:120',
+            'audit' => 'array',
+            'audit.retention_days' => 'nullable|integer|min:1|max:3650',
             'branding_logo' => 'nullable|file|image|max:2048', // up to 2MB
         ]);
 
@@ -120,6 +126,13 @@ class SettingsController extends Controller
                 Setting::put($key, $value);
             }
         }
+
+        AuditLogger::logSystem('settings.update', 'System settings updated.', [
+            'service' => 'settings',
+            'function' => 'settings-update',
+        ], [
+            'new_values' => ['keys' => array_keys($data)],
+        ]);
 
         return back()->with('status', 'Settings saved.');
     }

--- a/app/Http/Controllers/Admin/SslPurchaseController.php
+++ b/app/Http/Controllers/Admin/SslPurchaseController.php
@@ -7,6 +7,7 @@ use App\Services\Synergy\SynergyWholesaleClient;
 use App\Models\Client;
 use App\Models\Domain;
 use App\Models\SslCertificate;
+use App\Services\AuditLogger;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
@@ -88,6 +89,19 @@ class SslPurchaseController extends Controller
 
                 DB::commit();
 
+                AuditLogger::logAction('ssl.purchase', $ssl, "SSL purchased for {$request->domain}.", [
+                    'context' => [
+                        'service' => 'ssl',
+                        'function' => 'purchase',
+                        'client_id' => $client->id,
+                    ],
+                    'new_values' => [
+                        'domain' => $request->domain,
+                        'years' => (int) $request->years,
+                        'product_id' => $request->product_id,
+                    ],
+                ]);
+
                 return response()->json([
                     'success' => true,
                     'message' => "SSL certificate for {$request->domain} purchased successfully!",
@@ -95,6 +109,13 @@ class SslPurchaseController extends Controller
                 ]);
             } else {
                 DB::rollBack();
+                AuditLogger::logSystem('purchase.failed', "SSL purchase failed for {$request->domain}.", [
+                    'service' => 'ssl',
+                    'function' => 'purchase',
+                    'client_id' => $request->client_id,
+                ], [
+                    'new_values' => ['error' => $result['errorMessage'] ?? 'Unknown error'],
+                ]);
                 return response()->json([
                     'success' => false,
                     'message' => 'SSL purchase failed: ' . ($result['errorMessage'] ?? 'Unknown error'),
@@ -102,6 +123,13 @@ class SslPurchaseController extends Controller
             }
         } catch (\Exception $e) {
             DB::rollBack();
+            AuditLogger::logSystem('purchase.failed', "SSL purchase exception for {$request->domain}.", [
+                'service' => 'ssl',
+                'function' => 'purchase',
+                'client_id' => $request->client_id,
+            ], [
+                'new_values' => ['error' => $e->getMessage()],
+            ]);
             return response()->json([
                 'success' => false,
                 'message' => 'Error purchasing SSL: ' . $e->getMessage(),

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Domain;
+use App\Models\HostingService;
+use App\Models\SslCertificate;
+use Illuminate\Contracts\View\View;
+
+class DashboardController extends Controller
+{
+    public function index(): View
+    {
+        $user = auth()->user();
+        $search = trim((string) request('q', ''));
+        $isAdmin = $user?->hasRole('Administrator') ?? false;
+        $clientIds = $isAdmin ? null : $user?->clients()->pluck('clients.id');
+
+        $domainsQuery = Domain::query()->with('client')->orderBy('name');
+        $hostingQuery = HostingService::query()->with('client', 'domain')->orderBy('next_renewal_due');
+        $sslQuery = SslCertificate::query()->with('client', 'domain')->orderBy('expire_date');
+
+        if (! $isAdmin && $clientIds !== null) {
+            $domainsQuery->whereIn('client_id', $clientIds);
+            $hostingQuery->whereIn('client_id', $clientIds);
+            $sslQuery->whereIn('client_id', $clientIds);
+        }
+
+        if ($search !== '') {
+            $domainsQuery->where(function ($query) use ($search) {
+                $query->where('name', 'like', '%'.$search.'%')
+                    ->orWhere('status', 'like', '%'.$search.'%')
+                    ->orWhereHas('client', function ($clientQuery) use ($search) {
+                        $clientQuery->where('business_name', 'like', '%'.$search.'%');
+                    });
+            });
+
+            $hostingQuery->where(function ($query) use ($search) {
+                $query->where('username', 'like', '%'.$search.'%')
+                    ->orWhere('plan', 'like', '%'.$search.'%')
+                    ->orWhere('server', 'like', '%'.$search.'%')
+                    ->orWhere('ip_address', 'like', '%'.$search.'%')
+                    ->orWhereHas('domain', function ($domainQuery) use ($search) {
+                        $domainQuery->where('name', 'like', '%'.$search.'%');
+                    })
+                    ->orWhereHas('client', function ($clientQuery) use ($search) {
+                        $clientQuery->where('business_name', 'like', '%'.$search.'%');
+                    });
+            });
+
+            $sslQuery->where(function ($query) use ($search) {
+                $query->where('common_name', 'like', '%'.$search.'%')
+                    ->orWhere('product_name', 'like', '%'.$search.'%')
+                    ->orWhere('status', 'like', '%'.$search.'%')
+                    ->orWhereHas('client', function ($clientQuery) use ($search) {
+                        $clientQuery->where('business_name', 'like', '%'.$search.'%');
+                    });
+            });
+        }
+
+        $domains = $domainsQuery->limit(50)->get();
+        $hostingServices = $hostingQuery->limit(50)->get();
+        $sslCertificates = $sslQuery->limit(50)->get();
+
+        return view('dashboard', compact('search', 'domains', 'hostingServices', 'sslCertificates'));
+    }
+}

--- a/app/Http/Controllers/DnsController.php
+++ b/app/Http/Controllers/DnsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Domain;
 use Illuminate\Http\Request;
+use App\Services\AuditLogger;
 use App\Services\Synergy\SynergyWholesaleClient;
 
 class DnsController extends Controller
@@ -87,6 +88,14 @@ class DnsController extends Controller
             $data['prio'] ?? 0
         );
 
+        AuditLogger::logSystem('dns.create', "DNS record added for {$domain->name}.", [
+            'service' => 'dns',
+            'function' => 'record-create',
+            'client_id' => $domain->client_id,
+        ], [
+            'new_values' => $data,
+        ]);
+
         return back()->with('status', 'DNS record added.');
     }
 
@@ -114,6 +123,14 @@ class DnsController extends Controller
             $data['prio'] ?? 0
         );
 
+        AuditLogger::logSystem('dns.update', "DNS record updated for {$domain->name}.", [
+            'service' => 'dns',
+            'function' => 'record-update',
+            'client_id' => $domain->client_id,
+        ], [
+            'new_values' => array_merge($data, ['record_id' => $recordId]),
+        ]);
+
         return back()->with('status', 'DNS record updated.');
     }
 
@@ -123,6 +140,14 @@ class DnsController extends Controller
     public function destroy(Domain $domain, $recordId, SynergyWholesaleClient $synergy)
     {
         $synergy->deleteDNSRecord($domain->name, $recordId);
+
+        AuditLogger::logSystem('dns.delete', "DNS record deleted for {$domain->name}.", [
+            'service' => 'dns',
+            'function' => 'record-delete',
+            'client_id' => $domain->client_id,
+        ], [
+            'new_values' => ['record_id' => $recordId],
+        ]);
 
         return back()->with('status', 'DNS record deleted.');
     }
@@ -170,6 +195,14 @@ class DnsController extends Controller
         }
 
         $domain->save();
+
+        AuditLogger::logSystem('dns.options-update', "DNS options updated for {$domain->name}.", [
+            'service' => 'dns',
+            'function' => 'dns-options',
+            'client_id' => $domain->client_id,
+        ], [
+            'new_values' => ['dns_mode' => $dnsMode, 'nameservers' => $nameservers],
+        ]);
 
         return back()->with(
             'status',

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -19,6 +19,7 @@ class AuditLog extends Model
         'description',
         'old_values',
         'new_values',
+        'context',
         'ip_address',
         'user_agent',
     ];
@@ -26,6 +27,7 @@ class AuditLog extends Model
     protected $casts = [
         'old_values' => 'array',
         'new_values' => 'array',
+        'context' => 'array',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];

--- a/app/Models/DomainPricing.php
+++ b/app/Models/DomainPricing.php
@@ -33,12 +33,14 @@ class DomainPricing extends Model
         'sale_transfer_price',
         'sale_end_date',
         'sell_price',
+        'is_common',
     ];
 
     protected $casts = [
         'id_protection' => 'boolean',
         'dnssec' => 'boolean',
         'sale_end_date' => 'date',
+        'is_common' => 'boolean',
     ];
 
     public function getEffectiveRegistrationPriceAttribute(): ?float

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,11 @@
 
 namespace App\Providers;
 
+use App\Services\AuditLogger;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Login;
 use App\Support\MailSettings;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
@@ -24,5 +28,41 @@ class AppServiceProvider extends ServiceProvider
         if (Schema::hasTable('settings')) {
             MailSettings::applyFromDatabase();
         }
+
+        Event::listen(Login::class, function (Login $event): void {
+            AuditLogger::logSystem(
+                'auth.login',
+                'User logged in successfully.',
+                [
+                    'function' => 'authentication',
+                    'service' => 'auth',
+                    'user_id' => $event->user->id,
+                ],
+                [
+                    'user_email' => $event->user->email,
+                    'new_values' => [
+                        'remember' => $event->remember,
+                    ],
+                ]
+            );
+        });
+
+        Event::listen(Failed::class, function (Failed $event): void {
+            AuditLogger::logSystem(
+                'auth.login_failed',
+                'Failed login attempt.',
+                [
+                    'function' => 'authentication',
+                    'service' => 'auth',
+                ],
+                [
+                    'user_email' => $event->credentials['email'] ?? null,
+                    'new_values' => [
+                        'guard' => $event->guard,
+                        'email' => $event->credentials['email'] ?? null,
+                    ],
+                ]
+            );
+        });
     }
 }

--- a/app/Services/AuditLogger.php
+++ b/app/Services/AuditLogger.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\AuditLog;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Request;
 
@@ -33,6 +34,7 @@ class AuditLogger
             'description' => $options['description'] ?? null,
             'old_values' => $options['old_values'] ?? null,
             'new_values' => $options['new_values'] ?? null,
+            'context' => $options['context'] ?? null,
             'ip_address' => Request::ip(),
             'user_agent' => Request::userAgent(),
         ]);
@@ -81,5 +83,20 @@ class AuditLogger
         return self::log($action, $model, array_merge([
             'description' => $description,
         ], $additionalData));
+    }
+
+    public static function logSystem(string $action, string $description, array $context = [], array $additionalData = []): AuditLog
+    {
+        return self::log($action, 'System', array_merge([
+            'description' => $description,
+            'context' => $context,
+        ], $additionalData));
+    }
+
+    public static function pruneOlderThanDays(int $days): int
+    {
+        $cutoff = Carbon::now()->subDays(max(1, $days));
+
+        return AuditLog::query()->where('created_at', '<', $cutoff)->delete();
     }
 }

--- a/database/migrations/2026_04_21_000200_add_is_common_to_domain_pricings_table.php
+++ b/database/migrations/2026_04_21_000200_add_is_common_to_domain_pricings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('domain_pricings', function (Blueprint $table) {
+            $table->boolean('is_common')->default(false)->after('sell_price');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('domain_pricings', function (Blueprint $table) {
+            $table->dropColumn('is_common');
+        });
+    }
+};

--- a/database/migrations/2026_04_21_001000_add_context_to_audit_logs_table.php
+++ b/database/migrations/2026_04_21_001000_add_context_to_audit_logs_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('audit_logs', function (Blueprint $table) {
+            $table->json('context')->nullable()->after('new_values');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('audit_logs', function (Blueprint $table) {
+            $table->dropColumn('context');
+        });
+    }
+};

--- a/resources/views/admin/audit/index.blade.php
+++ b/resources/views/admin/audit/index.blade.php
@@ -1,0 +1,143 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="dd-page">
+    <h1 class="dd-page-title">Audit & Logging</h1>
+
+    <div class="dd-card" style="margin-bottom: 1rem;">
+        <h2 style="margin-bottom: 0.75rem;">Retention & Storage</h2>
+        <form method="POST" action="{{ route('admin.audit.retention') }}" style="display:flex;gap:0.75rem;align-items:flex-end;flex-wrap:wrap;">
+            @csrf
+            <div>
+                <label style="display:block;font-size:12px;margin-bottom:4px;">Retention days</label>
+                <input type="number" name="retention_days" min="1" max="3650" value="{{ $retentionDays }}" required>
+            </div>
+            <label style="display:flex;align-items:center;gap:0.4rem;">
+                <input type="checkbox" name="prune_now" value="1">
+                Prune now
+            </label>
+            <button type="submit" class="btn-accent">Save retention</button>
+        </form>
+        <div style="margin-top:0.8rem;color:#6b7280;">
+            <div>Audit DB size (estimated): {{ number_format($dbBytes / 1024, 1) }} KB</div>
+            <div>Laravel log file size: {{ number_format($logFileBytes / 1024, 1) }} KB</div>
+        </div>
+    </div>
+
+    <div class="dd-card" style="margin-bottom: 1rem;">
+        <h2 style="margin-bottom: 0.75rem;">Filters</h2>
+        <form method="GET" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:0.75rem;align-items:end;">
+            <div>
+                <label style="display:block;font-size:12px;margin-bottom:4px;">Event</label>
+                <select name="action">
+                    <option value="">All events</option>
+                    @foreach($actionOptions as $action)
+                        <option value="{{ $action }}" {{ $filters['action'] === $action ? 'selected' : '' }}>{{ $action }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div>
+                <label style="display:block;font-size:12px;margin-bottom:4px;">User</label>
+                <select name="user_id">
+                    <option value="">All users</option>
+                    @foreach($users as $user)
+                        <option value="{{ $user->id }}" {{ $filters['user_id'] === (string) $user->id ? 'selected' : '' }}>
+                            {{ $user->name }} ({{ $user->email }})
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div>
+                <label style="display:block;font-size:12px;margin-bottom:4px;">Client</label>
+                <select name="client_id">
+                    <option value="">All clients</option>
+                    @foreach($clients as $client)
+                        <option value="{{ $client->id }}" {{ $filters['client_id'] === (string) $client->id ? 'selected' : '' }}>{{ $client->business_name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div>
+                <label style="display:block;font-size:12px;margin-bottom:4px;">Service</label>
+                <input type="text" name="service" value="{{ $filters['service'] }}" placeholder="synergy, halo, dns, ssl...">
+            </div>
+            <div>
+                <label style="display:block;font-size:12px;margin-bottom:4px;">Function</label>
+                <input type="text" name="function" value="{{ $filters['function'] }}" placeholder="purchase, sync, update...">
+            </div>
+            <label style="display:flex;align-items:center;gap:0.4rem;">
+                <input type="checkbox" name="failed_only" value="1" {{ $filters['failed_only'] ? 'checked' : '' }}>
+                Failed only
+            </label>
+            <div style="display:flex;gap:0.5rem;">
+                <button type="submit" class="btn-accent">Apply</button>
+                <a href="{{ route('admin.audit.index') }}" class="btn-accent" style="text-decoration:none;background:#64748b;">Reset</a>
+            </div>
+        </form>
+    </div>
+
+    <div class="dd-card">
+        <h2 style="margin-bottom: 0.75rem;">Event Timeline</h2>
+        <div style="overflow:auto;">
+            <table class="dd-table" style="width:100%; min-width:1200px;">
+                <thead>
+                    <tr>
+                        <th>Timestamp</th>
+                        <th>Event</th>
+                        <th>User</th>
+                        <th>Client</th>
+                        <th>Service / Function</th>
+                        <th>Description</th>
+                        <th>Entity</th>
+                        <th>Changes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($logs as $log)
+                        @php
+                            $context = $log->context ?? [];
+                            $clientId = $context['client_id'] ?? $log->new_values['client_id'] ?? $log->old_values['client_id'] ?? null;
+                            $service = $context['service'] ?? '-';
+                            $function = $context['function'] ?? '-';
+                        @endphp
+                        <tr>
+                            <td>{{ $log->created_at?->toDateTimeString() }}</td>
+                            <td>{{ $log->action }}</td>
+                            <td>{{ $log->user_email ?? optional($log->user)->email ?? '-' }}</td>
+                            <td>{{ $clientId ?? '-' }}</td>
+                            <td>{{ $service }} / {{ $function }}</td>
+                            <td>{{ $log->description ?? '-' }}</td>
+                            <td>{{ class_basename($log->auditable_type) }} #{{ $log->auditable_id ?? '-' }}</td>
+                            <td>
+                                @if(!empty($log->old_values) || !empty($log->new_values))
+                                    <details>
+                                        <summary>View</summary>
+                                        <div style="font-size:12px;line-height:1.5;margin-top:6px;">
+                                            @if(!empty($log->old_values))
+                                                <strong>Old:</strong>
+                                                <pre style="white-space:pre-wrap;">{{ json_encode($log->old_values, JSON_PRETTY_PRINT) }}</pre>
+                                            @endif
+                                            @if(!empty($log->new_values))
+                                                <strong>New:</strong>
+                                                <pre style="white-space:pre-wrap;">{{ json_encode($log->new_values, JSON_PRETTY_PRINT) }}</pre>
+                                            @endif
+                                        </div>
+                                    </details>
+                                @else
+                                    -
+                                @endif
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="8" style="text-align:center;color:#6b7280;">No audit events match the current filters.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div style="margin-top: 1rem;">
+            {{ $logs->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/audit/index.blade.php
+++ b/resources/views/admin/audit/index.blade.php
@@ -58,7 +58,12 @@
             </div>
             <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Service</label>
-                <input type="text" name="service" value="{{ $filters['service'] }}" placeholder="synergy, halo, dns, ssl...">
+                <select name="service">
+                    <option value="">All services</option>
+                    @foreach($serviceOptions as $serviceOption)
+                        <option value="{{ $serviceOption }}" {{ $filters['service'] === $serviceOption ? 'selected' : '' }}>{{ $serviceOption }}</option>
+                    @endforeach
+                </select>
             </div>
             <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Function</label>
@@ -82,6 +87,11 @@
 
     <div class="dd-card">
         <h2 style="margin-bottom: 0.75rem;">Event Timeline</h2>
+        <div style="margin-bottom:0.75rem;max-width:360px;">
+            <label for="audit-live-search" style="display:block;font-size:12px;margin-bottom:4px;">Live search in current results</label>
+            <input id="audit-live-search" type="text" placeholder="Type to filter visible rows...">
+        </div>
+        <p id="audit-live-empty" style="display:none; margin:0 0 0.75rem; color:#6b7280;">No rows match the live search.</p>
         <div style="overflow:auto;">
             <table class="dd-table" style="width:100%; min-width:1200px;">
                 <thead>
@@ -96,15 +106,19 @@
                         <th>Changes</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody id="audit-log-body">
                     @forelse($logs as $log)
                         @php
                             $context = $log->context ?? [];
                             $clientId = $context['client_id'] ?? $log->new_values['client_id'] ?? $log->old_values['client_id'] ?? null;
                             $service = $context['service'] ?? '-';
                             $function = $context['function'] ?? '-';
+                            $changePayload = json_encode([
+                                'old' => $log->old_values,
+                                'new' => $log->new_values,
+                            ], JSON_PRETTY_PRINT);
                         @endphp
-                        <tr>
+                        <tr data-audit-row>
                             <td>{{ $log->created_at?->toDateTimeString() }}</td>
                             <td>{{ $log->action }}</td>
                             <td>{{ $log->user_email ?? optional($log->user)->email ?? '-' }}</td>
@@ -114,19 +128,20 @@
                             <td>{{ class_basename($log->auditable_type) }} #{{ $log->auditable_id ?? '-' }}</td>
                             <td>
                                 @if(!empty($log->old_values) || !empty($log->new_values))
-                                    <details>
-                                        <summary>View</summary>
-                                        <div style="font-size:12px;line-height:1.5;margin-top:6px;">
-                                            @if(!empty($log->old_values))
-                                                <strong>Old:</strong>
-                                                <pre style="white-space:pre-wrap;">{{ json_encode($log->old_values, JSON_PRETTY_PRINT) }}</pre>
-                                            @endif
-                                            @if(!empty($log->new_values))
-                                                <strong>New:</strong>
-                                                <pre style="white-space:pre-wrap;">{{ json_encode($log->new_values, JSON_PRETTY_PRINT) }}</pre>
-                                            @endif
-                                        </div>
-                                    </details>
+                                    <button
+                                        type="button"
+                                        class="dd-account-password-btn dd-audit-view-btn"
+                                        data-event="{{ $log->action }}"
+                                        data-timestamp="{{ $log->created_at?->toDateTimeString() }}"
+                                        data-user="{{ $log->user_email ?? optional($log->user)->email ?? '-' }}"
+                                        data-service="{{ $service }}"
+                                        data-function="{{ $function }}"
+                                        data-description="{{ $log->description ?? '-' }}"
+                                        data-entity="{{ class_basename($log->auditable_type) }} #{{ $log->auditable_id ?? '-' }}"
+                                        data-changes="{{ $changePayload }}"
+                                    >
+                                        View
+                                    </button>
                                 @else
                                     -
                                 @endif
@@ -142,6 +157,27 @@
         </div>
         <div style="margin-top: 1rem;">
             {{ $logs->links() }}
+        </div>
+    </div>
+</div>
+
+<div id="audit-event-modal" class="dd-account-modal-backdrop" hidden>
+    <div class="dd-account-modal" role="dialog" aria-modal="true" aria-labelledby="auditEventTitle">
+        <div class="dd-account-modal-header">
+            <h2 id="auditEventTitle">Audit Event Details</h2>
+            <button type="button" class="dd-account-modal-close" id="audit-event-close" aria-label="Close audit event details">x</button>
+        </div>
+        <div class="dd-account-modal-grid">
+            <div><strong>Timestamp:</strong> <span id="audit-event-time"></span></div>
+            <div><strong>Event:</strong> <span id="audit-event-action"></span></div>
+            <div><strong>User:</strong> <span id="audit-event-user"></span></div>
+            <div><strong>Service / Function:</strong> <span id="audit-event-scope"></span></div>
+            <div><strong>Entity:</strong> <span id="audit-event-entity"></span></div>
+            <div><strong>Description:</strong> <span id="audit-event-description"></span></div>
+            <div>
+                <strong>Changes:</strong>
+                <pre id="audit-event-changes" style="white-space:pre-wrap;margin-top:8px;"></pre>
+            </div>
         </div>
     </div>
 </div>
@@ -217,4 +253,72 @@
     transform: rotate(45deg);
 }
 </style>
+
+<script>
+(function () {
+    const searchInput = document.getElementById('audit-live-search');
+    const body = document.getElementById('audit-log-body');
+    const noResults = document.getElementById('audit-live-empty');
+    const modal = document.getElementById('audit-event-modal');
+    const close = document.getElementById('audit-event-close');
+
+    function applyLiveSearch() {
+        if (!searchInput || !body) {
+            return;
+        }
+
+        const term = searchInput.value.trim().toLowerCase();
+        const rows = Array.from(body.querySelectorAll('tr[data-audit-row]'));
+        let shown = 0;
+
+        rows.forEach((row) => {
+            const text = (row.textContent || '').toLowerCase();
+            const visible = term === '' || text.includes(term);
+            row.style.display = visible ? '' : 'none';
+            if (visible) {
+                shown += 1;
+            }
+        });
+
+        if (noResults) {
+            noResults.style.display = rows.length > 0 && shown === 0 ? 'block' : 'none';
+        }
+    }
+
+    function openEventModal(button) {
+        if (!modal) {
+            return;
+        }
+
+        document.getElementById('audit-event-time').textContent = button.dataset.timestamp || '-';
+        document.getElementById('audit-event-action').textContent = button.dataset.event || '-';
+        document.getElementById('audit-event-user').textContent = button.dataset.user || '-';
+        document.getElementById('audit-event-scope').textContent = `${button.dataset.service || '-'} / ${button.dataset.function || '-'}`;
+        document.getElementById('audit-event-entity').textContent = button.dataset.entity || '-';
+        document.getElementById('audit-event-description').textContent = button.dataset.description || '-';
+        document.getElementById('audit-event-changes').textContent = button.dataset.changes || '{}';
+
+        modal.hidden = false;
+    }
+
+    function closeEventModal() {
+        if (modal) {
+            modal.hidden = true;
+        }
+    }
+
+    document.querySelectorAll('.dd-audit-view-btn').forEach((button) => {
+        button.addEventListener('click', () => openEventModal(button));
+    });
+
+    close?.addEventListener('click', closeEventModal);
+    modal?.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            closeEventModal();
+        }
+    });
+
+    searchInput?.addEventListener('input', applyLiveSearch);
+})();
+</script>
 @endsection

--- a/resources/views/admin/audit/index.blade.php
+++ b/resources/views/admin/audit/index.blade.php
@@ -6,14 +6,14 @@
 
     <div class="dd-card" style="margin-bottom: 1rem;">
         <h2 style="margin-bottom: 0.75rem;">Retention & Storage</h2>
-        <form method="POST" action="{{ route('admin.audit.retention') }}" style="display:flex;gap:0.75rem;align-items:flex-end;flex-wrap:wrap;">
+        <form method="POST" action="{{ route('admin.audit.retention') }}" class="dd-audit-retention-form">
             @csrf
-            <div>
+            <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Retention days</label>
                 <input type="number" name="retention_days" min="1" max="3650" value="{{ $retentionDays }}" required>
             </div>
-            <label style="display:flex;align-items:center;gap:0.4rem;">
-                <input type="checkbox" name="prune_now" value="1">
+            <label class="dd-audit-checkbox-label">
+                <input type="checkbox" class="dd-audit-checkbox" name="prune_now" value="1">
                 Prune now
             </label>
             <button type="submit" class="btn-accent">Save retention</button>
@@ -26,8 +26,8 @@
 
     <div class="dd-card" style="margin-bottom: 1rem;">
         <h2 style="margin-bottom: 0.75rem;">Filters</h2>
-        <form method="GET" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:0.75rem;align-items:end;">
-            <div>
+        <form method="GET" class="dd-audit-filter-grid">
+            <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Event</label>
                 <select name="action">
                     <option value="">All events</option>
@@ -36,7 +36,7 @@
                     @endforeach
                 </select>
             </div>
-            <div>
+            <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">User</label>
                 <select name="user_id">
                     <option value="">All users</option>
@@ -47,7 +47,7 @@
                     @endforeach
                 </select>
             </div>
-            <div>
+            <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Client</label>
                 <select name="client_id">
                     <option value="">All clients</option>
@@ -56,19 +56,24 @@
                     @endforeach
                 </select>
             </div>
-            <div>
+            <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Service</label>
                 <input type="text" name="service" value="{{ $filters['service'] }}" placeholder="synergy, halo, dns, ssl...">
             </div>
-            <div>
+            <div class="dd-audit-field">
                 <label style="display:block;font-size:12px;margin-bottom:4px;">Function</label>
-                <input type="text" name="function" value="{{ $filters['function'] }}" placeholder="purchase, sync, update...">
+                <select name="function">
+                    <option value="">All functions</option>
+                    @foreach($functionOptions as $functionOption)
+                        <option value="{{ $functionOption }}" {{ $filters['function'] === $functionOption ? 'selected' : '' }}>{{ $functionOption }}</option>
+                    @endforeach
+                </select>
             </div>
-            <label style="display:flex;align-items:center;gap:0.4rem;">
-                <input type="checkbox" name="failed_only" value="1" {{ $filters['failed_only'] ? 'checked' : '' }}>
+            <label class="dd-audit-checkbox-label dd-audit-field">
+                <input type="checkbox" class="dd-audit-checkbox" name="failed_only" value="1" {{ $filters['failed_only'] ? 'checked' : '' }}>
                 Failed only
             </label>
-            <div style="display:flex;gap:0.5rem;">
+            <div class="dd-audit-actions">
                 <button type="submit" class="btn-accent">Apply</button>
                 <a href="{{ route('admin.audit.index') }}" class="btn-accent" style="text-decoration:none;background:#64748b;">Reset</a>
             </div>
@@ -140,4 +145,76 @@
         </div>
     </div>
 </div>
+
+<style>
+.dd-audit-retention-form {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.dd-audit-filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.9rem;
+    align-items: end;
+}
+
+.dd-audit-field {
+    min-width: 0;
+}
+
+.dd-audit-field select,
+.dd-audit-field input[type="text"],
+.dd-audit-field input[type="number"] {
+    width: 100%;
+}
+
+.dd-audit-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.dd-audit-checkbox-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.95rem;
+    white-space: nowrap;
+    padding-bottom: 0.2rem;
+}
+
+.dd-audit-checkbox {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    border: 1px solid var(--dd-border, #334155);
+    background: var(--dd-surface-soft, #1f2937);
+    position: relative;
+    cursor: pointer;
+    margin: 0;
+}
+
+.dd-audit-checkbox:checked {
+    background: #22c55e;
+    border-color: #22c55e;
+}
+
+.dd-audit-checkbox:checked::after {
+    content: '';
+    position: absolute;
+    left: 6px;
+    top: 3px;
+    width: 4px;
+    height: 8px;
+    border: solid #fff;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+</style>
 @endsection

--- a/resources/views/admin/domains/pricing.blade.php
+++ b/resources/views/admin/domains/pricing.blade.php
@@ -68,6 +68,7 @@
                     <th><button type="button" class="dd-sort-btn" data-sort-key="saleEnd">Sale End Date <span class="dd-sort-indicator"></span></button></th>
                     <th><button type="button" class="dd-sort-btn" data-sort-key="effective">Effective Buy <span class="dd-sort-indicator"></span></button></th>
                     <th><button type="button" class="dd-sort-btn" data-sort-key="sell">Sell Price <span class="dd-sort-indicator"></span></button></th>
+                    <th><button type="button" class="dd-sort-btn" data-sort-key="common">Common Domain <span class="dd-sort-indicator"></span></button></th>
                 </tr>
                 </thead>
                 <tbody id="pricing-table-body">
@@ -87,6 +88,7 @@
                         data-sale-end="{{ $saleEndDate ?? '' }}"
                         data-effective="{{ $effectivePrice !== null ? number_format((float) $effectivePrice, 2, '.', '') : '' }}"
                         data-sell="{{ $pricing->sell_price !== null ? number_format((float) $pricing->sell_price, 2, '.', '') : '' }}"
+                        data-common="{{ $pricing->is_common ? '1' : '0' }}"
                         data-on-sale="{{ $saleActive ? '1' : '0' }}"
                         data-sale-ended="{{ $saleEnded ? '1' : '0' }}"
                     >
@@ -114,10 +116,22 @@
                             <span>{{ $pricing->sell_price !== null ? '$' . number_format((float) $pricing->sell_price, 2) : 'N/A' }}</span>
                             @endcan
                         </td>
+                        <td>
+                            @can('domain-pricing.manage')
+                            <form method="POST" action="{{ route('admin.domains.pricing.common-domain', $pricing) }}">
+                                @csrf
+                                @method('PUT')
+                                <input type="hidden" name="is_common" value="0">
+                                <input type="checkbox" name="is_common" value="1" onchange="this.form.submit()" {{ $pricing->is_common ? 'checked' : '' }}>
+                            </form>
+                            @else
+                            <span>{{ $pricing->is_common ? 'Yes' : 'No' }}</span>
+                            @endcan
+                        </td>
                     </tr>
                 @empty
                     <tr id="pricing-empty-row">
-                        <td colspan="6" style="text-align:center; color:#6b7280;">No pricing loaded yet. Import a CSV to begin.</td>
+                        <td colspan="7" style="text-align:center; color:#6b7280;">No pricing loaded yet. Import a CSV to begin.</td>
                     </tr>
                 @endforelse
                 </tbody>
@@ -145,7 +159,7 @@
             return value === '' ? Number.POSITIVE_INFINITY : Date.parse(value);
         }
 
-        if (['buy', 'sale', 'effective', 'sell'].includes(key)) {
+        if (['buy', 'sale', 'effective', 'sell', 'common'].includes(key)) {
             const value = row.dataset[key] || '';
             return value === '' ? Number.POSITIVE_INFINITY : Number.parseFloat(value);
         }

--- a/resources/views/admin/domains/purchase.blade.php
+++ b/resources/views/admin/domains/purchase.blade.php
@@ -15,7 +15,19 @@
                 <div class="fancy-select-wrapper dd-search-extension-wrap" style="min-width: 200px;">
                     <select id="extension" class="fancy-select dd-search-extension">
                         <option value="">Select an Extension</option>
-                        @forelse(($extensions ?? collect()) as $extension)
+                        @php
+                            $commonExtensions = $commonExtensions ?? collect();
+                            $otherExtensions = $otherExtensions ?? collect();
+                        @endphp
+                        @if($commonExtensions->isNotEmpty())
+                            @foreach($commonExtensions as $extension)
+                                <option value="{{ $extension }}">{{ $extension }}</option>
+                            @endforeach
+                        @endif
+                        @if($commonExtensions->isNotEmpty() && $otherExtensions->isNotEmpty())
+                            <option value="" disabled>-------------</option>
+                        @endif
+                        @forelse($otherExtensions as $extension)
                             <option value="{{ $extension }}">{{ $extension }}</option>
                         @empty
                             <option value="com">com</option>

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -574,7 +574,7 @@
                 </div>
                 <div id="sync-scheduler-content" class="settings-content" style="padding:20px 24px;display:none;">
                     @foreach([
-                        'sync_domains' => 'Sync Domains to HaloPSA',
+                        'sync_domains' => 'Sync Domains from Synergy',
                         'sync_hosting_services' => 'Sync Hosting Services',
                         'sync_halo_assets' => 'Sync Client Domain Assets to/from HaloPSA',
                         'sync_itglue' => 'Sync IT Glue Domain Assets',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,46 +1,104 @@
 @extends('layouts.app')
-@section('content')
-@php
-$clientIds = auth()->user()->hasRole('Administrator') ? \App\Models\Client::pluck('id') : auth()->user()->clients()->pluck('clients.id');
-$search = trim((string) request('q', ''));
-$domainsQuery = \App\Models\Domain::whereIn('client_id',$clientIds);
-if ($search !== '') {
-    $domainsQuery->where(function ($query) use ($search) {
-        $query->where('name', 'like', '%'.$search.'%')
-            ->orWhere('status', 'like', '%'.$search.'%')
-            ->orWhereHas('client', function ($clientQuery) use ($search) {
-                $clientQuery->where('business_name', 'like', '%'.$search.'%');
-            });
-    });
-}
-$domains = $domainsQuery->with('client')->orderBy('name')->limit(50)->get();
-@endphp
 
+@section('content')
 <div class="dd-page">
     <h1 class="dd-page-title">Dashboard</h1>
-    <div class="dd-card">
-        <div class="dd-toolbar">
-            <form method="GET" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-                <input class="dd-input dd-input-inline" type="text" name="q" placeholder="Search domains, status, or client" value="{{ $search }}">
-                <button type="submit" class="btn-accent">Search</button>
-            </form>
-        </div>
 
-        <table class="dd-table-clean">
-            <thead><tr><th>Domain</th><th>Client</th><th>Expiry</th><th>Status</th></tr></thead>
-            <tbody>
-                @forelse($domains as $d)
-                    <tr @class(['danger'=>$d->isExpiringSoon()])>
-                        <td>{{ $d->name }}</td>
-                        <td>{{ optional($d->client)->business_name ?? '-' }}</td>
-                        <td>{{ optional($d->expiry_date)->toDateString() }}</td>
-                        <td>{{ $d->status }}</td>
-                    </tr>
-                @empty
-                    <tr><td colspan="4">No matching domains found.</td></tr>
-                @endforelse
-            </tbody>
-        </table>
+    <div class="dd-card" style="margin-bottom: 1rem;">
+        <form method="GET" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+            <input class="dd-input dd-input-inline" type="text" name="q" placeholder="Search services, status, or client" value="{{ $search }}">
+            <button type="submit" class="btn-accent">Search</button>
+        </form>
     </div>
+
+    @if($domains->isEmpty() && $hostingServices->isEmpty() && $sslCertificates->isEmpty())
+        <div class="dd-card">
+            <p style="margin:0; color:#6b7280;">
+                No assigned services found{{ $search !== '' ? ' for the current search.' : '.' }}
+            </p>
+        </div>
+    @endif
+
+    @if($domains->isNotEmpty())
+        <div class="dd-card" style="margin-bottom: 1rem;">
+            <h2 style="margin-bottom: 0.85rem;">Domains</h2>
+            <table class="dd-table-clean">
+                <thead>
+                    <tr>
+                        <th>Domain</th>
+                        <th>Client</th>
+                        <th>Expiry</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($domains as $domain)
+                        <tr @class(['danger' => $domain->isExpiringSoon()])>
+                            <td>{{ $domain->name }}</td>
+                            <td>{{ optional($domain->client)->business_name ?? '-' }}</td>
+                            <td>{{ optional($domain->expiry_date)->toDateString() ?? '-' }}</td>
+                            <td>{{ $domain->status ?? '-' }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+
+    @if($hostingServices->isNotEmpty())
+        <div class="dd-card" style="margin-bottom: 1rem;">
+            <h2 style="margin-bottom: 0.85rem;">Hosting Services</h2>
+            <table class="dd-table-clean">
+                <thead>
+                    <tr>
+                        <th>Domain</th>
+                        <th>Plan</th>
+                        <th>Username</th>
+                        <th>Client</th>
+                        <th>Renewal</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($hostingServices as $service)
+                        <tr>
+                            <td>{{ optional($service->domain)->name ?? '-' }}</td>
+                            <td>{{ $service->plan ?? '-' }}</td>
+                            <td>{{ $service->username ?? '-' }}</td>
+                            <td>{{ optional($service->client)->business_name ?? '-' }}</td>
+                            <td>{{ optional($service->next_renewal_due)->toDateString() ?? '-' }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+
+    @if($sslCertificates->isNotEmpty())
+        <div class="dd-card">
+            <h2 style="margin-bottom: 0.85rem;">SSL Certificates</h2>
+            <table class="dd-table-clean">
+                <thead>
+                    <tr>
+                        <th>Common Name</th>
+                        <th>Product</th>
+                        <th>Client</th>
+                        <th>Expires</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($sslCertificates as $certificate)
+                        <tr @class(['danger' => $certificate->isExpiringSoon()])>
+                            <td>{{ $certificate->common_name ?? '-' }}</td>
+                            <td>{{ $certificate->product_name ?? '-' }}</td>
+                            <td>{{ optional($certificate->client)->business_name ?? '-' }}</td>
+                            <td>{{ optional($certificate->expire_date)->toDateString() ?? '-' }}</td>
+                            <td>{{ $certificate->status ?? '-' }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
 </div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -901,7 +901,7 @@
 
                 <!-- Admin Section (hidden for non-admin users) -->
                 @role('Administrator')
-                    <li class="nav-item nav-section {{ request()->routeIs('admin.clients*') || request()->routeIs('admin.users*') || request()->routeIs('admin.settings') || request()->routeIs('admin.notifications.templates*') || request()->routeIs('admin.apikeys') || request()->routeIs('admin.dashboard') || request()->routeIs('admin.domains.pricing*') ? 'expanded' : '' }}">
+                    <li class="nav-item nav-section {{ request()->routeIs('admin.clients*') || request()->routeIs('admin.users*') || request()->routeIs('admin.settings') || request()->routeIs('admin.notifications.templates*') || request()->routeIs('admin.apikeys') || request()->routeIs('admin.dashboard') || request()->routeIs('admin.domains.pricing*') || request()->routeIs('admin.audit.*') ? 'expanded' : '' }}">
                         <div class="nav-link nav-toggle" onclick="toggleNav(this)">
                             <span class="icon">⚙️</span>
                             <span class="text">Admin</span>
@@ -941,6 +941,11 @@
                             <li class="nav-item">
                                 <a href="{{ route('admin.dashboard') }}" class="nav-link {{ request()->routeIs('admin.dashboard') ? 'active' : '' }}">
                                     System Status
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a href="{{ route('admin.audit.index') }}" class="nav-link {{ request()->routeIs('admin.audit.*') ? 'active' : '' }}">
+                                    Audit & Logging
                                 </a>
                             </li>
                             @can('domain-pricing.view')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -145,6 +145,15 @@
             font-size: 13px;
         }
 
+        .nav-submenu.nested {
+            padding-left: 18px;
+        }
+
+        .nav-submenu .nav-section > .nav-toggle {
+            padding: 8px 14px;
+            font-size: 13px;
+        }
+
         .topbar {
             height: 56px;
             background: var(--bg);
@@ -841,44 +850,51 @@
                     </ul>
                 </li>
 
-                <!-- Hosting Services (with submenu) -->
-                <li class="nav-item nav-section {{ request()->routeIs('admin.services.hosting*') ? 'expanded' : '' }}">
+                <!-- Services (with nested submenus for future expansion) -->
+                <li class="nav-item nav-section {{ request()->routeIs('admin.services.*') ? 'expanded' : '' }}">
                     <div class="nav-link nav-toggle" onclick="toggleNav(this)">
-                        <span class="icon">🖥️</span>
-                        <span class="text">Hosting Services</span>
+                        <span class="icon">🧰</span>
+                        <span class="text">Services</span>
                         <span class="arrow">▶</span>
                     </div>
                     <ul class="nav-submenu">
-                        <li class="nav-item">
-                            <a href="{{ route('admin.services.hosting') }}" class="nav-link {{ request()->routeIs('admin.services.hosting') && !request()->routeIs('admin.services.hosting.purchase') ? 'active' : '' }}">
-                                Manage Hosting
-                            </a>
+                        <li class="nav-item nav-section {{ request()->routeIs('admin.services.ssl*') || request()->routeIs('admin.services.ssls') ? 'expanded' : '' }}">
+                            <div class="nav-link nav-toggle" onclick="toggleNav(this)">
+                                <span class="icon">🔒</span>
+                                <span class="text">SSLs</span>
+                                <span class="arrow">▶</span>
+                            </div>
+                            <ul class="nav-submenu nested">
+                                <li class="nav-item">
+                                    <a href="{{ route('admin.services.ssls') }}" class="nav-link {{ request()->routeIs('admin.services.ssls') && !request()->routeIs('admin.services.ssl.purchase') ? 'active' : '' }}">
+                                        Manage SSLs
+                                    </a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="{{ route('admin.services.ssl.purchase') }}" class="nav-link {{ request()->routeIs('admin.services.ssl.purchase') ? 'active' : '' }}">
+                                        Purchase SSL
+                                    </a>
+                                </li>
+                            </ul>
                         </li>
-                        <li class="nav-item">
-                            <a href="{{ route('admin.services.hosting.purchase') }}" class="nav-link {{ request()->routeIs('admin.services.hosting.purchase') ? 'active' : '' }}">
-                                Purchase Hosting
-                            </a>
-                        </li>
-                    </ul>
-                </li>
-
-                <!-- SSLs (with submenu) -->
-                <li class="nav-item nav-section {{ request()->routeIs('admin.services.ssl*') ? 'expanded' : '' }}">
-                    <div class="nav-link nav-toggle" onclick="toggleNav(this)">
-                        <span class="icon">🔒</span>
-                        <span class="text">SSLs</span>
-                        <span class="arrow">▶</span>
-                    </div>
-                    <ul class="nav-submenu">
-                        <li class="nav-item">
-                            <a href="{{ route('admin.services.ssls') }}" class="nav-link {{ request()->routeIs('admin.services.ssls') && !request()->routeIs('admin.services.ssl.purchase') ? 'active' : '' }}">
-                                Manage SSLs
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a href="{{ route('admin.services.ssl.purchase') }}" class="nav-link {{ request()->routeIs('admin.services.ssl.purchase') ? 'active' : '' }}">
-                                Purchase SSL
-                            </a>
+                        <li class="nav-item nav-section {{ request()->routeIs('admin.services.hosting*') ? 'expanded' : '' }}">
+                            <div class="nav-link nav-toggle" onclick="toggleNav(this)">
+                                <span class="icon">🖥️</span>
+                                <span class="text">Hosting Services</span>
+                                <span class="arrow">▶</span>
+                            </div>
+                            <ul class="nav-submenu nested">
+                                <li class="nav-item">
+                                    <a href="{{ route('admin.services.hosting') }}" class="nav-link {{ request()->routeIs('admin.services.hosting') && !request()->routeIs('admin.services.hosting.purchase') ? 'active' : '' }}">
+                                        Manage Hosting
+                                    </a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="{{ route('admin.services.hosting.purchase') }}" class="nav-link {{ request()->routeIs('admin.services.hosting.purchase') ? 'active' : '' }}">
+                                        Purchase Hosting
+                                    </a>
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\ServicesController;
 use App\Http\Controllers\Admin\ClientsController;
 use App\Http\Controllers\Admin\DomainPricingController;
 use App\Http\Controllers\Admin\EmailNotificationTemplatesController;
+use App\Http\Controllers\Admin\AuditLogController;
 use App\Http\Controllers\UserNotificationController;
 
 
@@ -106,6 +107,8 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::get('/settings', [SettingsController::class,'index'])->name('admin.settings');
         Route::post('/settings', [SettingsController::class,'update'])->name('admin.settings.update');
         Route::post('/settings/test-smtp', [SettingsController::class,'testSmtp'])->name('admin.settings.smtp-test');
+        Route::get('/audit', [AuditLogController::class, 'index'])->name('admin.audit.index');
+        Route::post('/audit/retention', [AuditLogController::class, 'updateRetention'])->name('admin.audit.retention');
         Route::get('/notifications/templates', [EmailNotificationTemplatesController::class, 'index'])->name('admin.notifications.templates');
         Route::post('/notifications/templates', [EmailNotificationTemplatesController::class, 'storeTemplate'])->name('admin.notifications.templates.store');
         Route::post('/notifications/templates/{template}', [EmailNotificationTemplatesController::class, 'updateTemplate'])->name('admin.notifications.templates.template.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,6 +88,9 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
             Route::put('/domains/pricing/{domainPricing}/sell-price', [DomainPricingController::class, 'updateSellPrice'])
                 ->middleware('permission:domain-pricing.manage')
                 ->name('admin.domains.pricing.sell-price');
+            Route::put('/domains/pricing/{domainPricing}/common-domain', [DomainPricingController::class, 'updateCommonDomain'])
+                ->middleware('permission:domain-pricing.manage')
+                ->name('admin.domains.pricing.common-domain');
         });
 
         // Admin area

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Admin\SettingsController;
 use App\Http\Controllers\Admin\DomainController as AdminDomainController;
 use App\Http\Controllers\Admin\ApiKeysController;
@@ -32,7 +33,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
 
         Route::post('/notifications/{notification}/read', [UserNotificationController::class, 'markRead'])->name('notifications.read');
 
-        Route::get('/dashboard', function () {return view('dashboard');})->name('dashboard');
+        Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
         // DNS (customer-visible for assigned domains)
         Route::get('/domains/{domain}/dns', [DnsController::class, 'index'])->name('dns.index');


### PR DESCRIPTION
### Motivation
- Provide a way for admins to mark frequently used TLDs as “common” so the purchase flow can surface them first and make extension selection faster and clearer.

### Description
- Add new boolean column `is_common` to `domain_pricings` via migration (`database/migrations/2026_04_21_000200_add_is_common_to_domain_pricings_table.php`).
- Expose `is_common` on the `DomainPricing` model by adding it to `$fillable` and `$casts` (`app/Models/DomainPricing.php`).
- Add an admin action `updateCommonDomain` and route to toggle the flag (`app/Http/Controllers/Admin/DomainPricingController.php` and `routes/web.php`).
- Extend the domain pricing UI with a new `Common Domain` column and per-row checkbox (non-required) that submits to the new endpoint (`resources/views/admin/domains/pricing.blade.php`).
- Update the purchase page to load extensions as two groups (`commonExtensions` then `otherExtensions`) and render a separator line between them in the dropdown (`app/Http/Controllers/Admin/DomainPurchaseController.php` and `resources/views/admin/domains/purchase.blade.php`).

### Testing
- Ran PHP syntax checks with `php -l` on modified files which reported no syntax errors (`app/Models/DomainPricing.php`, `app/Http/Controllers/Admin/DomainPricingController.php`, `app/Http/Controllers/Admin/DomainPurchaseController.php`, `routes/web.php`, and the new migration`).
- Attempted to run the test suite with `php artisan test --filter=ExampleTest`, but it failed in this environment because `vendor/autoload.php` is missing (dependencies not installed), so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e703f36c8c83308a07a4ed1395e958)