### PR TITLE
Fix Synergy SSL integration: use WSDL operations for product listing, purchase and sync

### DIFF
--- a/app/Http/Controllers/Admin/SslController.php
+++ b/app/Http/Controllers/Admin/SslController.php
@@ -6,9 +6,63 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\SslCertificate;
 use App\Models\Client;
+use App\Models\Domain;
+use App\Services\AuditLogger;
+use App\Services\Synergy\SynergyWholesaleClient;
 
 class SslController extends Controller
 {
+
+
+    public function sync(SynergyWholesaleClient $synergy)
+    {
+        $response = $synergy->listAllSSLCerts();
+
+        if (strtoupper((string) ($response['status'] ?? '')) !== 'OK') {
+            $message = $response['errorMessage'] ?? 'Unknown error';
+            AuditLogger::logSystem('sync.failed', 'SSL sync from Synergy failed.', [
+                'service' => 'synergy',
+                'function' => 'ssl-sync',
+            ], [
+                'new_values' => ['error' => $message],
+            ]);
+
+            return back()->with('status', 'Synergy SSL sync failed: ' . $message);
+        }
+
+        $certs = $response['certs'] ?? [];
+        $synced = 0;
+
+        foreach ($certs as $cert) {
+            $entry = (array) $cert;
+            $commonName = $entry['commonName'] ?? null;
+            $domain = $commonName ? Domain::where('name', strtolower($commonName))->first() : null;
+
+            SslCertificate::updateOrCreate(
+                ['cert_id' => $entry['certID'] ?? null, 'common_name' => $commonName],
+                [
+                    'client_id' => $domain?->client_id,
+                    'domain_id' => $domain?->id,
+                    'product_name' => $entry['productID'] ?? null,
+                    'start_date' => !empty($entry['startDate']) ? date('Y-m-d', strtotime($entry['startDate'])) : null,
+                    'expire_date' => !empty($entry['expireDate']) ? date('Y-m-d', strtotime($entry['expireDate'])) : null,
+                    'status' => $entry['status'] ?? null,
+                ]
+            );
+
+            $synced++;
+        }
+
+        AuditLogger::logSystem('sync.completed', 'SSL sync from Synergy completed.', [
+            'service' => 'synergy',
+            'function' => 'ssl-sync',
+        ], [
+            'new_values' => ['synced_count' => $synced],
+        ]);
+
+        return back()->with('status', "SSL certificates synced from Synergy ({$synced} records processed).");
+    }
+
     public function index(Request $request)
     {
         $q = SslCertificate::query()->with('domain','client');

--- a/app/Http/Controllers/Admin/SslController.php
+++ b/app/Http/Controllers/Admin/SslController.php
@@ -3,17 +3,15 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
-use App\Models\SslCertificate;
 use App\Models\Client;
 use App\Models\Domain;
+use App\Models\SslCertificate;
 use App\Services\AuditLogger;
 use App\Services\Synergy\SynergyWholesaleClient;
+use Illuminate\Http\Request;
 
 class SslController extends Controller
 {
-
-
     public function sync(SynergyWholesaleClient $synergy)
     {
         $response = $synergy->listAllSSLCerts();
@@ -30,25 +28,40 @@ class SslController extends Controller
             return back()->with('status', 'Synergy SSL sync failed: ' . $message);
         }
 
+        $productsResponse = $synergy->listSSLProducts();
+        $productNameById = collect($productsResponse['pricing'] ?? [])
+            ->map(fn (array $entry): array => [
+                'id' => (string) ($entry['productID'] ?? ''),
+                'name' => $entry['productName'] ?? null,
+            ])
+            ->filter(fn (array $entry): bool => $entry['id'] !== '' && !empty($entry['name']))
+            ->pluck('name', 'id')
+            ->all();
+
         $certs = $response['certs'] ?? [];
         $synced = 0;
 
-        foreach ($certs as $cert) {
-            $entry = (array) $cert;
+        foreach ($certs as $entry) {
             $commonName = $entry['commonName'] ?? null;
-            $domain = $commonName ? Domain::where('name', strtolower($commonName))->first() : null;
+            $normalizedDomainName = $commonName ? strtolower(ltrim($commonName, '*.')) : null;
+            $domain = $normalizedDomainName ? Domain::where('name', $normalizedDomainName)->first() : null;
+            $productId = (string) ($entry['productID'] ?? '');
 
-            SslCertificate::updateOrCreate(
-                ['cert_id' => $entry['certID'] ?? null, 'common_name' => $commonName],
-                [
-                    'client_id' => $domain?->client_id,
-                    'domain_id' => $domain?->id,
-                    'product_name' => $entry['productID'] ?? null,
-                    'start_date' => !empty($entry['startDate']) ? date('Y-m-d', strtotime($entry['startDate'])) : null,
-                    'expire_date' => !empty($entry['expireDate']) ? date('Y-m-d', strtotime($entry['expireDate'])) : null,
-                    'status' => $entry['status'] ?? null,
-                ]
-            );
+            $ssl = !empty($entry['certID'])
+                ? SslCertificate::firstOrNew(['cert_id' => (string) $entry['certID']])
+                : SslCertificate::firstOrNew(['common_name' => $commonName]);
+
+            $ssl->fill([
+                'client_id' => $domain?->client_id,
+                'domain_id' => $domain?->id,
+                'cert_id' => $entry['certID'] ?? $ssl->cert_id,
+                'common_name' => $commonName,
+                'product_name' => $productNameById[$productId] ?? ($entry['productName'] ?? $productId ?: null),
+                'start_date' => !empty($entry['startDate']) ? date('Y-m-d', strtotime($entry['startDate'])) : null,
+                'expire_date' => !empty($entry['expireDate']) ? date('Y-m-d', strtotime($entry['expireDate'])) : null,
+                'status' => $entry['status'] ?? null,
+            ]);
+            $ssl->save();
 
             $synced++;
         }
@@ -65,10 +78,107 @@ class SslController extends Controller
 
     public function index(Request $request)
     {
-        $q = SslCertificate::query()->with('domain','client');
-        if ($client = $request->get('client_id')) $q->where('client_id',$client);
-        $ssls = $q->paginate(25);
+        $q = SslCertificate::query()->with('domain', 'client');
+
+        if ($client = $request->get('client_id')) {
+            $q->where('client_id', $client);
+        }
+
+        $ssls = $q->orderByDesc('expire_date')->paginate(25);
         $clients = Client::orderBy('business_name')->get();
-        return view('admin.ssls.index', compact('ssls','clients'));
+
+        return view('admin.ssls.index', compact('ssls', 'clients'));
+    }
+
+    public function show(SslCertificate $ssl, SynergyWholesaleClient $synergy)
+    {
+        $ssl->load('client', 'domain');
+
+        $statusPayload = null;
+
+        if ($ssl->cert_id) {
+            $statusPayload = $synergy->getSSLCertSimpleStatus($ssl->cert_id);
+        }
+
+        return view('admin.ssls.show', [
+            'ssl' => $ssl,
+            'statusPayload' => $statusPayload,
+            'certPayload' => session('ssl_certificate_payload'),
+            'actionMessage' => session('ssl_action_message'),
+        ]);
+    }
+
+    public function getCertificate(SslCertificate $ssl, SynergyWholesaleClient $synergy)
+    {
+        if (!$ssl->cert_id) {
+            return back()->with('ssl_action_message', 'This SSL record has no Synergy cert ID. Run sync first.');
+        }
+
+        $payload = $synergy->getSSLCertificate($ssl->cert_id);
+
+        AuditLogger::logAction('ssl.get-certificate', $ssl, "Fetched certificate bundle for {$ssl->common_name}.", [
+            'context' => ['service' => 'ssl', 'function' => 'get-certificate'],
+            'new_values' => ['cert_id' => $ssl->cert_id],
+        ]);
+
+        return back()
+            ->with('ssl_action_message', $payload['errorMessage'] ?? 'Certificate bundle fetched from Synergy.')
+            ->with('ssl_certificate_payload', $payload);
+    }
+
+    public function renew(Request $request, SslCertificate $ssl, SynergyWholesaleClient $synergy)
+    {
+        if (!$ssl->cert_id) {
+            return back()->with('ssl_action_message', 'This SSL record has no Synergy cert ID. Run sync first.');
+        }
+
+        $contact = $this->buildContactPayload($ssl->client);
+        $payload = $synergy->renewSSLCertificate($ssl->cert_id, $contact);
+
+        AuditLogger::logAction('ssl.renew', $ssl, "Renew attempted for {$ssl->common_name}.", [
+            'context' => ['service' => 'ssl', 'function' => 'renew'],
+            'new_values' => ['cert_id' => $ssl->cert_id, 'status' => $payload['status'] ?? null],
+        ]);
+
+        return back()->with('ssl_action_message', $payload['errorMessage'] ?? ($payload['status'] ?? 'Renew request submitted.'));
+    }
+
+    public function rekey(Request $request, SslCertificate $ssl, SynergyWholesaleClient $synergy)
+    {
+        $validated = $request->validate([
+            'csr' => 'required|string',
+        ]);
+
+        if (!$ssl->cert_id) {
+            return back()->with('ssl_action_message', 'This SSL record has no Synergy cert ID. Run sync first.');
+        }
+
+        $payload = $synergy->reissueSSLCertificate($ssl->cert_id, $validated['csr']);
+
+        AuditLogger::logAction('ssl.rekey', $ssl, "Rekey/reissue attempted for {$ssl->common_name}.", [
+            'context' => ['service' => 'ssl', 'function' => 'rekey'],
+            'new_values' => ['cert_id' => $ssl->cert_id, 'status' => $payload['status'] ?? null],
+        ]);
+
+        return back()->with('ssl_action_message', $payload['errorMessage'] ?? ($payload['status'] ?? 'Rekey request submitted.'));
+    }
+
+    private function buildContactPayload(?Client $client): array
+    {
+        $contactName = trim((string) (($client?->primary_contact_name) ?: ($client?->business_name) ?: 'DomainDash Contact'));
+        [$firstName, $lastName] = array_pad(preg_split('/\s+/', $contactName, 2) ?: [], 2, '');
+
+        return [
+            'firstName' => $firstName,
+            'lastName' => $lastName,
+            'emailAddress' => $client?->email ?: 'support@example.com',
+            'address' => $client?->address ?: 'Unknown',
+            'city' => $client?->city ?: 'Unknown',
+            'state' => $client?->state ?: 'Unknown',
+            'postCode' => $client?->postcode ?: '0000',
+            'country' => $client?->country ?: 'AU',
+            'phone' => $client?->phone ?: '0000000000',
+            'fax' => $client?->phone ?: '0000000000',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/SslController.php
+++ b/app/Http/Controllers/Admin/SslController.php
@@ -163,6 +163,54 @@ class SslController extends Controller
         return back()->with('ssl_action_message', $payload['errorMessage'] ?? ($payload['status'] ?? 'Rekey request submitted.'));
     }
 
+    public function assignClient(Request $request, SslCertificate $ssl)
+    {
+        $validated = $request->validate([
+            'client_id' => 'nullable|integer|exists:clients,id',
+        ]);
+
+        $ssl->client_id = $validated['client_id'] ?? null;
+        $ssl->save();
+
+        AuditLogger::logAction('ssl.assign-client', $ssl, "Updated SSL client assignment for {$ssl->common_name}.", [
+            'context' => ['service' => 'ssl', 'function' => 'assign-client'],
+            'new_values' => ['client_id' => $ssl->client_id],
+        ]);
+
+        return back()->with('ssl_action_message', 'Client assignment updated.');
+    }
+
+    public function decodeCsr(Request $request, SynergyWholesaleClient $synergy)
+    {
+        $validated = $request->validate([
+            'csr' => 'required|string',
+        ]);
+
+        $payload = $synergy->decodeSSLCsr($validated['csr']);
+        $status = strtoupper((string) ($payload['status'] ?? ''));
+
+        if ($status !== 'OK') {
+            return response()->json([
+                'success' => false,
+                'message' => $payload['errorMessage'] ?? 'Unable to decode CSR.',
+            ], 422);
+        }
+
+        return response()->json([
+            'success' => true,
+            'decoded' => [
+                'commonName' => $payload['commonName'] ?? null,
+                'organisation' => $payload['organisation'] ?? null,
+                'organisationUnit' => $payload['organisationUnit'] ?? null,
+                'city' => $payload['city'] ?? null,
+                'state' => $payload['state'] ?? null,
+                'country' => $payload['country'] ?? null,
+                'emailAddress' => $payload['emailAddress'] ?? null,
+                'privateKeyLength' => $payload['privateKeyLength'] ?? null,
+            ],
+        ]);
+    }
+
     private function buildContactPayload(?Client $client): array
     {
         $contactName = trim((string) (($client?->primary_contact_name) ?: ($client?->business_name) ?: 'DomainDash Contact'));

--- a/app/Http/Controllers/Admin/SslController.php
+++ b/app/Http/Controllers/Admin/SslController.php
@@ -123,9 +123,26 @@ class SslController extends Controller
         $ssl->load('client', 'domain');
 
         $statusPayload = null;
+        $csrDetails = null;
 
         if ($ssl->cert_id) {
             $statusPayload = $synergy->getSSLCertSimpleStatus($ssl->cert_id);
+            $csr = $synergy->getCsrForCertificate($ssl->cert_id);
+            if (!empty($csr)) {
+                $decoded = $synergy->decodeSSLCsr($csr);
+                if (strtoupper((string) ($decoded['status'] ?? '')) === 'OK') {
+                    $csrDetails = [
+                        'country' => $decoded['country'] ?? null,
+                        'commonName' => $decoded['commonName'] ?? null,
+                        'city' => $decoded['city'] ?? null,
+                        'state' => $decoded['state'] ?? null,
+                        'organisation' => $decoded['organisation'] ?? null,
+                        'organisationUnit' => $decoded['organisationUnit'] ?? null,
+                        'emailAddress' => $decoded['emailAddress'] ?? null,
+                        'privateKeyLength' => $decoded['privateKeyLength'] ?? null,
+                    ];
+                }
+            }
         }
 
         $ssl->setAttribute('display_product_name', $this->resolveProductName($ssl->product_name));
@@ -133,6 +150,7 @@ class SslController extends Controller
         return view('admin.ssls.show', [
             'ssl' => $ssl,
             'statusPayload' => $statusPayload,
+            'csrDetails' => $csrDetails,
             'certPayload' => session('ssl_certificate_payload'),
             'actionMessage' => session('ssl_action_message'),
         ]);
@@ -225,6 +243,27 @@ class SslController extends Controller
         ]);
 
         return back()->with('ssl_action_message', $payload['errorMessage'] ?? ($payload['status'] ?? 'Renew request submitted.'));
+    }
+
+    public function resendCompletionEmail(SslCertificate $ssl, SynergyWholesaleClient $synergy)
+    {
+        if (!$ssl->cert_id) {
+            return back()->with('ssl_action_message', 'This SSL record has no Synergy cert ID. Run sync first.');
+        }
+
+        $payload = $synergy->resendIssuedCertificateEmail($ssl->cert_id);
+        $status = strtoupper((string) ($payload['status'] ?? ''));
+
+        AuditLogger::logAction('ssl.resend-completion-email', $ssl, "Resent completion email for {$ssl->common_name}.", [
+            'context' => ['service' => 'ssl', 'function' => 'resend-completion-email'],
+            'new_values' => ['cert_id' => $ssl->cert_id, 'status' => $payload['status'] ?? null],
+        ]);
+
+        if ($status !== 'OK') {
+            return back()->with('ssl_action_message', $payload['errorMessage'] ?? 'Unable to resend completion email.');
+        }
+
+        return back()->with('ssl_action_message', 'Completion email sent from Synergy.');
     }
 
     public function rekey(Request $request, SslCertificate $ssl, SynergyWholesaleClient $synergy)

--- a/app/Http/Controllers/Admin/SslController.php
+++ b/app/Http/Controllers/Admin/SslController.php
@@ -6,9 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Models\Client;
 use App\Models\Domain;
 use App\Models\SslCertificate;
+use App\Models\SslProduct;
 use App\Services\AuditLogger;
 use App\Services\Synergy\SynergyWholesaleClient;
 use Illuminate\Http\Request;
+use ZipArchive;
 
 class SslController extends Controller
 {
@@ -29,7 +31,9 @@ class SslController extends Controller
         }
 
         $productsResponse = $synergy->listSSLProducts();
-        $productNameById = collect($productsResponse['pricing'] ?? [])
+        $pricing = collect($productsResponse['pricing'] ?? []);
+
+        $productNameById = $pricing
             ->map(fn (array $entry): array => [
                 'id' => (string) ($entry['productID'] ?? ''),
                 'name' => $entry['productName'] ?? null,
@@ -37,6 +41,24 @@ class SslController extends Controller
             ->filter(fn (array $entry): bool => $entry['id'] !== '' && !empty($entry['name']))
             ->pluck('name', 'id')
             ->all();
+
+        foreach ($pricing as $entry) {
+            $productId = (string) ($entry['productID'] ?? '');
+            if ($productId === '') {
+                continue;
+            }
+
+            SslProduct::updateOrCreate(
+                ['product_id' => $productId],
+                [
+                    'name' => (string) ($entry['productName'] ?? ('Product #' . $productId)),
+                    'description' => $entry['productDescription'] ?? null,
+                    'remote_product_type' => $entry['remoteProductType'] ?? null,
+                    'price' => $entry['price'] ?? null,
+                    'last_synced_at' => now(),
+                ]
+            );
+        }
 
         $certs = $response['certs'] ?? [];
         $synced = 0;
@@ -86,6 +108,12 @@ class SslController extends Controller
 
         $ssls = $q->orderByDesc('expire_date')->paginate(25);
         $clients = Client::orderBy('business_name')->get();
+        $productNames = SslProduct::query()->pluck('name', 'product_id');
+
+        $ssls->getCollection()->transform(function (SslCertificate $ssl) use ($productNames): SslCertificate {
+            $ssl->setAttribute('display_product_name', $this->resolveProductName($ssl->product_name, $productNames));
+            return $ssl;
+        });
 
         return view('admin.ssls.index', compact('ssls', 'clients'));
     }
@@ -100,6 +128,8 @@ class SslController extends Controller
             $statusPayload = $synergy->getSSLCertSimpleStatus($ssl->cert_id);
         }
 
+        $ssl->setAttribute('display_product_name', $this->resolveProductName($ssl->product_name));
+
         return view('admin.ssls.show', [
             'ssl' => $ssl,
             'statusPayload' => $statusPayload,
@@ -111,10 +141,35 @@ class SslController extends Controller
     public function getCertificate(SslCertificate $ssl, SynergyWholesaleClient $synergy)
     {
         if (!$ssl->cert_id) {
+            if (request()->expectsJson()) {
+                return response()->json(['success' => false, 'message' => 'This SSL record has no Synergy cert ID. Run sync first.'], 422);
+            }
+
             return back()->with('ssl_action_message', 'This SSL record has no Synergy cert ID. Run sync first.');
         }
 
         $payload = $synergy->getSSLCertificate($ssl->cert_id);
+        $status = strtoupper((string) ($payload['status'] ?? ''));
+
+        if (request()->expectsJson()) {
+            if ($status !== 'OK') {
+                return response()->json([
+                    'success' => false,
+                    'message' => $payload['errorMessage'] ?? 'Unable to fetch certificate bundle.',
+                ], 422);
+            }
+
+            return response()->json([
+                'success' => true,
+                'bundle' => [
+                    'cer' => $payload['cer'] ?? '',
+                    'p7b' => $payload['p7b'] ?? '',
+                    'caBundle' => $payload['caBundle'] ?? '',
+                    'certStatus' => $payload['certStatus'] ?? null,
+                    'commonName' => $payload['commonName'] ?? $ssl->common_name,
+                ],
+            ]);
+        }
 
         AuditLogger::logAction('ssl.get-certificate', $ssl, "Fetched certificate bundle for {$ssl->common_name}.", [
             'context' => ['service' => 'ssl', 'function' => 'get-certificate'],
@@ -124,6 +179,35 @@ class SslController extends Controller
         return back()
             ->with('ssl_action_message', $payload['errorMessage'] ?? 'Certificate bundle fetched from Synergy.')
             ->with('ssl_certificate_payload', $payload);
+    }
+
+    public function downloadBundle(SslCertificate $ssl, SynergyWholesaleClient $synergy)
+    {
+        if (!$ssl->cert_id) {
+            return back()->with('ssl_action_message', 'This SSL record has no Synergy cert ID. Run sync first.');
+        }
+
+        $payload = $synergy->getSSLCertificate($ssl->cert_id);
+        $status = strtoupper((string) ($payload['status'] ?? ''));
+
+        if ($status !== 'OK') {
+            return back()->with('ssl_action_message', $payload['errorMessage'] ?? 'Unable to build certificate ZIP.');
+        }
+
+        if (!class_exists(ZipArchive::class)) {
+            return back()->with('ssl_action_message', 'ZIP support is not available on this server.');
+        }
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ssl_bundle_');
+        $zip = new ZipArchive();
+        $zip->open($zipPath, ZipArchive::OVERWRITE);
+        $zip->addFromString('certificate.cer', (string) ($payload['cer'] ?? ''));
+        $zip->addFromString('certificate.p7b', (string) ($payload['p7b'] ?? ''));
+        $zip->addFromString('ca-bundle.pem', (string) ($payload['caBundle'] ?? ''));
+        $zip->close();
+
+        $safeName = preg_replace('/[^A-Za-z0-9_.-]/', '-', (string) ($ssl->common_name ?: 'ssl-certificate'));
+        return response()->download($zipPath, $safeName . '-bundle.zip')->deleteFileAfterSend(true);
     }
 
     public function renew(Request $request, SslCertificate $ssl, SynergyWholesaleClient $synergy)
@@ -228,5 +312,24 @@ class SslController extends Controller
             'phone' => $client?->phone ?: '0000000000',
             'fax' => $client?->phone ?: '0000000000',
         ];
+    }
+
+    private function resolveProductName(?string $rawProductName, $productNames = null): string
+    {
+        $value = trim((string) ($rawProductName ?? ''));
+        if ($value === '') {
+            return 'Unknown product';
+        }
+
+        $map = $productNames ?? SslProduct::query()->pluck('name', 'product_id');
+        if (isset($map[$value]) && !empty($map[$value])) {
+            return $map[$value];
+        }
+
+        if (ctype_digit($value)) {
+            return 'Product #' . $value;
+        }
+
+        return $value;
     }
 }

--- a/app/Http/Controllers/Admin/SslPurchaseController.php
+++ b/app/Http/Controllers/Admin/SslPurchaseController.php
@@ -26,7 +26,8 @@ class SslPurchaseController extends Controller
     public function index()
     {
         try {
-            $products = $this->synergy->listSSLProducts();
+            $productsResponse = $this->synergy->listSSLProducts();
+            $products = $productsResponse['pricing'] ?? [];
             $clients = Client::orderBy('business_name')->get();
 
             return view('admin.services.ssl-purchase', compact('products', 'clients'));
@@ -49,6 +50,8 @@ class SslPurchaseController extends Controller
             'domain' => 'required|string',
             'years' => 'required|integer|min:1|max:5',
             'client_id' => 'required|exists:clients,id',
+            'csr' => 'required|string',
+            'private_key' => 'required|string',
         ]);
 
         DB::beginTransaction();
@@ -56,14 +59,30 @@ class SslPurchaseController extends Controller
         try {
             $client = Client::findOrFail($request->client_id);
 
-            // Purchase SSL with Synergy
+            $contactName = trim((string) ($client->primary_contact_name ?: $client->business_name));
+            [$firstName, $lastName] = array_pad(preg_split('/\s+/', $contactName, 2) ?: [], 2, '');
+
             $result = $this->synergy->purchaseSSL(
                 $request->product_id,
                 $request->domain,
-                $request->years
+                $request->years,
+                [
+                    'csr' => $request->csr,
+                    'privateKey' => $request->private_key,
+                    'firstName' => $firstName,
+                    'lastName' => $lastName,
+                    'emailAddress' => $client->email ?: 'support@example.com',
+                    'address' => $client->address ?: 'Unknown',
+                    'city' => $client->city ?: 'Unknown',
+                    'state' => $client->state ?: 'Unknown',
+                    'postCode' => $client->postcode ?: '0000',
+                    'country' => $client->country ?: 'AU',
+                    'phone' => $client->phone ?: '0000000000',
+                    'fax' => $client->phone ?: '0000000000',
+                ]
             );
 
-            if (isset($result['status']) && in_array($result['status'], ['OK', 'pending'])) {
+            if (isset($result['status']) && in_array(strtolower((string) $result['status']), ['ok', 'pending'], true)) {
                 // Find or create domain record
                 $domain = Domain::where('name', $request->domain)->first();
                 if (!$domain) {
@@ -80,11 +99,11 @@ class SslPurchaseController extends Controller
                     'client_id' => $client->id,
                     'domain_id' => $domain->id,
                     'cert_id' => $result['certID'] ?? null,
-                    'common_name' => $request->domain,
+                    'common_name' => $result['commonName'] ?? $request->domain,
                     'product_name' => $request->product_id,
                     'start_date' => now(),
                     'expire_date' => now()->addYears($request->years),
-                    'status' => 'pending',
+                    'status' => $result['certStatus'] ?? 'pending',
                 ]);
 
                 DB::commit();

--- a/app/Models/SslProduct.php
+++ b/app/Models/SslProduct.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SslProduct extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'name',
+        'description',
+        'remote_product_type',
+        'price',
+        'last_synced_at',
+    ];
+
+    protected $casts = [
+        'price' => 'decimal:2',
+        'last_synced_at' => 'datetime',
+    ];
+}

--- a/app/Services/Synergy/SynergyWholesaleClient.php
+++ b/app/Services/Synergy/SynergyWholesaleClient.php
@@ -654,6 +654,17 @@ class SynergyWholesaleClient
         return (array) $res;
     }
 
+    public function resendIssuedCertificateEmail(string $certId): array
+    {
+        $params = array_merge($this->creds(), [
+            'certID' => $certId,
+        ]);
+
+        $res = $this->soap->__soapCall('SSL_resendIssuedCertificateEmail', [$params]);
+
+        return (array) $res;
+    }
+
     public function decodeSSLCsr(string $csr): array
     {
         $params = array_merge($this->creds(), [
@@ -663,6 +674,23 @@ class SynergyWholesaleClient
         $res = $this->soap->__soapCall('SSL_decodeCSR', [$params]);
 
         return (array) $res;
+    }
+
+    public function getCsrForCertificate(string $certId): ?string
+    {
+        $payload = $this->listAllSSLCerts();
+        if (strtoupper((string) ($payload['status'] ?? '')) !== 'OK') {
+            return null;
+        }
+
+        foreach ($payload['certs'] ?? [] as $entry) {
+            if ((string) ($entry['certID'] ?? '') === $certId) {
+                $csr = trim((string) ($entry['csr'] ?? ''));
+                return $csr !== '' ? $csr : null;
+            }
+        }
+
+        return null;
     }
 
     /* -----------------------------------------------------------------

--- a/app/Services/Synergy/SynergyWholesaleClient.php
+++ b/app/Services/Synergy/SynergyWholesaleClient.php
@@ -594,6 +594,66 @@ class SynergyWholesaleClient
         return $payload;
     }
 
+
+
+    public function getSSLCertificate(string $certId): array
+    {
+        $params = array_merge($this->creds(), [
+            'certID' => $certId,
+        ]);
+
+        $res = $this->soap->__soapCall('SSL_getSSLCertificate', [$params]);
+
+        return (array) $res;
+    }
+
+    public function getSSLCertSimpleStatus(string $certId): array
+    {
+        $params = array_merge($this->creds(), [
+            'certID' => $certId,
+        ]);
+
+        $res = $this->soap->__soapCall('SSL_getCertSimpleStatus', [$params]);
+
+        return (array) $res;
+    }
+
+    public function renewSSLCertificate(string $certId, array $contact): array
+    {
+        $defaults = [
+            'firstName' => '',
+            'lastName' => '',
+            'emailAddress' => '',
+            'address' => '',
+            'city' => '',
+            'state' => '',
+            'postCode' => '',
+            'country' => '',
+            'phone' => '',
+            'fax' => '',
+        ];
+
+        $params = array_merge($this->creds(), $defaults, [
+            'certID' => $certId,
+        ], $contact);
+
+        $res = $this->soap->__soapCall('SSL_renewSSLCertificate', [$params]);
+
+        return (array) $res;
+    }
+
+    public function reissueSSLCertificate(string $certId, string $newCsr): array
+    {
+        $params = array_merge($this->creds(), [
+            'certID' => $certId,
+            'newCSR' => $newCsr,
+        ]);
+
+        $res = $this->soap->__soapCall('SSL_reissueCertificate', [$params]);
+
+        return (array) $res;
+    }
+
     /* -----------------------------------------------------------------
      |  Account Balance
      |------------------------------------------------------------------*/

--- a/app/Services/Synergy/SynergyWholesaleClient.php
+++ b/app/Services/Synergy/SynergyWholesaleClient.php
@@ -44,6 +44,31 @@ class SynergyWholesaleClient
     }
 
     /**
+     * Normalize SOAP array-like payloads to plain PHP arrays.
+     *
+     * Synergy SOAP responses often return stdClass entries inside array fields,
+     * even when the parent field is cast to an array.
+     */
+    protected function normalizeSoapEntries(mixed $value): array
+    {
+        if (is_object($value)) {
+            $value = [$value];
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_map(function ($entry) {
+            if (is_object($entry)) {
+                return (array) $entry;
+            }
+
+            return is_array($entry) ? $entry : [];
+        }, $value);
+    }
+
+    /**
      * Update nameservers and DNS config for a domain.
      *
      * Wraps the Synergy "updateNameServers" SOAP operation.
@@ -510,17 +535,7 @@ class SynergyWholesaleClient
         $res = $this->soap->__soapCall('getSSLPricing', [$params]);
         $payload = (array) $res;
 
-        $pricing = $payload['pricing'] ?? [];
-
-        if (is_object($pricing)) {
-            $pricing = [$pricing];
-        }
-
-        if (! is_array($pricing)) {
-            $pricing = [];
-        }
-
-        $payload['pricing'] = $pricing;
+        $payload['pricing'] = $this->normalizeSoapEntries($payload['pricing'] ?? []);
 
         return $payload;
     }
@@ -574,17 +589,7 @@ class SynergyWholesaleClient
         $res = $this->soap->__soapCall('SSL_listAllCerts', [$params]);
         $payload = (array) $res;
 
-        $certs = $payload['certs'] ?? [];
-
-        if (is_object($certs)) {
-            $certs = [$certs];
-        }
-
-        if (! is_array($certs)) {
-            $certs = [];
-        }
-
-        $payload['certs'] = $certs;
+        $payload['certs'] = $this->normalizeSoapEntries($payload['certs'] ?? []);
 
         return $payload;
     }

--- a/app/Services/Synergy/SynergyWholesaleClient.php
+++ b/app/Services/Synergy/SynergyWholesaleClient.php
@@ -507,8 +507,22 @@ class SynergyWholesaleClient
     public function listSSLProducts(): array
     {
         $params = $this->creds();
-        $res = $this->soap->__soapCall('listSSLProducts', [$params]);
-        return (array) $res;
+        $res = $this->soap->__soapCall('getSSLPricing', [$params]);
+        $payload = (array) $res;
+
+        $pricing = $payload['pricing'] ?? [];
+
+        if (is_object($pricing)) {
+            $pricing = [$pricing];
+        }
+
+        if (! is_array($pricing)) {
+            $pricing = [];
+        }
+
+        $payload['pricing'] = $pricing;
+
+        return $payload;
     }
 
     /**
@@ -526,18 +540,53 @@ class SynergyWholesaleClient
         int $years = 1,
         array $extra = []
     ): array {
-        $params = array_merge($this->creds(), [
-            'productID' => $productId,
-            'domain' => $domain,
-            'years' => $years,
-        ]);
+        $defaults = [
+            'privateKey' => '',
+            'csr' => '',
+            'firstName' => '',
+            'lastName' => '',
+            'emailAddress' => '',
+            'address' => '',
+            'city' => '',
+            'state' => '',
+            'postCode' => '',
+            'country' => '',
+            'phone' => '',
+            'fax' => '',
+            'businessCategory' => null,
+        ];
 
-        if (!empty($extra)) {
-            $params = array_merge($params, $extra);
+        $params = array_merge($this->creds(), $defaults, [
+            'productID' => $productId,
+        ], $extra);
+
+        $res = $this->soap->__soapCall('SSL_purchaseSSLCertificate', [$params]);
+
+        return (array) $res;
+    }
+
+    /**
+     * List all SSL certificates in the reseller account.
+     */
+    public function listAllSSLCerts(): array
+    {
+        $params = $this->creds();
+        $res = $this->soap->__soapCall('SSL_listAllCerts', [$params]);
+        $payload = (array) $res;
+
+        $certs = $payload['certs'] ?? [];
+
+        if (is_object($certs)) {
+            $certs = [$certs];
         }
 
-        $res = $this->soap->__soapCall('purchaseSSL', [$params]);
-        return (array) $res;
+        if (! is_array($certs)) {
+            $certs = [];
+        }
+
+        $payload['certs'] = $certs;
+
+        return $payload;
     }
 
     /* -----------------------------------------------------------------

--- a/app/Services/Synergy/SynergyWholesaleClient.php
+++ b/app/Services/Synergy/SynergyWholesaleClient.php
@@ -654,6 +654,17 @@ class SynergyWholesaleClient
         return (array) $res;
     }
 
+    public function decodeSSLCsr(string $csr): array
+    {
+        $params = array_merge($this->creds(), [
+            'csr' => $csr,
+        ]);
+
+        $res = $this->soap->__soapCall('SSL_decodeCSR', [$params]);
+
+        return (array) $res;
+    }
+
     /* -----------------------------------------------------------------
      |  Account Balance
      |------------------------------------------------------------------*/

--- a/database/migrations/2026_04_22_000100_create_ssl_products_table.php
+++ b/database/migrations/2026_04_22_000100_create_ssl_products_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ssl_products', function (Blueprint $table) {
+            $table->id();
+            $table->string('product_id')->unique();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('remote_product_type')->nullable();
+            $table->decimal('price', 10, 2)->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ssl_products');
+    }
+};

--- a/resources/views/admin/services/ssl-purchase.blade.php
+++ b/resources/views/admin/services/ssl-purchase.blade.php
@@ -64,6 +64,19 @@
             </div>
         </div>
 
+
+        <div style="margin-bottom: 16px;">
+            <label style="display: block; margin-bottom: 8px; font-weight: 500;">CSR *</label>
+            <textarea id="csr" rows="5" placeholder="-----BEGIN CERTIFICATE REQUEST-----"
+                style="width: 100%; padding: 12px; border: 1px solid #e5e7eb; border-radius: 6px; font-size: 13px; font-family: monospace;"></textarea>
+        </div>
+
+        <div style="margin-bottom: 16px;">
+            <label style="display: block; margin-bottom: 8px; font-weight: 500;">Private Key *</label>
+            <textarea id="private-key" rows="5" placeholder="-----BEGIN PRIVATE KEY-----"
+                style="width: 100%; padding: 12px; border: 1px solid #e5e7eb; border-radius: 6px; font-size: 13px; font-family: monospace;"></textarea>
+        </div>
+
         <div style="margin-bottom: 16px; padding: 16px; background: #dbeafe; border: 1px solid #3b82f6; border-radius: 6px;">
             <p style="color: #1e40af; font-size: 14px;">
                 <strong>Note:</strong> After purchase, you will need to generate and submit a CSR (Certificate Signing Request) to activate the certificate.
@@ -82,8 +95,10 @@ function purchaseSSL() {
     const domain = document.getElementById('domain').value.trim();
     const years = parseInt(document.getElementById('years').value);
     const clientId = document.getElementById('client-id').value;
+    const csr = document.getElementById('csr').value.trim();
+    const privateKey = document.getElementById('private-key').value.trim();
 
-    if (!productId || !domain || !clientId) {
+    if (!productId || !domain || !clientId || !csr || !privateKey) {
         alert('Please fill in all required fields.');
         return;
     }
@@ -102,7 +117,9 @@ function purchaseSSL() {
             product_id: productId,
             domain: domain,
             years: years,
-            client_id: clientId
+            client_id: clientId,
+            csr: csr,
+            private_key: privateKey
         })
     })
     .then(res => res.json())

--- a/resources/views/admin/ssls/index.blade.php
+++ b/resources/views/admin/ssls/index.blade.php
@@ -59,7 +59,7 @@
 
                 <tr data-ssl-toggle="{{ $rowId }}" class="dd-domain-row" style="cursor:pointer;">
                     <td>{{ $ssl->common_name ?: '—' }}</td>
-                    <td>{{ $ssl->product_name ?: 'Unknown product' }}</td>
+                    <td>{{ $ssl->display_product_name }}</td>
                     <td class="{{ $ssl->isExpiringSoon() ? 'danger' : '' }}">
                         @if($expiresInDays !== null)
                             {{ optional($ssl->expire_date)->toDateString() }} ({{ $expiresInDays }} day{{ $expiresInDays === 1 ? '' : 's' }})
@@ -92,7 +92,7 @@
                                         @endif
                                     </div>
                                 </div>
-                                <div style="font-size:13px;opacity:.7;">Product: {{ $ssl->product_name ?: 'Unknown product' }}</div>
+                                <div style="font-size:13px;opacity:.7;">Product: {{ $ssl->display_product_name }}</div>
                             </div>
 
                             <div class="dd-domain-options-grid">
@@ -114,13 +114,10 @@
                                     <div class="dd-domain-option-label">Assign client</div>
                                 </button>
 
-                                <form method="POST" action="{{ route('admin.services.ssl.certificate', $ssl) }}" class="dd-domain-option-form">
-                                    @csrf
-                                    <button type="submit" class="dd-domain-option-btn">
-                                        <div class="dd-domain-option-icon">📄</div>
-                                        <div class="dd-domain-option-label">Get cert / bundle</div>
-                                    </button>
-                                </form>
+                                <button type="button" class="dd-domain-option" data-open-bundle="{{ $ssl->id }}" data-ssl-name="{{ $ssl->common_name ?: 'Certificate #'.$ssl->id }}">
+                                    <div class="dd-domain-option-icon">📄</div>
+                                    <div class="dd-domain-option-label">Get cert / bundle</div>
+                                </button>
 
                                 <button type="button" class="dd-domain-option" data-open-rekey="{{ $ssl->id }}" data-ssl-name="{{ $ssl->common_name ?: 'Certificate #'.$ssl->id }}">
                                     <div class="dd-domain-option-icon">♻️</div>
@@ -192,6 +189,36 @@
                 @csrf
                 <input type="hidden" name="csr" id="dd-rekey-csr-hidden">
             </form>
+        </div>
+    </div>
+
+    <div id="dd-bundle-modal" class="dd-modal" style="display:none;">
+        <div class="dd-modal-backdrop"></div>
+        <div class="dd-modal-dialog" style="width:900px;max-width:97%;">
+            <h2 style="font-size:18px;font-weight:600;margin-bottom:12px;">Certificate Bundle</h2>
+            <p style="font-size:14px;margin-bottom:12px;">Certificate: <span id="dd-bundle-ssl-name"></span></p>
+
+            <div style="display:flex;gap:10px;margin-bottom:10px;">
+                <a href="#" id="dd-bundle-download-link" class="btn-accent" style="text-decoration:none;pointer-events:none;opacity:.5;">Download ZIP file</a>
+                <button type="button" id="dd-bundle-close" class="btn-accent">Close</button>
+            </div>
+
+            <div id="dd-bundle-status" style="margin-bottom:10px;font-size:14px;"></div>
+
+            <div style="display:grid;grid-template-columns:1fr;gap:10px;">
+                <div>
+                    <label style="display:block;margin-bottom:6px;">Certificate (CER)</label>
+                    <textarea id="dd-bundle-cer" rows="5" class="dd-input" style="width:100%;font-family:monospace;" readonly></textarea>
+                </div>
+                <div>
+                    <label style="display:block;margin-bottom:6px;">Certificate (P7B)</label>
+                    <textarea id="dd-bundle-p7b" rows="5" class="dd-input" style="width:100%;font-family:monospace;" readonly></textarea>
+                </div>
+                <div>
+                    <label style="display:block;margin-bottom:6px;">CA Bundle</label>
+                    <textarea id="dd-bundle-ca" rows="5" class="dd-input" style="width:100%;font-family:monospace;" readonly></textarea>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -357,6 +384,72 @@
 
             rekeyCancelBtn.addEventListener('click', closeRekeyModal);
             rekeyModal.querySelector('.dd-modal-backdrop').addEventListener('click', closeRekeyModal);
+
+            var bundleModal = document.getElementById('dd-bundle-modal');
+            var bundleSslName = document.getElementById('dd-bundle-ssl-name');
+            var bundleStatus = document.getElementById('dd-bundle-status');
+            var bundleCer = document.getElementById('dd-bundle-cer');
+            var bundleP7b = document.getElementById('dd-bundle-p7b');
+            var bundleCa = document.getElementById('dd-bundle-ca');
+            var bundleDownloadLink = document.getElementById('dd-bundle-download-link');
+            var bundleCloseBtn = document.getElementById('dd-bundle-close');
+
+            function closeBundleModal() {
+                bundleModal.style.display = 'none';
+                bundleStatus.textContent = '';
+                bundleCer.value = '';
+                bundleP7b.value = '';
+                bundleCa.value = '';
+                bundleDownloadLink.href = '#';
+                bundleDownloadLink.style.pointerEvents = 'none';
+                bundleDownloadLink.style.opacity = '0.5';
+            }
+
+            document.querySelectorAll('[data-open-bundle]').forEach(function (btn) {
+                btn.addEventListener('click', async function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    var sslId = this.getAttribute('data-open-bundle');
+                    var sslName = this.getAttribute('data-ssl-name') || '';
+
+                    bundleModal.style.display = 'flex';
+                    bundleSslName.textContent = sslName;
+                    bundleStatus.textContent = 'Loading certificate bundle...';
+                    bundleCer.value = '';
+                    bundleP7b.value = '';
+                    bundleCa.value = '';
+                    bundleDownloadLink.href = '/admin/services/ssl/' + sslId + '/bundle.zip';
+
+                    try {
+                        var response = await fetch('/admin/services/ssl/' + sslId + '/certificate', {
+                            method: 'POST',
+                            headers: {
+                                'X-CSRF-TOKEN': csrfToken,
+                                'Accept': 'application/json'
+                            }
+                        });
+
+                        var payload = await response.json();
+                        if (!response.ok || !payload.success) {
+                            bundleStatus.textContent = payload.message || 'Unable to load certificate bundle.';
+                            return;
+                        }
+
+                        bundleCer.value = payload.bundle.cer || '';
+                        bundleP7b.value = payload.bundle.p7b || '';
+                        bundleCa.value = payload.bundle.caBundle || '';
+                        bundleStatus.textContent = 'Certificate bundle fetched from Synergy.';
+                        bundleDownloadLink.style.pointerEvents = 'auto';
+                        bundleDownloadLink.style.opacity = '1';
+                    } catch (error) {
+                        bundleStatus.textContent = 'Bundle fetch failed: ' + error.message;
+                    }
+                });
+            });
+
+            bundleCloseBtn.addEventListener('click', closeBundleModal);
+            bundleModal.querySelector('.dd-modal-backdrop').addEventListener('click', closeBundleModal);
         });
     </script>
 

--- a/resources/views/admin/ssls/index.blade.php
+++ b/resources/views/admin/ssls/index.blade.php
@@ -15,16 +15,21 @@
     <button type="submit">Filter</button>
 </form>
 <table border="1" cellpadding="6" cellspacing="0" width="100%" style="margin-top:12px;">
-    <thead><tr><th>Common Name</th><th>Client</th><th>Product</th><th>Start</th><th>Expire</th><th>Status</th></tr></thead>
+    <thead><tr><th>Common Name</th><th>Client</th><th>Product</th><th>Start</th><th>Expire</th><th>Status</th><th>Actions</th></tr></thead>
     <tbody>
     @foreach($ssls as $s)
         <tr @class(['danger'=>$s->isExpiringSoon()])>
-            <td>{{ $s->common_name }}</td>
+            <td>
+                <a href="{{ route('admin.services.ssl.show', $s) }}" style="color:inherit;text-decoration:underline;">
+                    {{ $s->common_name }}
+                </a>
+            </td>
             <td>{{ optional($s->client)->business_name }}</td>
-            <td>{{ $s->product_name }}</td>
+            <td>{{ $s->product_name ?: 'Unknown product' }}</td>
             <td>{{ optional($s->start_date)->toDateString() }}</td>
             <td>{{ optional($s->expire_date)->toDateString() }}</td>
             <td>{{ $s->status }}</td>
+            <td><a href="{{ route('admin.services.ssl.show', $s) }}">Manage</a></td>
         </tr>
     @endforeach
     </tbody>

--- a/resources/views/admin/ssls/index.blade.php
+++ b/resources/views/admin/ssls/index.blade.php
@@ -1,38 +1,489 @@
 @extends('layouts.app')
+
 @section('content')
-<h1>SSL Certificates</h1>
-<form method="POST" action="{{ route('admin.services.ssl.sync') }}" style="margin-bottom:12px;">
-    @csrf
-    <button type="submit" class="btn-accent">Sync from Synergy</button>
-</form>
-<form method="GET">
-    <select name="client_id">
-        <option value="">All Clients</option>
-        @foreach($clients as $c)
-            <option value="{{ $c->id }}" @selected(request('client_id')==$c->id)>{{ $c->business_name }}</option>
-        @endforeach
-    </select>
-    <button type="submit">Filter</button>
-</form>
-<table border="1" cellpadding="6" cellspacing="0" width="100%" style="margin-top:12px;">
-    <thead><tr><th>Common Name</th><th>Client</th><th>Product</th><th>Start</th><th>Expire</th><th>Status</th><th>Actions</th></tr></thead>
-    <tbody>
-    @foreach($ssls as $s)
-        <tr @class(['danger'=>$s->isExpiringSoon()])>
-            <td>
-                <a href="{{ route('admin.services.ssl.show', $s) }}" style="color:inherit;text-decoration:underline;">
-                    {{ $s->common_name }}
-                </a>
-            </td>
-            <td>{{ optional($s->client)->business_name }}</td>
-            <td>{{ $s->product_name ?: 'Unknown product' }}</td>
-            <td>{{ optional($s->start_date)->toDateString() }}</td>
-            <td>{{ optional($s->expire_date)->toDateString() }}</td>
-            <td>{{ $s->status }}</td>
-            <td><a href="{{ route('admin.services.ssl.show', $s) }}">Manage</a></td>
-        </tr>
-    @endforeach
-    </tbody>
-</table>
-{{ $ssls->withQueryString()->links() }}
+<div class="dd-page">
+    <h1 class="dd-page-title" style="font-size:1.45rem;">SSL Certificates</h1>
+
+    @if(session('status'))
+        <div class="dd-alert dd-alert-success" style="margin-bottom:12px;">{{ session('status') }}</div>
+    @endif
+
+    @if(session('ssl_action_message'))
+        <div class="dd-alert dd-alert-success" style="margin-bottom:12px;">{{ session('ssl_action_message') }}</div>
+    @endif
+
+    <div class="dd-toolbar" style="display:flex;align-items:center;gap:10px;flex-wrap:nowrap;margin-bottom:14px;">
+        <form method="GET" style="display:flex;align-items:center;gap:8px;flex:1;flex-wrap:nowrap;">
+            <select name="client_id" class="dd-input dd-input-inline" style="flex:1;min-width:240px;">
+                <option value="">All Clients</option>
+                @foreach($clients as $c)
+                    <option value="{{ $c->id }}" @selected(request('client_id')==$c->id)>{{ $c->business_name }}</option>
+                @endforeach
+            </select>
+            <button type="submit" class="btn-accent">Filter</button>
+        </form>
+
+        <form method="POST" action="{{ route('admin.services.ssl.sync') }}" style="flex:0 0 auto;">
+            @csrf
+            <button type="submit" class="btn-accent" style="white-space:nowrap;">Sync from Synergy</button>
+        </form>
+    </div>
+
+    <div class="dd-card">
+        <table>
+            <thead>
+                <tr>
+                    <th>SSL Certificate</th>
+                    <th>Product</th>
+                    <th>Certificate Expiry</th>
+                    <th>Status</th>
+                    <th>Client</th>
+                    <th style="width:120px;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach($ssls as $ssl)
+                @php
+                    $rowId = 'ssl-'.$ssl->id;
+                    $expiresInDays = null;
+                    if (!empty($ssl->expire_date)) {
+                        try {
+                            $expiry = \Carbon\Carbon::parse($ssl->expire_date)->startOfDay();
+                            $today = now()->startOfDay();
+                            $expiresInDays = (int) floor($today->diffInDays($expiry, false));
+                        } catch (\Throwable $e) {
+                            $expiresInDays = null;
+                        }
+                    }
+                @endphp
+
+                <tr data-ssl-toggle="{{ $rowId }}" class="dd-domain-row" style="cursor:pointer;">
+                    <td>{{ $ssl->common_name ?: '—' }}</td>
+                    <td>{{ $ssl->product_name ?: 'Unknown product' }}</td>
+                    <td class="{{ $ssl->isExpiringSoon() ? 'danger' : '' }}">
+                        @if($expiresInDays !== null)
+                            {{ optional($ssl->expire_date)->toDateString() }} ({{ $expiresInDays }} day{{ $expiresInDays === 1 ? '' : 's' }})
+                        @else
+                            —
+                        @endif
+                    </td>
+                    <td>{{ $ssl->status ?: '—' }}</td>
+                    <td>{{ optional($ssl->client)->business_name ?: '—' }}</td>
+                    <td>
+                        <div style="display:flex;gap:8px;justify-content:flex-end;align-items:center;font-size:14px;">
+                            <span title="Toggle details">▾</span>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr data-ssl-panel="{{ $rowId }}" class="dd-domain-panel">
+                    <td colspan="6">
+                        <div class="dd-domain-panel-inner">
+                            <div class="dd-domain-panel-header">
+                                <div>
+                                    <div style="font-weight:600;">{{ $ssl->common_name ?: 'Certificate #'.$ssl->id }}</div>
+                                    <div style="font-size:13px;opacity:.8;">
+                                        {{ $ssl->status ?: 'Status unknown' }}
+                                        @if($expiresInDays !== null)
+                                            • expires in {{ $expiresInDays }} day{{ $expiresInDays === 1 ? '' : 's' }}
+                                        @endif
+                                        @if($ssl->cert_id)
+                                            • Cert ID {{ $ssl->cert_id }}
+                                        @endif
+                                    </div>
+                                </div>
+                                <div style="font-size:13px;opacity:.7;">Product: {{ $ssl->product_name ?: 'Unknown product' }}</div>
+                            </div>
+
+                            <div class="dd-domain-options-grid">
+                                <a href="{{ route('admin.services.ssl.show', $ssl) }}" class="dd-domain-option">
+                                    <div class="dd-domain-option-icon">👁️</div>
+                                    <div class="dd-domain-option-label">Overview</div>
+                                </a>
+
+                                <form method="POST" action="{{ route('admin.services.ssl.renew', $ssl) }}" class="dd-domain-option-form" onsubmit="return confirm('Renew this SSL now?');">
+                                    @csrf
+                                    <button type="submit" class="dd-domain-option-btn">
+                                        <div class="dd-domain-option-icon">🔄</div>
+                                        <div class="dd-domain-option-label">Renew</div>
+                                    </button>
+                                </form>
+
+                                <button type="button" class="dd-domain-option" data-assign-client="{{ $ssl->id }}" data-ssl-name="{{ $ssl->common_name ?: 'Certificate #'.$ssl->id }}" data-client-id="{{ $ssl->client_id }}">
+                                    <div class="dd-domain-option-icon">👥</div>
+                                    <div class="dd-domain-option-label">Assign client</div>
+                                </button>
+
+                                <form method="POST" action="{{ route('admin.services.ssl.certificate', $ssl) }}" class="dd-domain-option-form">
+                                    @csrf
+                                    <button type="submit" class="dd-domain-option-btn">
+                                        <div class="dd-domain-option-icon">📄</div>
+                                        <div class="dd-domain-option-label">Get cert / bundle</div>
+                                    </button>
+                                </form>
+
+                                <button type="button" class="dd-domain-option" data-open-rekey="{{ $ssl->id }}" data-ssl-name="{{ $ssl->common_name ?: 'Certificate #'.$ssl->id }}">
+                                    <div class="dd-domain-option-icon">♻️</div>
+                                    <div class="dd-domain-option-label">Rekey / reissue</div>
+                                </button>
+
+                                <a href="{{ route('admin.services.ssl.show', $ssl) }}" class="dd-domain-option">
+                                    <div class="dd-domain-option-icon">🧩</div>
+                                    <div class="dd-domain-option-label">Manage details</div>
+                                </a>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+
+        {{ $ssls->withQueryString()->links() }}
+    </div>
+
+    <div id="dd-assign-modal" class="dd-modal" style="display:none;">
+        <div class="dd-modal-backdrop"></div>
+        <div class="dd-modal-dialog">
+            <h2 style="font-size:18px;font-weight:600;margin-bottom:12px;">Assign client</h2>
+            <p style="font-size:14px;margin-bottom:12px;">Update client for <span id="dd-assign-ssl-name"></span></p>
+
+            <form method="POST" id="dd-assign-form" data-action-template="{{ url('/admin/services/ssl/__SSL__/assign-client') }}" action="{{ url('/admin/services/ssl/0/assign-client') }}">
+                @csrf
+                <input type="hidden" id="dd-assign-ssl-id">
+                <label for="dd-assign-client-select" style="font-size:14px;display:block;margin-bottom:6px;">Client organisation</label>
+                <select id="dd-assign-client-select" name="client_id" class="dd-input" style="width:100%;">
+                    <option value="">— No client —</option>
+                    @foreach($clients as $client)
+                        <option value="{{ $client->id }}">{{ $client->business_name }}</option>
+                    @endforeach
+                </select>
+                <div style="margin-top:18px;display:flex;gap:10px;justify-content:flex-end;">
+                    <button type="submit" class="btn-accent">Save</button>
+                    <button type="button" class="btn-accent" id="dd-assign-cancel">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div id="dd-rekey-modal" class="dd-modal" style="display:none;">
+        <div class="dd-modal-backdrop"></div>
+        <div class="dd-modal-dialog" style="width:720px;max-width:96%;">
+            <h2 style="font-size:18px;font-weight:600;margin-bottom:12px;">Rekey / Reissue SSL</h2>
+            <p style="font-size:14px;margin-bottom:12px;">Certificate: <span id="dd-rekey-ssl-name"></span></p>
+
+            <label for="dd-rekey-csr" style="font-size:14px;display:block;margin-bottom:6px;">CSR</label>
+            <textarea id="dd-rekey-csr" rows="7" class="dd-input" style="width:100%;font-family:monospace;" placeholder="-----BEGIN CERTIFICATE REQUEST-----"></textarea>
+
+            <div style="margin-top:10px;display:flex;gap:10px;">
+                <button type="button" class="btn-accent" id="dd-rekey-decode">Decode CSR</button>
+                <button type="button" class="btn-accent" id="dd-rekey-submit" disabled>Confirm and submit reissue</button>
+                <button type="button" class="btn-accent" id="dd-rekey-cancel">Cancel</button>
+            </div>
+
+            <div id="dd-rekey-status" style="margin-top:10px;font-size:14px;"></div>
+
+            <div id="dd-rekey-decoded" style="display:none;margin-top:12px;padding:12px;border-radius:8px;border:1px solid var(--border-subtle);background:var(--surface-muted);">
+                <div style="font-weight:600;margin-bottom:8px;">CSR decoded details</div>
+                <div id="dd-rekey-decoded-grid" style="display:grid;grid-template-columns:160px 1fr;gap:6px;font-size:14px;"></div>
+            </div>
+
+            <form method="POST" id="dd-rekey-form" data-action-template="{{ url('/admin/services/ssl/__SSL__/rekey') }}" action="{{ url('/admin/services/ssl/0/rekey') }}" style="display:none;">
+                @csrf
+                <input type="hidden" name="csr" id="dd-rekey-csr-hidden">
+            </form>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('[data-ssl-toggle]').forEach(function (row) {
+                row.addEventListener('click', function (e) {
+                    if (e.target.closest('a,button,form,input,select,textarea')) return;
+
+                    var id = this.dataset.sslToggle;
+                    var panel = document.querySelector('[data-ssl-panel="' + id + '"]');
+                    if (!panel) return;
+
+                    panel.classList.toggle('open', !panel.classList.contains('open'));
+                });
+            });
+
+            var assignModal = document.getElementById('dd-assign-modal');
+            var assignForm = document.getElementById('dd-assign-form');
+            var assignSslName = document.getElementById('dd-assign-ssl-name');
+            var assignSelect = document.getElementById('dd-assign-client-select');
+            var assignCancel = document.getElementById('dd-assign-cancel');
+
+            function closeAssignModal() {
+                assignModal.style.display = 'none';
+            }
+
+            document.querySelectorAll('[data-assign-client]').forEach(function (btn) {
+                btn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    var sslId = this.getAttribute('data-assign-client');
+                    var sslName = this.getAttribute('data-ssl-name') || '';
+                    var clientId = this.getAttribute('data-client-id') || '';
+
+                    assignSslName.textContent = sslName;
+                    assignSelect.value = clientId;
+                    assignForm.action = assignForm.dataset.actionTemplate.replace('__SSL__', sslId);
+                    assignModal.style.display = 'flex';
+                });
+            });
+
+            assignCancel.addEventListener('click', function (e) {
+                e.preventDefault();
+                closeAssignModal();
+            });
+
+            assignModal.querySelector('.dd-modal-backdrop').addEventListener('click', closeAssignModal);
+
+            var rekeyModal = document.getElementById('dd-rekey-modal');
+            var rekeyForm = document.getElementById('dd-rekey-form');
+            var rekeySslName = document.getElementById('dd-rekey-ssl-name');
+            var rekeyCsr = document.getElementById('dd-rekey-csr');
+            var rekeyCsrHidden = document.getElementById('dd-rekey-csr-hidden');
+            var rekeyDecodeBtn = document.getElementById('dd-rekey-decode');
+            var rekeySubmitBtn = document.getElementById('dd-rekey-submit');
+            var rekeyCancelBtn = document.getElementById('dd-rekey-cancel');
+            var rekeyStatus = document.getElementById('dd-rekey-status');
+            var rekeyDecoded = document.getElementById('dd-rekey-decoded');
+            var rekeyDecodedGrid = document.getElementById('dd-rekey-decoded-grid');
+            var csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
+
+            function closeRekeyModal() {
+                rekeyModal.style.display = 'none';
+                rekeyCsr.value = '';
+                rekeyCsrHidden.value = '';
+                rekeyStatus.textContent = '';
+                rekeyDecoded.style.display = 'none';
+                rekeyDecodedGrid.innerHTML = '';
+                rekeySubmitBtn.disabled = true;
+            }
+
+            document.querySelectorAll('[data-open-rekey]').forEach(function (btn) {
+                btn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    var sslId = this.getAttribute('data-open-rekey');
+                    var sslName = this.getAttribute('data-ssl-name') || '';
+
+                    rekeySslName.textContent = sslName;
+                    rekeyForm.action = rekeyForm.dataset.actionTemplate.replace('__SSL__', sslId);
+                    rekeyModal.style.display = 'flex';
+                });
+            });
+
+            rekeyDecodeBtn.addEventListener('click', async function () {
+                var csrValue = rekeyCsr.value.trim();
+                if (!csrValue) {
+                    rekeyStatus.textContent = 'Please paste CSR data first.';
+                    return;
+                }
+
+                rekeyDecodeBtn.disabled = true;
+                rekeySubmitBtn.disabled = true;
+                rekeyStatus.textContent = 'Decoding CSR...';
+                rekeyDecoded.style.display = 'none';
+                rekeyDecodedGrid.innerHTML = '';
+
+                try {
+                    var response = await fetch('{{ route('admin.services.ssl.decodeCsr') }}', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken,
+                            'Accept': 'application/json'
+                        },
+                        body: JSON.stringify({ csr: csrValue })
+                    });
+
+                    var payload = await response.json();
+
+                    if (!response.ok || !payload.success) {
+                        rekeyStatus.textContent = payload.message || 'Unable to decode CSR.';
+                        return;
+                    }
+
+                    var decoded = payload.decoded || {};
+                    var fields = [
+                        ['Common Name', decoded.commonName],
+                        ['Organisation', decoded.organisation],
+                        ['Org Unit', decoded.organisationUnit],
+                        ['City', decoded.city],
+                        ['State', decoded.state],
+                        ['Country', decoded.country],
+                        ['Email', decoded.emailAddress],
+                        ['Key Length', decoded.privateKeyLength]
+                    ];
+
+                    fields.forEach(function (field) {
+                        var label = document.createElement('strong');
+                        label.textContent = field[0];
+                        var value = document.createElement('span');
+                        value.textContent = field[1] || '—';
+                        rekeyDecodedGrid.appendChild(label);
+                        rekeyDecodedGrid.appendChild(value);
+                    });
+
+                    rekeyDecoded.style.display = 'block';
+                    rekeyStatus.textContent = 'CSR decoded successfully. Confirm to submit reissue.';
+                    rekeyCsrHidden.value = csrValue;
+                    rekeySubmitBtn.disabled = false;
+                } catch (error) {
+                    rekeyStatus.textContent = 'Decode failed: ' + error.message;
+                } finally {
+                    rekeyDecodeBtn.disabled = false;
+                }
+            });
+
+            rekeySubmitBtn.addEventListener('click', function () {
+                if (!rekeyCsrHidden.value) {
+                    rekeyStatus.textContent = 'Decode CSR first before submitting.';
+                    return;
+                }
+
+                if (!confirm('Submit this CSR for reissue to Synergy?')) {
+                    return;
+                }
+
+                rekeyForm.submit();
+            });
+
+            rekeyCancelBtn.addEventListener('click', closeRekeyModal);
+            rekeyModal.querySelector('.dd-modal-backdrop').addEventListener('click', closeRekeyModal);
+        });
+    </script>
+
+    <style>
+        tr[data-ssl-panel] {
+            display: none;
+            height: 0;
+        }
+        tr[data-ssl-panel] > td {
+            padding: 0;
+            border: 0;
+        }
+        tr[data-ssl-panel].open {
+            display: table-row;
+            height: auto;
+        }
+
+        .dd-domain-panel-inner {
+            max-height: 0;
+            padding: 0;
+            margin-top: 0;
+            border: 0;
+            overflow: hidden;
+            opacity: 0;
+            transform: translateY(-4px);
+            transition: max-height 0.25s ease, opacity 0.2s ease, transform 0.2s ease, padding 0.2s ease, margin-top 0.2s ease, border-width 0.2s ease;
+        }
+
+        tr[data-ssl-panel].open > td > .dd-domain-panel-inner {
+            max-height: 700px;
+            opacity: 1;
+            transform: translateY(0);
+            padding: 16px 18px 18px;
+            margin-top: 0;
+            border-radius: 8px;
+            border: 1px solid var(--border-subtle);
+            background: var(--surface-elevated);
+        }
+
+        .dd-domain-panel-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 8px 12px;
+            border-radius: 6px;
+            background: var(--surface-muted);
+            border: 1px solid var(--border-subtle);
+            margin-bottom: 14px;
+        }
+
+        .dd-domain-options-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 10px;
+        }
+
+        .dd-domain-option,
+        .dd-domain-option-btn {
+            display: flex;
+            align-items: center;
+            padding: 10px 14px;
+            border-radius: 12px;
+            background: var(--bg);
+            border: 1px solid var(--border-subtle);
+            text-decoration: none;
+            font-size: 14px;
+            cursor: pointer;
+            width: 100%;
+            min-height: 52px;
+            box-sizing: border-box;
+            transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+        }
+
+        .dd-domain-option:hover,
+        .dd-domain-option-btn:hover {
+            background: var(--surface-muted);
+            border-color: var(--accent);
+            transform: translateY(-1px);
+        }
+
+        .dd-domain-option-btn {
+            background: transparent;
+            color: inherit;
+            height: 100%;
+        }
+
+        .dd-domain-option-form {
+            margin: 0;
+        }
+
+        .dd-domain-option-icon {
+            width: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 8px;
+        }
+
+        .dd-domain-option-label {
+            flex: 1;
+        }
+
+        .dd-modal {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 70;
+        }
+
+        .dd-modal-backdrop {
+            position: absolute;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.75);
+        }
+
+        .dd-modal-dialog {
+            position: relative;
+            background: var(--surface-elevated);
+            border-radius: 12px;
+            padding: 16px 18px 18px;
+            border: 1px solid var(--border-subtle);
+            width: 420px;
+            max-width: 95%;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+        }
+    </style>
+</div>
 @endsection

--- a/resources/views/admin/ssls/index.blade.php
+++ b/resources/views/admin/ssls/index.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 @section('content')
 <h1>SSL Certificates</h1>
+<form method="POST" action="{{ route('admin.services.ssl.sync') }}" style="margin-bottom:12px;">
+    @csrf
+    <button type="submit" class="btn-accent">Sync from Synergy</button>
+</form>
 <form method="GET">
     <select name="client_id">
         <option value="">All Clients</option>

--- a/resources/views/admin/ssls/index.blade.php
+++ b/resources/views/admin/ssls/index.blade.php
@@ -124,10 +124,13 @@
                                     <div class="dd-domain-option-label">Rekey / reissue</div>
                                 </button>
 
-                                <a href="{{ route('admin.services.ssl.show', $ssl) }}" class="dd-domain-option">
-                                    <div class="dd-domain-option-icon">🧩</div>
-                                    <div class="dd-domain-option-label">Manage details</div>
-                                </a>
+                                <form method="POST" action="{{ route('admin.services.ssl.resendCompletionEmail', $ssl) }}" class="dd-domain-option-form">
+                                    @csrf
+                                    <button type="submit" class="dd-domain-option-btn">
+                                        <div class="dd-domain-option-icon">✉️</div>
+                                        <div class="dd-domain-option-label">Resend completion email</div>
+                                    </button>
+                                </form>
                             </div>
                         </div>
                     </td>

--- a/resources/views/admin/ssls/show.blade.php
+++ b/resources/views/admin/ssls/show.blade.php
@@ -42,6 +42,24 @@
         </div>
     </div>
 
+    <div style="padding:16px;border:1px solid #334155;border-radius:10px;margin-bottom:16px;">
+        <h2 style="font-size:18px;margin-bottom:10px;">CSR Details</h2>
+        @if($csrDetails)
+            <div style="display:grid;grid-template-columns:170px 1fr;gap:8px;">
+                <strong>Country</strong><span>{{ $csrDetails['country'] ?: 'N/A' }}</span>
+                <strong>Common Name</strong><span>{{ $csrDetails['commonName'] ?: 'N/A' }}</span>
+                <strong>Location</strong><span>{{ $csrDetails['city'] ?: 'N/A' }}</span>
+                <strong>State</strong><span>{{ $csrDetails['state'] ?: 'N/A' }}</span>
+                <strong>Organization</strong><span>{{ $csrDetails['organisation'] ?: 'N/A' }}</span>
+                <strong>Organization Unit</strong><span>{{ $csrDetails['organisationUnit'] ?: 'N/A' }}</span>
+                <strong>Email</strong><span>{{ $csrDetails['emailAddress'] ?: 'N/A' }}</span>
+                <strong>Key Length</strong><span>{{ $csrDetails['privateKeyLength'] ?: 'N/A' }}</span>
+            </div>
+        @else
+            <p>CSR details are unavailable for this certificate.</p>
+        @endif
+    </div>
+
     <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
         <h2 style="font-size:18px;margin-bottom:12px;">SSL Management Options</h2>
         <div style="display:flex;flex-wrap:wrap;gap:10px;">

--- a/resources/views/admin/ssls/show.blade.php
+++ b/resources/views/admin/ssls/show.blade.php
@@ -17,7 +17,7 @@
             <div style="display:grid;grid-template-columns:160px 1fr;gap:8px;">
                 <strong>Common Name</strong><span>{{ $ssl->common_name ?: '—' }}</span>
                 <strong>Synergy Cert ID</strong><span>{{ $ssl->cert_id ?: '—' }}</span>
-                <strong>Product</strong><span>{{ $ssl->product_name ?: '—' }}</span>
+                <strong>Product</strong><span>{{ $ssl->display_product_name }}</span>
                 <strong>Status</strong><span>{{ $ssl->status ?: '—' }}</span>
                 <strong>Start Date</strong><span>{{ optional($ssl->start_date)->toDateString() ?: '—' }}</span>
                 <strong>Expire Date</strong><span>{{ optional($ssl->expire_date)->toDateString() ?: '—' }}</span>
@@ -31,7 +31,7 @@
                 <div style="display:grid;grid-template-columns:160px 1fr;gap:8px;">
                     <strong>Status</strong><span>{{ $statusPayload['status'] ?? '—' }}</span>
                     <strong>Cert Status</strong><span>{{ $statusPayload['certStatus'] ?? '—' }}</span>
-                    <strong>Product Name</strong><span>{{ $statusPayload['productName'] ?? '—' }}</span>
+                    <strong>Product Name</strong><span>{{ $statusPayload['productName'] ?? $ssl->display_product_name }}</span>
                     <strong>Product Years</strong><span>{{ $statusPayload['productYears'] ?? '—' }}</span>
                     <strong>Start Date</strong><span>{{ $statusPayload['startDate'] ?? '—' }}</span>
                     <strong>Expire Date</strong><span>{{ $statusPayload['expireDate'] ?? '—' }}</span>
@@ -42,40 +42,239 @@
         </div>
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
-        <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
-            <h2 style="font-size:18px;margin-bottom:12px;">Certificate Actions</h2>
-            <form method="POST" action="{{ route('admin.services.ssl.certificate', $ssl) }}" style="margin-bottom:10px;">
-                @csrf
-                <button type="submit" class="btn-accent">Get Certificate / Bundle</button>
-            </form>
-
-            <form method="POST" action="{{ route('admin.services.ssl.renew', $ssl) }}" style="margin-bottom:10px;">
+    <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
+        <h2 style="font-size:18px;margin-bottom:12px;">SSL Management Options</h2>
+        <div style="display:flex;flex-wrap:wrap;gap:10px;">
+            <button type="button" class="btn-accent" id="open-bundle-modal">Get Certificate / Bundle</button>
+            <form method="POST" action="{{ route('admin.services.ssl.renew', $ssl) }}" onsubmit="return confirm('Renew this SSL now?');">
                 @csrf
                 <button type="submit" class="btn-accent">Renew Certificate</button>
             </form>
-
-            <form method="POST" action="{{ route('admin.services.ssl.rekey', $ssl) }}">
-                @csrf
-                <label style="display:block;margin-bottom:6px;">New CSR for Rekey/Reissue</label>
-                <textarea name="csr" rows="6" style="width:100%;margin-bottom:10px;" required placeholder="-----BEGIN CERTIFICATE REQUEST-----"></textarea>
-                <button type="submit" class="btn-accent">Rekey / Reissue Certificate</button>
-            </form>
-        </div>
-
-        <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
-            <h2 style="font-size:18px;margin-bottom:12px;">Fetched Certificate Data</h2>
-            @if($certPayload)
-                <label style="display:block;margin-bottom:6px;">CER</label>
-                <textarea rows="5" style="width:100%;margin-bottom:8px;" readonly>{{ $certPayload['cer'] ?? '' }}</textarea>
-                <label style="display:block;margin-bottom:6px;">P7B</label>
-                <textarea rows="5" style="width:100%;margin-bottom:8px;" readonly>{{ $certPayload['p7b'] ?? '' }}</textarea>
-                <label style="display:block;margin-bottom:6px;">CA Bundle</label>
-                <textarea rows="5" style="width:100%;" readonly>{{ $certPayload['caBundle'] ?? '' }}</textarea>
-            @else
-                <p>No certificate payload loaded in this session yet.</p>
-            @endif
+            <button type="button" class="btn-accent" id="open-rekey-modal">Rekey / Reissue</button>
         </div>
     </div>
 </div>
+
+<div id="bundle-modal" class="dd-modal" style="display:none;">
+    <div class="dd-modal-backdrop"></div>
+    <div class="dd-modal-dialog" style="width:900px;max-width:97%;">
+        <h2 style="font-size:18px;font-weight:600;margin-bottom:12px;">Certificate Bundle</h2>
+        <div style="display:flex;gap:10px;margin-bottom:10px;">
+            <a href="{{ route('admin.services.ssl.bundleZip', $ssl) }}" class="btn-accent" style="text-decoration:none;">Download ZIP file</a>
+            <button type="button" id="close-bundle-modal" class="btn-accent">Close</button>
+        </div>
+        <div id="bundle-status" style="margin-bottom:10px;"></div>
+        <label style="display:block;margin-bottom:6px;">Certificate (CER)</label>
+        <textarea id="bundle-cer" rows="4" class="dd-input" style="width:100%;font-family:monospace;margin-bottom:8px;" readonly></textarea>
+        <label style="display:block;margin-bottom:6px;">Certificate (P7B)</label>
+        <textarea id="bundle-p7b" rows="4" class="dd-input" style="width:100%;font-family:monospace;margin-bottom:8px;" readonly></textarea>
+        <label style="display:block;margin-bottom:6px;">CA Bundle</label>
+        <textarea id="bundle-ca" rows="4" class="dd-input" style="width:100%;font-family:monospace;" readonly></textarea>
+    </div>
+</div>
+
+<div id="rekey-modal" class="dd-modal" style="display:none;">
+    <div class="dd-modal-backdrop"></div>
+    <div class="dd-modal-dialog" style="width:760px;max-width:97%;">
+        <h2 style="font-size:18px;font-weight:600;margin-bottom:12px;">Rekey / Reissue</h2>
+        <label for="rekey-csr" style="display:block;margin-bottom:6px;">CSR</label>
+        <textarea id="rekey-csr" rows="7" class="dd-input" style="width:100%;font-family:monospace;" placeholder="-----BEGIN CERTIFICATE REQUEST-----"></textarea>
+
+        <div style="display:flex;gap:10px;margin-top:10px;">
+            <button type="button" class="btn-accent" id="decode-csr-btn">Decode CSR</button>
+            <button type="button" class="btn-accent" id="confirm-rekey-btn" disabled>Confirm and submit reissue</button>
+            <button type="button" class="btn-accent" id="close-rekey-modal">Close</button>
+        </div>
+
+        <div id="rekey-status" style="margin-top:10px;"></div>
+
+        <details id="rekey-csr-details" style="margin-top:12px;display:none;">
+            <summary style="cursor:pointer;font-weight:600;">CSR Details</summary>
+            <div id="rekey-csr-grid" style="display:grid;grid-template-columns:170px 1fr;gap:6px;margin-top:8px;"></div>
+        </details>
+
+        <form method="POST" id="rekey-form" action="{{ route('admin.services.ssl.rekey', $ssl) }}" style="display:none;">
+            @csrf
+            <input type="hidden" name="csr" id="rekey-csr-hidden">
+        </form>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
+
+    const bundleModal = document.getElementById('bundle-modal');
+    const openBundleBtn = document.getElementById('open-bundle-modal');
+    const closeBundleBtn = document.getElementById('close-bundle-modal');
+    const bundleCer = document.getElementById('bundle-cer');
+    const bundleP7b = document.getElementById('bundle-p7b');
+    const bundleCa = document.getElementById('bundle-ca');
+    const bundleStatus = document.getElementById('bundle-status');
+
+    function closeBundleModal() {
+        bundleModal.style.display = 'none';
+        bundleStatus.textContent = '';
+    }
+
+    openBundleBtn.addEventListener('click', async function () {
+        bundleModal.style.display = 'flex';
+        bundleStatus.textContent = 'Loading certificate bundle...';
+
+        try {
+            const response = await fetch('{{ route('admin.services.ssl.certificate', $ssl) }}', {
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': csrfToken,
+                    'Accept': 'application/json'
+                }
+            });
+
+            const payload = await response.json();
+            if (!response.ok || !payload.success) {
+                bundleStatus.textContent = payload.message || 'Unable to load certificate bundle.';
+                return;
+            }
+
+            bundleCer.value = payload.bundle.cer || '';
+            bundleP7b.value = payload.bundle.p7b || '';
+            bundleCa.value = payload.bundle.caBundle || '';
+            bundleStatus.textContent = 'Certificate bundle fetched from Synergy.';
+        } catch (error) {
+            bundleStatus.textContent = 'Bundle fetch failed: ' + error.message;
+        }
+    });
+
+    closeBundleBtn.addEventListener('click', closeBundleModal);
+    bundleModal.querySelector('.dd-modal-backdrop').addEventListener('click', closeBundleModal);
+
+    const rekeyModal = document.getElementById('rekey-modal');
+    const openRekeyBtn = document.getElementById('open-rekey-modal');
+    const closeRekeyBtn = document.getElementById('close-rekey-modal');
+    const decodeBtn = document.getElementById('decode-csr-btn');
+    const confirmBtn = document.getElementById('confirm-rekey-btn');
+    const rekeyCsr = document.getElementById('rekey-csr');
+    const rekeyCsrHidden = document.getElementById('rekey-csr-hidden');
+    const rekeyStatus = document.getElementById('rekey-status');
+    const csrDetails = document.getElementById('rekey-csr-details');
+    const csrGrid = document.getElementById('rekey-csr-grid');
+    const rekeyForm = document.getElementById('rekey-form');
+
+    function closeRekeyModal() {
+        rekeyModal.style.display = 'none';
+        rekeyCsr.value = '';
+        rekeyCsrHidden.value = '';
+        rekeyStatus.textContent = '';
+        csrDetails.style.display = 'none';
+        csrGrid.innerHTML = '';
+        confirmBtn.disabled = true;
+    }
+
+    openRekeyBtn.addEventListener('click', function () {
+        rekeyModal.style.display = 'flex';
+    });
+
+    decodeBtn.addEventListener('click', async function () {
+        const csrValue = rekeyCsr.value.trim();
+        if (!csrValue) {
+            rekeyStatus.textContent = 'Please paste CSR data first.';
+            return;
+        }
+
+        decodeBtn.disabled = true;
+        confirmBtn.disabled = true;
+        csrGrid.innerHTML = '';
+        csrDetails.style.display = 'none';
+        rekeyStatus.textContent = 'Decoding CSR...';
+
+        try {
+            const response = await fetch('{{ route('admin.services.ssl.decodeCsr') }}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken,
+                    'Accept': 'application/json'
+                },
+                body: JSON.stringify({ csr: csrValue })
+            });
+
+            const payload = await response.json();
+            if (!response.ok || !payload.success) {
+                rekeyStatus.textContent = payload.message || 'Unable to decode CSR.';
+                return;
+            }
+
+            const decoded = payload.decoded || {};
+            const fields = [
+                ['Country', decoded.country],
+                ['Common Name', decoded.commonName],
+                ['Location', decoded.city],
+                ['State', decoded.state],
+                ['Organization', decoded.organisation],
+                ['Organization Unit', decoded.organisationUnit],
+                ['Email', decoded.emailAddress],
+                ['Key Length', decoded.privateKeyLength]
+            ];
+
+            fields.forEach(function (field) {
+                const label = document.createElement('strong');
+                label.textContent = field[0];
+                const value = document.createElement('span');
+                value.textContent = field[1] || 'N/A';
+                csrGrid.appendChild(label);
+                csrGrid.appendChild(value);
+            });
+
+            csrDetails.style.display = 'block';
+            rekeyCsrHidden.value = csrValue;
+            rekeyStatus.textContent = 'CSR decoded. Confirm to submit reissue.';
+            confirmBtn.disabled = false;
+        } catch (error) {
+            rekeyStatus.textContent = 'Decode failed: ' + error.message;
+        } finally {
+            decodeBtn.disabled = false;
+        }
+    });
+
+    confirmBtn.addEventListener('click', function () {
+        if (!rekeyCsrHidden.value) {
+            rekeyStatus.textContent = 'Decode CSR before submitting.';
+            return;
+        }
+
+        if (!confirm('Submit this CSR for reissue to Synergy?')) {
+            return;
+        }
+
+        rekeyForm.submit();
+    });
+
+    closeRekeyBtn.addEventListener('click', closeRekeyModal);
+    rekeyModal.querySelector('.dd-modal-backdrop').addEventListener('click', closeRekeyModal);
+});
+</script>
+
+<style>
+.dd-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 80;
+}
+.dd-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.75);
+}
+.dd-modal-dialog {
+    position: relative;
+    background: var(--surface-elevated);
+    border-radius: 12px;
+    padding: 16px 18px 18px;
+    border: 1px solid var(--border-subtle);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+</style>
 @endsection

--- a/resources/views/admin/ssls/show.blade.php
+++ b/resources/views/admin/ssls/show.blade.php
@@ -1,0 +1,81 @@
+@extends('layouts.app')
+
+@section('content')
+<div style="max-width: 1100px;">
+    <h1 style="font-size:24px;margin-bottom:10px;">SSL Certificate Details</h1>
+    <p style="margin-bottom:16px;opacity:0.8;">
+        <a href="{{ route('admin.services.ssls') }}">SSL Certificates</a> / {{ $ssl->common_name ?: 'Certificate #' . $ssl->id }}
+    </p>
+
+    @if($actionMessage)
+        <div style="padding:12px;border:1px solid #3b82f6;border-radius:8px;margin-bottom:16px;">{{ $actionMessage }}</div>
+    @endif
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px;">
+        <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
+            <h2 style="font-size:18px;margin-bottom:10px;">Overview</h2>
+            <div style="display:grid;grid-template-columns:160px 1fr;gap:8px;">
+                <strong>Common Name</strong><span>{{ $ssl->common_name ?: '—' }}</span>
+                <strong>Synergy Cert ID</strong><span>{{ $ssl->cert_id ?: '—' }}</span>
+                <strong>Product</strong><span>{{ $ssl->product_name ?: '—' }}</span>
+                <strong>Status</strong><span>{{ $ssl->status ?: '—' }}</span>
+                <strong>Start Date</strong><span>{{ optional($ssl->start_date)->toDateString() ?: '—' }}</span>
+                <strong>Expire Date</strong><span>{{ optional($ssl->expire_date)->toDateString() ?: '—' }}</span>
+                <strong>Client</strong><span>{{ optional($ssl->client)->business_name ?: '—' }}</span>
+            </div>
+        </div>
+
+        <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
+            <h2 style="font-size:18px;margin-bottom:10px;">Live Synergy Status</h2>
+            @if($statusPayload)
+                <div style="display:grid;grid-template-columns:160px 1fr;gap:8px;">
+                    <strong>Status</strong><span>{{ $statusPayload['status'] ?? '—' }}</span>
+                    <strong>Cert Status</strong><span>{{ $statusPayload['certStatus'] ?? '—' }}</span>
+                    <strong>Product Name</strong><span>{{ $statusPayload['productName'] ?? '—' }}</span>
+                    <strong>Product Years</strong><span>{{ $statusPayload['productYears'] ?? '—' }}</span>
+                    <strong>Start Date</strong><span>{{ $statusPayload['startDate'] ?? '—' }}</span>
+                    <strong>Expire Date</strong><span>{{ $statusPayload['expireDate'] ?? '—' }}</span>
+                </div>
+            @else
+                <p>Live status unavailable (missing cert ID).</p>
+            @endif
+        </div>
+    </div>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
+            <h2 style="font-size:18px;margin-bottom:12px;">Certificate Actions</h2>
+            <form method="POST" action="{{ route('admin.services.ssl.certificate', $ssl) }}" style="margin-bottom:10px;">
+                @csrf
+                <button type="submit" class="btn-accent">Get Certificate / Bundle</button>
+            </form>
+
+            <form method="POST" action="{{ route('admin.services.ssl.renew', $ssl) }}" style="margin-bottom:10px;">
+                @csrf
+                <button type="submit" class="btn-accent">Renew Certificate</button>
+            </form>
+
+            <form method="POST" action="{{ route('admin.services.ssl.rekey', $ssl) }}">
+                @csrf
+                <label style="display:block;margin-bottom:6px;">New CSR for Rekey/Reissue</label>
+                <textarea name="csr" rows="6" style="width:100%;margin-bottom:10px;" required placeholder="-----BEGIN CERTIFICATE REQUEST-----"></textarea>
+                <button type="submit" class="btn-accent">Rekey / Reissue Certificate</button>
+            </form>
+        </div>
+
+        <div style="padding:16px;border:1px solid #334155;border-radius:10px;">
+            <h2 style="font-size:18px;margin-bottom:12px;">Fetched Certificate Data</h2>
+            @if($certPayload)
+                <label style="display:block;margin-bottom:6px;">CER</label>
+                <textarea rows="5" style="width:100%;margin-bottom:8px;" readonly>{{ $certPayload['cer'] ?? '' }}</textarea>
+                <label style="display:block;margin-bottom:6px;">P7B</label>
+                <textarea rows="5" style="width:100%;margin-bottom:8px;" readonly>{{ $certPayload['p7b'] ?? '' }}</textarea>
+                <label style="display:block;margin-bottom:6px;">CA Bundle</label>
+                <textarea rows="5" style="width:100%;" readonly>{{ $certPayload['caBundle'] ?? '' }}</textarea>
+            @else
+                <p>No certificate payload loaded in this session yet.</p>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -211,6 +211,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::get('/services/ssl/{ssl}', [\App\Http\Controllers\Admin\SslController::class,'show'])->whereNumber('ssl')->name('admin.services.ssl.show');
         Route::post('/services/ssl/{ssl}/certificate', [\App\Http\Controllers\Admin\SslController::class,'getCertificate'])->whereNumber('ssl')->name('admin.services.ssl.certificate');
         Route::get('/services/ssl/{ssl}/bundle.zip', [\App\Http\Controllers\Admin\SslController::class,'downloadBundle'])->whereNumber('ssl')->name('admin.services.ssl.bundleZip');
+        Route::post('/services/ssl/{ssl}/resend-completion-email', [\App\Http\Controllers\Admin\SslController::class,'resendCompletionEmail'])->whereNumber('ssl')->name('admin.services.ssl.resendCompletionEmail');
         Route::post('/services/ssl/{ssl}/renew', [\App\Http\Controllers\Admin\SslController::class,'renew'])->whereNumber('ssl')->name('admin.services.ssl.renew');
         Route::post('/services/ssl/{ssl}/rekey', [\App\Http\Controllers\Admin\SslController::class,'rekey'])->whereNumber('ssl')->name('admin.services.ssl.rekey');
         Route::post('/services/ssl/{ssl}/assign-client', [\App\Http\Controllers\Admin\SslController::class,'assignClient'])->whereNumber('ssl')->name('admin.services.ssl.assignClient');

--- a/routes/web.php
+++ b/routes/web.php
@@ -208,5 +208,9 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::post('/services/ssl/sync', [\App\Http\Controllers\Admin\SslController::class,'sync'])->name('admin.services.ssl.sync');
         Route::get('/services/ssl/purchase', [\App\Http\Controllers\Admin\SslPurchaseController::class,'index'])->name('admin.services.ssl.purchase');
         Route::post('/services/ssl/purchase', [\App\Http\Controllers\Admin\SslPurchaseController::class,'purchase'])->name('admin.services.ssl.purchase.store');
+        Route::get('/services/ssl/{ssl}', [\App\Http\Controllers\Admin\SslController::class,'show'])->whereNumber('ssl')->name('admin.services.ssl.show');
+        Route::post('/services/ssl/{ssl}/certificate', [\App\Http\Controllers\Admin\SslController::class,'getCertificate'])->whereNumber('ssl')->name('admin.services.ssl.certificate');
+        Route::post('/services/ssl/{ssl}/renew', [\App\Http\Controllers\Admin\SslController::class,'renew'])->whereNumber('ssl')->name('admin.services.ssl.renew');
+        Route::post('/services/ssl/{ssl}/rekey', [\App\Http\Controllers\Admin\SslController::class,'rekey'])->whereNumber('ssl')->name('admin.services.ssl.rekey');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -210,6 +210,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::post('/services/ssl/purchase', [\App\Http\Controllers\Admin\SslPurchaseController::class,'purchase'])->name('admin.services.ssl.purchase.store');
         Route::get('/services/ssl/{ssl}', [\App\Http\Controllers\Admin\SslController::class,'show'])->whereNumber('ssl')->name('admin.services.ssl.show');
         Route::post('/services/ssl/{ssl}/certificate', [\App\Http\Controllers\Admin\SslController::class,'getCertificate'])->whereNumber('ssl')->name('admin.services.ssl.certificate');
+        Route::get('/services/ssl/{ssl}/bundle.zip', [\App\Http\Controllers\Admin\SslController::class,'downloadBundle'])->whereNumber('ssl')->name('admin.services.ssl.bundleZip');
         Route::post('/services/ssl/{ssl}/renew', [\App\Http\Controllers\Admin\SslController::class,'renew'])->whereNumber('ssl')->name('admin.services.ssl.renew');
         Route::post('/services/ssl/{ssl}/rekey', [\App\Http\Controllers\Admin\SslController::class,'rekey'])->whereNumber('ssl')->name('admin.services.ssl.rekey');
         Route::post('/services/ssl/{ssl}/assign-client', [\App\Http\Controllers\Admin\SslController::class,'assignClient'])->whereNumber('ssl')->name('admin.services.ssl.assignClient');

--- a/routes/web.php
+++ b/routes/web.php
@@ -212,5 +212,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::post('/services/ssl/{ssl}/certificate', [\App\Http\Controllers\Admin\SslController::class,'getCertificate'])->whereNumber('ssl')->name('admin.services.ssl.certificate');
         Route::post('/services/ssl/{ssl}/renew', [\App\Http\Controllers\Admin\SslController::class,'renew'])->whereNumber('ssl')->name('admin.services.ssl.renew');
         Route::post('/services/ssl/{ssl}/rekey', [\App\Http\Controllers\Admin\SslController::class,'rekey'])->whereNumber('ssl')->name('admin.services.ssl.rekey');
+        Route::post('/services/ssl/{ssl}/assign-client', [\App\Http\Controllers\Admin\SslController::class,'assignClient'])->whereNumber('ssl')->name('admin.services.ssl.assignClient');
+        Route::post('/services/ssl/decode-csr', [\App\Http\Controllers\Admin\SslController::class,'decodeCsr'])->name('admin.services.ssl.decodeCsr');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -205,6 +205,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         // ============================================================================
         // SSL CERTIFICATE ROUTES
         // ============================================================================
+        Route::post('/services/ssl/sync', [\App\Http\Controllers\Admin\SslController::class,'sync'])->name('admin.services.ssl.sync');
         Route::get('/services/ssl/purchase', [\App\Http\Controllers\Admin\SslPurchaseController::class,'index'])->name('admin.services.ssl.purchase');
         Route::post('/services/ssl/purchase', [\App\Http\Controllers\Admin\SslPurchaseController::class,'purchase'])->name('admin.services.ssl.purchase.store');
     });


### PR DESCRIPTION
### Motivation
- SSL product listing, purchase and sync were failing because the code used non‑existent SOAP operations and did not send required CSR/contact data to Synergy.  
- Align the app with the Synergy WSDL so products load, purchases can be created with CSR/private key, and existing certificates can be synced into the local DB.  
- Provide an admin sync entrypoint so operators can import reseller SSL certificates from Synergy into `ssl_certificates`.

### Description
- Updated the Synergy client in `app/Services/Synergy/SynergyWholesaleClient.php` to call `getSSLPricing` (normalized `pricing` to an array), to call `SSL_purchaseSSLCertificate` for purchases and to add `listAllSSLCerts()` which wraps `SSL_listAllCerts`.  
- Updated the purchase flow in `app/Http/Controllers/Admin/SslPurchaseController.php` to require `csr` and `private_key`, map contact fields from the `Client` record, pass them to Synergy, and use the provider response (`certID`, `commonName`, `certStatus`) when creating local records.  
- Added an SSL sync action `SslController::sync()` in `app/Http/Controllers/Admin/SslController.php` which calls `listAllSSLCerts()` and upserts certificates into `ssl_certificates`.  
- Added a `POST /services/ssl/sync` route and small UI changes: a “Sync from Synergy” button on `resources/views/admin/ssls/index.blade.php` and CSR + Private Key inputs on `resources/views/admin/services/ssl-purchase.blade.php` so the purchase page captures required data.

### Testing
- Ran PHP lint checks which passed for modified files: `php -l app/Http/Controllers/Admin/SslController.php`, `php -l app/Http/Controllers/Admin/SslPurchaseController.php`, and `php -l app/Services/Synergy/SynergyWholesaleClient.php` (all OK).  
- Attempted `php artisan route:list --path=services/ssl` and `php artisan test --filter=Ssl --testsuite=Feature`, but both were blocked in this environment due to a missing `vendor/autoload.php` (cannot run full framework commands/tests here).  
- No additional automated tests were executed in this environment; manual verification steps are: submit `POST /admin/services/ssl/sync` to import certs and validate the UI purchase flow sends `csr`/`private_key` and that Synergy responses are recorded in `ssl_certificates`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8acdb71c48330be54141b0b552405)