### PR TITLE
Make support tickets clickable; add ticket detail view, client-visible actions, and reply flow

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -344,6 +344,7 @@ class TicketController extends Controller
     {
         $data = $request->validate([
             'client_id' => 'required|integer|exists:clients,id',
+            'reason' => 'required|string',
         ]);
 
         $clients = $this->availableClients(auth()->user());
@@ -384,6 +385,8 @@ class TicketController extends Controller
                 abort(403, 'You are not allowed to close this ticket.');
             }
 
+            $closeReason = trim((string) $data['reason']);
+            $halo->createTicketAction($ticketId, "Ticket closure requested by client:\n" . $closeReason);
             $halo->updateTicketStatus($ticketId, $closedStatusId);
         } catch (\RuntimeException $exception) {
             return back()->withErrors([
@@ -892,13 +895,14 @@ class TicketController extends Controller
             $action['Body'] ?? null,
         ];
 
-        $needle = strtolower(trim($message));
+        $needle = strtolower(trim(strip_tags($message)));
         foreach ($candidates as $candidate) {
             if (!is_string($candidate)) {
                 continue;
             }
 
-            if (str_contains(strtolower($candidate), $needle)) {
+            $haystack = strtolower(trim(strip_tags($candidate)));
+            if ($needle !== '' && str_contains($haystack, $needle)) {
                 return true;
             }
         }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -193,6 +193,11 @@ class TicketController extends Controller
             }
         }
 
+        $ticketServiceLabel = $this->extractTicketServiceLabel($ticket);
+        if (trim($ticketServiceLabel) === '-' && $request->filled('service')) {
+            $ticketServiceLabel = trim((string) $request->query('service'));
+        }
+
         return view('tickets.show', [
             'ticket' => $ticket,
             'ticketId' => $ticketId,
@@ -202,7 +207,7 @@ class TicketController extends Controller
             'portalUrl' => $this->extractPortalUrl($ticket),
             'ticketStatusLabel' => $this->resolveTicketStatusLabel($ticket, $statusNameById),
             'ticketTypeLabel' => $this->extractTicketTypeLabel($ticket),
-            'ticketServiceLabel' => $this->extractTicketServiceLabel($ticket),
+            'ticketServiceLabel' => $ticketServiceLabel,
             'ticketUpdatedLabel' => $this->extractTicketUpdated($ticket),
         ]);
     }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -310,7 +310,24 @@ class TicketController extends Controller
                 abort(403, 'You are not allowed to reply to this ticket.');
             }
 
-            $halo->createTicketAction($ticketId, trim((string) $data['message']));
+            $message = trim((string) $data['message']);
+            $halo->createTicketAction($ticketId, $message);
+            $updatedActions = $halo->getTicketActions($ticketId);
+            $hasMessage = false;
+            foreach ($updatedActions as $action) {
+                if (!is_array($action)) {
+                    continue;
+                }
+
+                if ($this->actionContainsMessage($action, $message)) {
+                    $hasMessage = true;
+                    break;
+                }
+            }
+
+            if (!$hasMessage) {
+                throw new \RuntimeException('Reply request was accepted by Halo, but no matching ticket update was returned afterwards.');
+            }
         } catch (\RuntimeException $exception) {
             return back()->withErrors([
                 'halo' => $exception->getMessage(),
@@ -321,6 +338,63 @@ class TicketController extends Controller
             'ticketId' => $ticketId,
             'client_id' => $selectedClient->id,
         ])->with('status', 'Reply sent to Halo ticket.');
+    }
+
+    public function close(Request $request, int $ticketId)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|integer|exists:clients,id',
+        ]);
+
+        $clients = $this->availableClients(auth()->user());
+        $selectedClient = $clients->firstWhere('id', (int) $data['client_id']);
+        if (!$selectedClient) {
+            abort(403, 'You are not allowed to close this ticket.');
+        }
+
+        if (!$selectedClient->halopsa_reference) {
+            return back()->withErrors([
+                'halo' => 'This client is not linked to HaloPSA yet.',
+            ]);
+        }
+
+        $closedStatusId = null;
+        foreach ($this->configuredStatusMappings() as $mapping) {
+            $statusLabel = strtolower(trim((string) ($mapping['domaindash_status'] ?? '')));
+            if (in_array($statusLabel, ['closed', 'resolved', 'complete', 'completed', 'done'], true)) {
+                $statusId = (int) ($mapping['halo_status_id'] ?? 0);
+                if ($statusId > 0) {
+                    $closedStatusId = $statusId;
+                    break;
+                }
+            }
+        }
+
+        if (!$closedStatusId) {
+            return back()->withErrors([
+                'halo' => 'No closed status mapping is configured in Halo settings.',
+            ]);
+        }
+
+        try {
+            $halo = app(HaloPsaClient::class);
+            $ticket = $halo->getTicket($ticketId);
+            $ticketClientId = (int) ($ticket['client_id'] ?? $ticket['ClientId'] ?? 0);
+            if ($ticketClientId !== (int) $selectedClient->halopsa_reference) {
+                abort(403, 'You are not allowed to close this ticket.');
+            }
+
+            $halo->updateTicketStatus($ticketId, $closedStatusId);
+        } catch (\RuntimeException $exception) {
+            return back()->withErrors([
+                'halo' => $exception->getMessage(),
+            ]);
+        }
+
+        return redirect()->route('tickets.show', [
+            'ticketId' => $ticketId,
+            'client_id' => $selectedClient->id,
+        ])->with('status', 'Ticket has been marked as closed.');
     }
 
     private function availableClients($user)
@@ -801,6 +875,31 @@ class TicketController extends Controller
             if (is_string($value)) {
                 $normalized = strtolower(trim($value));
                 return in_array($normalized, ['1', 'true', 'yes', 'y'], true);
+            }
+        }
+
+        return false;
+    }
+
+    private function actionContainsMessage(array $action, string $message): bool
+    {
+        $candidates = [
+            $action['details'] ?? null,
+            $action['Details'] ?? null,
+            $action['note'] ?? null,
+            $action['Note'] ?? null,
+            $action['body'] ?? null,
+            $action['Body'] ?? null,
+        ];
+
+        $needle = strtolower(trim($message));
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate)) {
+                continue;
+            }
+
+            if (str_contains(strtolower($candidate), $needle)) {
+                return true;
             }
         }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -311,12 +311,15 @@ class TicketController extends Controller
             }
 
             $message = trim((string) $data['message']);
-            $beforeActions = $halo->getTicketActions($ticketId);
-            $halo->createTicketAction($ticketId, $message, 'Client Update', auth()->user()?->name ?? 'Client');
-            $updatedActions = $halo->getTicketActions($ticketId);
-            $hasMessage = $this->actionsContainMessage($updatedActions, $message);
-            $hasNewAction = count($updatedActions) > count($beforeActions);
-            if (!$hasMessage && !$hasNewAction) {
+            $replyAction = $halo->createTicketAction(
+                $ticketId,
+                $message,
+                'Client-Responded',
+                auth()->user()?->name ?? 'Client'
+            );
+            $hasMessage = $this->actionContainsMessage($replyAction, $message);
+            $outcome = strtolower(trim((string) ($replyAction['outcome'] ?? $replyAction['Outcome'] ?? '')));
+            if (!$hasMessage && $outcome !== 'client-responded') {
                 throw new \RuntimeException('Reply request was accepted by Halo, but no matching ticket update was returned afterwards.');
             }
         } catch (\RuntimeException $exception) {
@@ -350,24 +353,6 @@ class TicketController extends Controller
             ]);
         }
 
-        $closedStatusId = null;
-        foreach ($this->configuredStatusMappings() as $mapping) {
-            $statusLabel = strtolower(trim((string) ($mapping['domaindash_status'] ?? '')));
-            if (in_array($statusLabel, ['closed', 'resolved', 'complete', 'completed', 'done'], true)) {
-                $statusId = (int) ($mapping['halo_status_id'] ?? 0);
-                if ($statusId > 0) {
-                    $closedStatusId = $statusId;
-                    break;
-                }
-            }
-        }
-
-        if (!$closedStatusId) {
-            return back()->withErrors([
-                'halo' => 'No closed status mapping is configured in Halo settings.',
-            ]);
-        }
-
         try {
             $halo = app(HaloPsaClient::class);
             $ticket = $halo->getTicket($ticketId);
@@ -377,23 +362,16 @@ class TicketController extends Controller
             }
 
             $closeReason = trim((string) $data['reason']);
-            $beforeActions = $halo->getTicketActions($ticketId);
-            $halo->createTicketAction($ticketId, $closeReason, 'Close No Survey', auth()->user()?->name ?? 'Client');
-            $updatedActions = $halo->getTicketActions($ticketId);
-            $hasClosure = false;
-            foreach ($updatedActions as $action) {
-                if (!is_array($action)) {
-                    continue;
-                }
+            $closeAction = $halo->createTicketAction(
+                $ticketId,
+                $closeReason,
+                'Close No Survey',
+                auth()->user()?->name ?? 'Client'
+            );
 
-                $outcome = strtolower(trim((string) ($action['outcome'] ?? $action['Outcome'] ?? '')));
-                if ($outcome === 'close no survey' || $outcome === 'closed') {
-                    $hasClosure = true;
-                    break;
-                }
-            }
-
-            if (!$hasClosure && count($updatedActions) <= count($beforeActions)) {
+            $outcome = strtolower(trim((string) ($closeAction['outcome'] ?? $closeAction['Outcome'] ?? '')));
+            $hasClosure = in_array($outcome, ['close no survey', 'closed'], true);
+            if (!$hasClosure) {
                 throw new \RuntimeException('Closure request was accepted by Halo, but no close action was returned afterwards.');
             }
         } catch (\RuntimeException $exception) {
@@ -886,21 +864,6 @@ class TicketController extends Controller
             if (is_string($value)) {
                 $normalized = strtolower(trim($value));
                 return in_array($normalized, ['1', 'true', 'yes', 'y'], true);
-            }
-        }
-
-        return false;
-    }
-
-    private function actionsContainMessage(array $actions, string $message): bool
-    {
-        foreach ($actions as $action) {
-            if (!is_array($action)) {
-                continue;
-            }
-
-            if ($this->actionContainsMessage($action, $message)) {
-                return true;
             }
         }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -174,7 +174,10 @@ class TicketController extends Controller
                 abort(403, 'You are not allowed to view this ticket.');
             }
 
-            $actions = $halo->getTicketActions($ticketId);
+            $actions = array_values(array_filter(
+                $halo->getTicketActions($ticketId),
+                fn (array $action): bool => $this->isClientVisibleAction($action)
+            ));
         } catch (\RuntimeException $exception) {
             return redirect()->route('tickets.index', ['client_id' => $selectedClientId])
                 ->withErrors(['halo' => $exception->getMessage()]);
@@ -645,5 +648,89 @@ class TicketController extends Controller
         }
 
         return $candidate;
+    }
+
+    private function isClientVisibleAction(array $action): bool
+    {
+        $privateFlags = [
+            'private',
+            'isprivate',
+            'is_private',
+            'private_note',
+            'privateNote',
+            'hiddenfromuser',
+            'hidden_from_user',
+            'hidefromuser',
+            'internal',
+            'internalnote',
+            'internal_note',
+            'agentonly',
+            'agent_only',
+            'nonpublic',
+            'non_public',
+        ];
+
+        foreach ($privateFlags as $flag) {
+            if ($this->extractTruthyFlag($action, $flag)) {
+                return false;
+            }
+        }
+
+        $clientVisibleFlags = [
+            'clientvisible',
+            'client_visible',
+            'showinportal',
+            'show_in_portal',
+            'public',
+            'ispublic',
+            'is_public',
+            'noteforclient',
+            'note_for_client',
+            'sendemail',
+            'send_email',
+            'emailsent',
+            'email_sent',
+        ];
+
+        foreach ($clientVisibleFlags as $flag) {
+            if ($this->extractTruthyFlag($action, $flag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function extractTruthyFlag(array $action, string $field): bool
+    {
+        $candidates = [$field, ucfirst($field)];
+        if (str_contains($field, '_')) {
+            $camel = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $field))));
+            $studly = str_replace(' ', '', ucwords(str_replace('_', ' ', $field)));
+            $candidates[] = $camel;
+            $candidates[] = $studly;
+        }
+
+        foreach ($candidates as $candidate) {
+            if (!array_key_exists($candidate, $action)) {
+                continue;
+            }
+
+            $value = $action[$candidate];
+            if (is_bool($value)) {
+                return $value;
+            }
+
+            if (is_numeric($value)) {
+                return (int) $value === 1;
+            }
+
+            if (is_string($value)) {
+                $normalized = strtolower(trim($value));
+                return in_array($normalized, ['1', 'true', 'yes', 'y'], true);
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -49,7 +49,6 @@ class TicketController extends Controller
                     $page,
                     $pageSize
                 );
-                $tickets = $this->hydrateTicketDetails($halo, $tickets);
                 $fetchedTicketCount = count($tickets);
             } catch (\RuntimeException $exception) {
                 $error = $exception->getMessage();

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -202,6 +202,7 @@ class TicketController extends Controller
             'portalUrl' => $this->extractPortalUrl($ticket),
             'ticketStatusLabel' => $this->resolveTicketStatusLabel($ticket, $statusNameById),
             'ticketTypeLabel' => $this->extractTicketTypeLabel($ticket),
+            'ticketServiceLabel' => $this->extractTicketServiceLabel($ticket),
             'ticketUpdatedLabel' => $this->extractTicketUpdated($ticket),
         ]);
     }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -311,21 +311,12 @@ class TicketController extends Controller
             }
 
             $message = trim((string) $data['message']);
-            $halo->createTicketAction($ticketId, $message);
+            $beforeActions = $halo->getTicketActions($ticketId);
+            $halo->createTicketAction($ticketId, $message, 'Client Update', auth()->user()?->name ?? 'Client');
             $updatedActions = $halo->getTicketActions($ticketId);
-            $hasMessage = false;
-            foreach ($updatedActions as $action) {
-                if (!is_array($action)) {
-                    continue;
-                }
-
-                if ($this->actionContainsMessage($action, $message)) {
-                    $hasMessage = true;
-                    break;
-                }
-            }
-
-            if (!$hasMessage) {
+            $hasMessage = $this->actionsContainMessage($updatedActions, $message);
+            $hasNewAction = count($updatedActions) > count($beforeActions);
+            if (!$hasMessage && !$hasNewAction) {
                 throw new \RuntimeException('Reply request was accepted by Halo, but no matching ticket update was returned afterwards.');
             }
         } catch (\RuntimeException $exception) {
@@ -386,8 +377,25 @@ class TicketController extends Controller
             }
 
             $closeReason = trim((string) $data['reason']);
-            $halo->createTicketAction($ticketId, "Ticket closure requested by client:\n" . $closeReason);
-            $halo->updateTicketStatus($ticketId, $closedStatusId);
+            $beforeActions = $halo->getTicketActions($ticketId);
+            $halo->createTicketAction($ticketId, $closeReason, 'Close No Survey', auth()->user()?->name ?? 'Client');
+            $updatedActions = $halo->getTicketActions($ticketId);
+            $hasClosure = false;
+            foreach ($updatedActions as $action) {
+                if (!is_array($action)) {
+                    continue;
+                }
+
+                $outcome = strtolower(trim((string) ($action['outcome'] ?? $action['Outcome'] ?? '')));
+                if ($outcome === 'close no survey' || $outcome === 'closed') {
+                    $hasClosure = true;
+                    break;
+                }
+            }
+
+            if (!$hasClosure && count($updatedActions) <= count($beforeActions)) {
+                throw new \RuntimeException('Closure request was accepted by Halo, but no close action was returned afterwards.');
+            }
         } catch (\RuntimeException $exception) {
             return back()->withErrors([
                 'halo' => $exception->getMessage(),
@@ -878,6 +886,21 @@ class TicketController extends Controller
             if (is_string($value)) {
                 $normalized = strtolower(trim($value));
                 return in_array($normalized, ['1', 'true', 'yes', 'y'], true);
+            }
+        }
+
+        return false;
+    }
+
+    private function actionsContainMessage(array $actions, string $message): bool
+    {
+        foreach ($actions as $action) {
+            if (!is_array($action)) {
+                continue;
+            }
+
+            if ($this->actionContainsMessage($action, $message)) {
+                return true;
             }
         }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -753,6 +753,24 @@ class TicketController extends Controller
             }
         }
 
+        $clientFacingTypes = [
+            strtolower(trim((string) ($action['outcome'] ?? ''))),
+            strtolower(trim((string) ($action['Outcome'] ?? ''))),
+            strtolower(trim((string) ($action['actiontype'] ?? ''))),
+            strtolower(trim((string) ($action['ActionType'] ?? ''))),
+            strtolower(trim((string) ($action['type'] ?? ''))),
+            strtolower(trim((string) ($action['Type'] ?? ''))),
+        ];
+        foreach ($clientFacingTypes as $typeLabel) {
+            if ($typeLabel === '') {
+                continue;
+            }
+
+            if (in_array($typeLabel, ['email user', 'with user', 'client note', 'public note'], true)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -178,9 +178,19 @@ class TicketController extends Controller
                 $halo->getTicketActions($ticketId),
                 fn (array $action): bool => $this->isClientVisibleAction($action)
             ));
+            $actions = $this->prependInitialSubmission($ticket, $actions);
         } catch (\RuntimeException $exception) {
             return redirect()->route('tickets.index', ['client_id' => $selectedClientId])
                 ->withErrors(['halo' => $exception->getMessage()]);
+        }
+
+        $statusNameById = [];
+        foreach ($this->configuredStatusMappings() as $mapping) {
+            $statusId = (int) ($mapping['halo_status_id'] ?? 0);
+            $statusName = trim((string) ($mapping['domaindash_status'] ?? ''));
+            if ($statusId > 0 && $statusName !== '') {
+                $statusNameById[$statusId] = $statusName;
+            }
         }
 
         return view('tickets.show', [
@@ -190,6 +200,9 @@ class TicketController extends Controller
             'selectedClientId' => $selectedClientId,
             'selectedClient' => $selectedClient,
             'portalUrl' => $this->extractPortalUrl($ticket),
+            'ticketStatusLabel' => $this->resolveTicketStatusLabel($ticket, $statusNameById),
+            'ticketTypeLabel' => $this->extractTicketTypeLabel($ticket),
+            'ticketUpdatedLabel' => $this->extractTicketUpdated($ticket),
         ]);
     }
 
@@ -648,6 +661,42 @@ class TicketController extends Controller
         }
 
         return $candidate;
+    }
+
+    private function prependInitialSubmission(array $ticket, array $actions): array
+    {
+        $initialMessage = $ticket['details'] ?? $ticket['Details'] ?? null;
+        if (!is_string($initialMessage) || trim($initialMessage) === '') {
+            return $actions;
+        }
+
+        foreach ($actions as $action) {
+            $existing = $action['note'] ?? $action['details'] ?? $action['Details'] ?? null;
+            if (is_string($existing) && trim($existing) === trim($initialMessage)) {
+                return $actions;
+            }
+        }
+
+        $actions = array_values($actions);
+        array_unshift($actions, [
+            'who' => $ticket['user_name'] ?? $ticket['UserName'] ?? 'Client',
+            'datecreated' => $ticket['datecreated'] ?? $ticket['DateCreated'] ?? '-',
+            'note' => $initialMessage,
+            '_domaindash_initial_submission' => true,
+        ]);
+
+        return $actions;
+    }
+
+    private function extractTicketUpdated(array $ticket): string
+    {
+        $updated = $ticket['lastactiondate']
+            ?? $ticket['LastActionDate']
+            ?? $ticket['datecreated']
+            ?? $ticket['DateCreated']
+            ?? '-';
+
+        return is_string($updated) ? $updated : '-';
     }
 
     private function isClientVisibleAction(array $action): bool

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -145,6 +145,52 @@ class TicketController extends Controller
         ]);
     }
 
+    public function show(Request $request, int $ticketId)
+    {
+        $user = auth()->user();
+        $clients = $this->availableClients($user);
+        $selectedClientId = $this->resolveSelectedClientId($request, $clients);
+        $selectedClient = $clients->firstWhere('id', $selectedClientId);
+
+        if (!$selectedClient) {
+            abort(403, 'You are not allowed to view this ticket.');
+        }
+
+        if (!$this->isHaloConfigured()) {
+            return redirect()->route('tickets.index', ['client_id' => $selectedClientId])
+                ->withErrors(['halo' => 'HaloPSA is not configured yet. Please update Admin > Settings > HaloPSA.']);
+        }
+
+        if (!$selectedClient->halopsa_reference) {
+            return redirect()->route('tickets.index', ['client_id' => $selectedClientId])
+                ->withErrors(['halo' => 'This client is not linked to HaloPSA yet.']);
+        }
+
+        try {
+            $halo = app(HaloPsaClient::class);
+            $ticket = $halo->getTicket($ticketId);
+            $ticketClientId = (int) ($ticket['client_id'] ?? $ticket['ClientId'] ?? 0);
+
+            if ($ticketClientId !== (int) $selectedClient->halopsa_reference) {
+                abort(403, 'You are not allowed to view this ticket.');
+            }
+
+            $actions = $halo->getTicketActions($ticketId);
+        } catch (\RuntimeException $exception) {
+            return redirect()->route('tickets.index', ['client_id' => $selectedClientId])
+                ->withErrors(['halo' => $exception->getMessage()]);
+        }
+
+        return view('tickets.show', [
+            'ticket' => $ticket,
+            'ticketId' => $ticketId,
+            'actions' => $actions,
+            'selectedClientId' => $selectedClientId,
+            'selectedClient' => $selectedClient,
+            'portalUrl' => $this->extractPortalUrl($ticket),
+        ]);
+    }
+
     public function store(Request $request)
     {
         $data = $request->validate([
@@ -214,6 +260,46 @@ class TicketController extends Controller
         }
 
         return redirect()->back()->with('status', 'Ticket logged to HaloPSA');
+    }
+
+    public function reply(Request $request, int $ticketId)
+    {
+        $data = $request->validate([
+            'client_id' => 'required|integer|exists:clients,id',
+            'message' => 'required|string',
+        ]);
+
+        $clients = $this->availableClients(auth()->user());
+        $selectedClient = $clients->firstWhere('id', (int) $data['client_id']);
+        if (!$selectedClient) {
+            abort(403, 'You are not allowed to reply to this ticket.');
+        }
+
+        if (!$selectedClient->halopsa_reference) {
+            return back()->withErrors([
+                'halo' => 'This client is not linked to HaloPSA yet.',
+            ])->withInput();
+        }
+
+        try {
+            $halo = app(HaloPsaClient::class);
+            $ticket = $halo->getTicket($ticketId);
+            $ticketClientId = (int) ($ticket['client_id'] ?? $ticket['ClientId'] ?? 0);
+            if ($ticketClientId !== (int) $selectedClient->halopsa_reference) {
+                abort(403, 'You are not allowed to reply to this ticket.');
+            }
+
+            $halo->createTicketAction($ticketId, trim((string) $data['message']));
+        } catch (\RuntimeException $exception) {
+            return back()->withErrors([
+                'halo' => $exception->getMessage(),
+            ])->withInput();
+        }
+
+        return redirect()->route('tickets.show', [
+            'ticketId' => $ticketId,
+            'client_id' => $selectedClient->id,
+        ])->with('status', 'Reply sent to Halo ticket.');
     }
 
     private function availableClients($user)
@@ -543,5 +629,22 @@ class TicketController extends Controller
                 return $ticket;
             }
         }, $tickets));
+    }
+
+    private function extractPortalUrl(array $ticket): ?string
+    {
+        $candidate = $ticket['portal_url']
+            ?? $ticket['PortalUrl']
+            ?? $ticket['client_portal_url']
+            ?? $ticket['ClientPortalUrl']
+            ?? $ticket['web_url']
+            ?? $ticket['WebUrl']
+            ?? null;
+
+        if (!is_string($candidate) || trim($candidate) === '') {
+            return null;
+        }
+
+        return $candidate;
     }
 }

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -661,14 +661,14 @@ class HaloPsaClient
         ];
 
         $endpoints = [
+            'actions',
+            'action',
             'tickets/' . $ticketId . '/actions',
             'tickets/' . $ticketId . '/action',
             'tickets/' . $ticketId . '/reply',
             'tickets/' . $ticketId . '/respond',
             'tickets/' . $ticketId . '/email',
             'tickets/' . $ticketId . '/emailuser',
-            'action',
-            'actions',
             'tickets',
         ];
 

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -700,6 +700,50 @@ class HaloPsaClient
         throw new \RuntimeException('Unable to submit reply to Halo ticket with available action payload formats.' . $suffix);
     }
 
+    public function updateTicketStatus(int $ticketId, int $statusId): array
+    {
+        $payloads = [
+            ['id' => $ticketId, 'status_id' => $statusId],
+            ['id' => $ticketId, 'ticketstatus_id' => $statusId],
+            ['TicketId' => $ticketId, 'StatusId' => $statusId],
+            ['TicketId' => $ticketId, 'TicketStatusId' => $statusId],
+        ];
+
+        $endpoints = [
+            'tickets/' . $ticketId,
+            'tickets/' . $ticketId . '/status',
+            'tickets',
+        ];
+
+        $lastError = null;
+        foreach ($endpoints as $endpoint) {
+            foreach ($payloads as $payload) {
+                foreach ([false, true] as $wrapInArray) {
+                    $jsonPayload = $wrapInArray ? [$payload] : $payload;
+
+                    try {
+                        return $this->request('POST', $endpoint, [
+                            'json' => $jsonPayload,
+                        ]);
+                    } catch (\RuntimeException $exception) {
+                        $lastError = $exception->getMessage();
+                        Log::warning('Failed Halo ticket status update payload.', [
+                            'ticket_id' => $ticketId,
+                            'status_id' => $statusId,
+                            'endpoint' => $endpoint,
+                            'wrapped' => $wrapInArray,
+                            'payload_keys' => array_keys($payload),
+                            'error' => $lastError,
+                        ]);
+                    }
+                }
+            }
+        }
+
+        $suffix = $lastError ? ' Last error: ' . $lastError : '';
+        throw new \RuntimeException('Unable to close ticket with available status payload formats.' . $suffix);
+    }
+
     /**
      * Fetch HaloPSA ticket types.
      */

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -622,6 +622,44 @@ class HaloPsaClient
     ): array {
         $author = trim((string) $who);
         $timestamp = gmdate('Y-m-d\TH:i:s\Z');
+        $effectiveAuthor = $author !== '' ? $author : 'Client';
+
+        // First attempt mirrors the known-good Swagger request shape exactly.
+        $swaggerPayload = [[
+            'outcome' => $outcome,
+            'ticket_id' => $ticketId,
+            'datetime' => $timestamp,
+            'last_updated' => $timestamp,
+            'note' => $message,
+            'Who' => $effectiveAuthor,
+        ]];
+
+        $lastError = null;
+        try {
+            $result = $this->request('POST', 'Actions', [
+                'headers' => [
+                    'Content-Type' => 'application/json-patch+json',
+                ],
+                'body' => json_encode($swaggerPayload, JSON_UNESCAPED_SLASHES),
+            ]);
+
+            $action = $this->extractActionPayload($result);
+            if (!empty($action)) {
+                return $action;
+            }
+
+            return $result;
+        } catch (\RuntimeException $exception) {
+            $lastError = $exception->getMessage();
+            Log::warning('Failed Halo ticket action create payload.', [
+                'ticket_id' => $ticketId,
+                'endpoint' => 'Actions',
+                'wrapped' => true,
+                'payload_keys' => array_keys($swaggerPayload[0]),
+                'error' => $lastError,
+            ]);
+        }
+
         $payloads = [
             [
                 'outcome' => $outcome,
@@ -629,7 +667,7 @@ class HaloPsaClient
                 'datetime' => $timestamp,
                 'last_updated' => $timestamp,
                 'note' => $message,
-                'Who' => $author !== '' ? $author : null,
+                'Who' => $effectiveAuthor,
             ],
             [
                 'ticket_id' => $ticketId,
@@ -681,22 +719,18 @@ class HaloPsaClient
             'Action',
             'actions',
             'action',
-            'tickets/' . $ticketId . '/actions',
-            'tickets/' . $ticketId . '/action',
         ];
-
-        $lastError = null;
         foreach ($endpoints as $endpoint) {
             foreach ($payloads as $payload) {
                 foreach ([false, true] as $wrapInArray) {
-                    $jsonPayload = $wrapInArray ? [$payload] : $payload;
+                    $requestPayload = $wrapInArray ? [$payload] : $payload;
 
                     try {
                         $result = $this->request('POST', $endpoint, [
                             'headers' => [
                                 'Content-Type' => 'application/json-patch+json',
                             ],
-                            'json' => $jsonPayload,
+                            'body' => json_encode($requestPayload, JSON_UNESCAPED_SLASHES),
                         ]);
 
                         $action = $this->extractActionPayload($result);

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -651,13 +651,25 @@ class HaloPsaClient
                 'HiddenFromUser' => false,
                 'SendEmail' => true,
             ],
+            [
+                'ticket_id' => $ticketId,
+                'note' => $message,
+                'actiontype' => 'Email User',
+                'hiddenfromuser' => false,
+                'sendemail' => true,
+            ],
         ];
 
         $endpoints = [
             'tickets/' . $ticketId . '/actions',
             'tickets/' . $ticketId . '/action',
+            'tickets/' . $ticketId . '/reply',
+            'tickets/' . $ticketId . '/respond',
+            'tickets/' . $ticketId . '/email',
+            'tickets/' . $ticketId . '/emailuser',
             'action',
             'actions',
+            'tickets',
         ];
 
         $lastError = null;

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -571,12 +571,13 @@ class HaloPsaClient
     {
         $endpoints = [
             'tickets/' . $ticketId . '/actions',
+            'action',
             'actions',
         ];
 
         foreach ($endpoints as $endpoint) {
             $query = [];
-            if ($endpoint === 'actions') {
+            if ($endpoint === 'actions' || $endpoint === 'action') {
                 $query = [
                     'ticket_id' => $ticketId,
                     'count' => 200,
@@ -614,18 +615,48 @@ class HaloPsaClient
      */
     public function createTicketAction(int $ticketId, string $message): array
     {
-        return $this->request('POST', 'actions', [
-            'json' => [
+        $payloads = [
+            [
                 'ticket_id' => $ticketId,
-                'TicketId' => $ticketId,
-                'details' => $message,
-                'Details' => $message,
-                'clientvisible' => true,
-                'ClientVisible' => true,
+                'note' => $message,
+                'outcome' => 'Note',
+                'hiddenfromuser' => false,
                 'sendemail' => true,
+            ],
+            [
+                'ticket_id' => $ticketId,
+                'details' => $message,
+                'outcome' => 'Note',
+                'hiddenfromuser' => false,
+                'sendemail' => true,
+            ],
+            [
+                'TicketId' => $ticketId,
+                'Note' => $message,
+                'Outcome' => 'Note',
+                'HiddenFromUser' => false,
                 'SendEmail' => true,
             ],
-        ]);
+        ];
+
+        foreach (['action', 'actions'] as $endpoint) {
+            foreach ($payloads as $payload) {
+                try {
+                    return $this->request('POST', $endpoint, [
+                        'json' => $payload,
+                    ]);
+                } catch (\RuntimeException $exception) {
+                    Log::warning('Failed Halo ticket action create payload.', [
+                        'ticket_id' => $ticketId,
+                        'endpoint' => $endpoint,
+                        'payload_keys' => array_keys($payload),
+                        'error' => $exception->getMessage(),
+                    ]);
+                }
+            }
+        }
+
+        throw new \RuntimeException('Unable to submit reply to Halo ticket with available action payload formats.');
     }
 
     /**

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Log;
 
 class HaloPsaClient
 {
+    private const ACCESS_TOKEN_CACHE_KEY = 'halo_api_access_token';
+
     protected Client $http;
 
     protected string $baseUrl;
@@ -50,7 +52,7 @@ class HaloPsaClient
      */
     protected function getAccessToken(): string
     {
-        $cacheKey = 'halo_api_access_token';
+        $cacheKey = self::ACCESS_TOKEN_CACHE_KEY;
 
         if ($token = Cache::get($cacheKey)) {
             return $token;
@@ -117,7 +119,19 @@ class HaloPsaClient
             $options['headers'] ?? []
         );
 
-        $response = $this->http->request($method, $uri, $options);
+        try {
+            $response = $this->http->request($method, $uri, $options);
+        } catch (ClientException $exception) {
+            $statusCode = $exception->getResponse()?->getStatusCode();
+            if ($statusCode === 401) {
+                Cache::forget(self::ACCESS_TOKEN_CACHE_KEY);
+
+                $options['headers']['Authorization'] = 'Bearer ' . $this->getAccessToken();
+                $response = $this->http->request($method, $uri, $options);
+            } else {
+                throw $exception;
+            }
+        }
 
         $json = json_decode((string) $response->getBody(), true);
 

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -623,138 +623,55 @@ class HaloPsaClient
         $author = trim((string) $who);
         $timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $effectiveAuthor = $author !== '' ? $author : 'Client';
-
-        // First attempt mirrors the known-good Swagger request shape exactly.
-        $swaggerPayload = [[
-            'outcome' => $outcome,
-            'ticket_id' => $ticketId,
-            'datetime' => $timestamp,
-            'last_updated' => $timestamp,
-            'note' => $message,
-            'Who' => $effectiveAuthor,
-        ]];
-
-        $lastError = null;
-        try {
-            $result = $this->request('POST', 'Actions', [
-                'headers' => [
-                    'Content-Type' => 'application/json-patch+json',
-                ],
-                'body' => json_encode($swaggerPayload, JSON_UNESCAPED_SLASHES),
-            ]);
-
-            $action = $this->extractActionPayload($result);
-            if (!empty($action)) {
-                return $action;
-            }
-
-            return $result;
-        } catch (\RuntimeException $exception) {
-            $lastError = $exception->getMessage();
-            Log::warning('Failed Halo ticket action create payload.', [
-                'ticket_id' => $ticketId,
-                'endpoint' => 'Actions',
-                'wrapped' => true,
-                'payload_keys' => array_keys($swaggerPayload[0]),
-                'error' => $lastError,
-            ]);
-        }
-
         $payloads = [
-            [
+            [[
                 'outcome' => $outcome,
                 'ticket_id' => $ticketId,
                 'datetime' => $timestamp,
                 'last_updated' => $timestamp,
                 'note' => $message,
                 'Who' => $effectiveAuthor,
-            ],
-            [
+            ]],
+            [[
                 'ticket_id' => $ticketId,
                 'note' => $message,
                 'outcome' => $outcome,
+                'who' => $effectiveAuthor,
                 'hiddenfromuser' => false,
                 'sendemail' => $sendEmail,
-            ],
-            [
-                'ticket_id' => $ticketId,
-                'note' => $message,
-                'outcome' => $outcome,
-                'who' => $author !== '' ? $author : null,
-                'hiddenfromuser' => false,
-                'sendemail' => $sendEmail,
-            ],
-            [
-                'ticket_id' => $ticketId,
-                'details' => $message,
-                'outcome' => $outcome,
-                'who' => $author !== '' ? $author : null,
-                'hiddenfromuser' => false,
-                'sendemail' => $sendEmail,
-            ],
-            [
-                'TicketId' => $ticketId,
-                'Note' => $message,
-                'Outcome' => $outcome,
-                'Who' => $author !== '' ? $author : null,
-                'HiddenFromUser' => false,
-                'SendEmail' => $sendEmail,
-            ],
-            [
-                'ticketid' => $ticketId,
-                'note' => $message,
-                'outcome' => $outcome,
-                'who' => $author !== '' ? $author : null,
-                'hiddenfromuser' => false,
-                'sendemail' => $sendEmail,
-            ],
+            ]],
         ];
 
-        $payloads = array_map(function (array $payload) {
-            return array_filter($payload, static fn ($value) => $value !== null);
-        }, $payloads);
+        $lastError = null;
+        foreach ($payloads as $requestPayload) {
+            try {
+                $result = $this->request('POST', 'Actions', [
+                    'headers' => [
+                        'Content-Type' => 'application/json-patch+json',
+                    ],
+                    'body' => json_encode($requestPayload, JSON_UNESCAPED_SLASHES),
+                ]);
 
-        $endpoints = [
-            'Actions',
-            'Action',
-            'actions',
-            'action',
-        ];
-        foreach ($endpoints as $endpoint) {
-            foreach ($payloads as $payload) {
-                foreach ([false, true] as $wrapInArray) {
-                    $requestPayload = $wrapInArray ? [$payload] : $payload;
-
-                    try {
-                        $result = $this->request('POST', $endpoint, [
-                            'headers' => [
-                                'Content-Type' => 'application/json-patch+json',
-                            ],
-                            'body' => json_encode($requestPayload, JSON_UNESCAPED_SLASHES),
-                        ]);
-
-                        $action = $this->extractActionPayload($result);
-                        if (!empty($action)) {
-                            return $action;
-                        }
-
-                        return $result;
-                    } catch (\RuntimeException $exception) {
-                        $lastError = $exception->getMessage();
-                        Log::warning('Failed Halo ticket action create payload.', [
-                            'ticket_id' => $ticketId,
-                            'endpoint' => $endpoint,
-                            'wrapped' => $wrapInArray,
-                            'payload_keys' => array_keys($payload),
-                            'error' => $lastError,
-                        ]);
-                    }
+                $action = $this->extractActionPayload($result);
+                if (!empty($action)) {
+                    return $action;
                 }
+
+                return $result;
+            } catch (\RuntimeException $exception) {
+                $lastError = $exception->getMessage();
+                Log::warning('Failed Halo ticket action create payload.', [
+                    'ticket_id' => $ticketId,
+                    'endpoint' => 'Actions',
+                    'wrapped' => true,
+                    'payload_keys' => array_keys($requestPayload[0] ?? []),
+                    'error' => $lastError,
+                ]);
             }
         }
 
         $suffix = $lastError ? ' Last error: ' . $lastError : '';
-        throw new \RuntimeException('Unable to submit reply to Halo ticket with available action payload formats.' . $suffix);
+        throw new \RuntimeException('Unable to submit reply to Halo ticket via /Actions endpoint.' . $suffix);
     }
 
     private function extractActionPayload(array $result): array

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -113,8 +113,8 @@ class HaloPsaClient
         }
 
         $options['headers'] = array_merge(
-            $options['headers'] ?? [],
-            $this->headers()
+            $this->headers(),
+            $options['headers'] ?? []
         );
 
         $response = $this->http->request($method, $uri, $options);
@@ -621,7 +621,16 @@ class HaloPsaClient
         bool $sendEmail = false
     ): array {
         $author = trim((string) $who);
+        $timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $payloads = [
+            [
+                'outcome' => $outcome,
+                'ticket_id' => $ticketId,
+                'datetime' => $timestamp,
+                'last_updated' => $timestamp,
+                'note' => $message,
+                'Who' => $author !== '' ? $author : null,
+            ],
             [
                 'ticket_id' => $ticketId,
                 'note' => $message,
@@ -668,6 +677,8 @@ class HaloPsaClient
         }, $payloads);
 
         $endpoints = [
+            'Actions',
+            'Action',
             'actions',
             'action',
             'tickets/' . $ticketId . '/actions',
@@ -682,6 +693,9 @@ class HaloPsaClient
 
                     try {
                         $result = $this->request('POST', $endpoint, [
+                            'headers' => [
+                                'Content-Type' => 'application/json-patch+json',
+                            ],
                             'json' => $jsonPayload,
                         ]);
 

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -611,65 +611,67 @@ class HaloPsaClient
     }
 
     /**
-     * Add a client-visible action/note reply to a ticket.
+     * Add an action/note to a ticket.
      */
-    public function createTicketAction(int $ticketId, string $message): array
-    {
+    public function createTicketAction(
+        int $ticketId,
+        string $message,
+        string $outcome = 'Client-Responded',
+        ?string $who = null,
+        bool $sendEmail = false
+    ): array {
+        $author = trim((string) $who);
         $payloads = [
             [
                 'ticket_id' => $ticketId,
                 'note' => $message,
-                'outcome' => 'Note',
+                'outcome' => $outcome,
                 'hiddenfromuser' => false,
-                'sendemail' => true,
+                'sendemail' => $sendEmail,
+            ],
+            [
+                'ticket_id' => $ticketId,
+                'note' => $message,
+                'outcome' => $outcome,
+                'who' => $author !== '' ? $author : null,
+                'hiddenfromuser' => false,
+                'sendemail' => $sendEmail,
             ],
             [
                 'ticket_id' => $ticketId,
                 'details' => $message,
-                'outcome' => 'Note',
+                'outcome' => $outcome,
+                'who' => $author !== '' ? $author : null,
                 'hiddenfromuser' => false,
-                'sendemail' => true,
+                'sendemail' => $sendEmail,
             ],
             [
                 'TicketId' => $ticketId,
                 'Note' => $message,
-                'Outcome' => 'Note',
+                'Outcome' => $outcome,
+                'Who' => $author !== '' ? $author : null,
                 'HiddenFromUser' => false,
-                'SendEmail' => true,
+                'SendEmail' => $sendEmail,
             ],
             [
                 'ticketid' => $ticketId,
                 'note' => $message,
-                'outcome' => 'Note',
+                'outcome' => $outcome,
+                'who' => $author !== '' ? $author : null,
                 'hiddenfromuser' => false,
-                'sendemail' => true,
-            ],
-            [
-                'TicketID' => $ticketId,
-                'Details' => $message,
-                'Outcome' => 'Note',
-                'HiddenFromUser' => false,
-                'SendEmail' => true,
-            ],
-            [
-                'ticket_id' => $ticketId,
-                'note' => $message,
-                'actiontype' => 'Email User',
-                'hiddenfromuser' => false,
-                'sendemail' => true,
+                'sendemail' => $sendEmail,
             ],
         ];
+
+        $payloads = array_map(function (array $payload) {
+            return array_filter($payload, static fn ($value) => $value !== null);
+        }, $payloads);
 
         $endpoints = [
             'actions',
             'action',
             'tickets/' . $ticketId . '/actions',
             'tickets/' . $ticketId . '/action',
-            'tickets/' . $ticketId . '/reply',
-            'tickets/' . $ticketId . '/respond',
-            'tickets/' . $ticketId . '/email',
-            'tickets/' . $ticketId . '/emailuser',
-            'tickets',
         ];
 
         $lastError = null;
@@ -679,9 +681,16 @@ class HaloPsaClient
                     $jsonPayload = $wrapInArray ? [$payload] : $payload;
 
                     try {
-                        return $this->request('POST', $endpoint, [
+                        $result = $this->request('POST', $endpoint, [
                             'json' => $jsonPayload,
                         ]);
+
+                        $action = $this->extractActionPayload($result);
+                        if (!empty($action)) {
+                            return $action;
+                        }
+
+                        return $result;
                     } catch (\RuntimeException $exception) {
                         $lastError = $exception->getMessage();
                         Log::warning('Failed Halo ticket action create payload.', [
@@ -698,6 +707,27 @@ class HaloPsaClient
 
         $suffix = $lastError ? ' Last error: ' . $lastError : '';
         throw new \RuntimeException('Unable to submit reply to Halo ticket with available action payload formats.' . $suffix);
+    }
+
+    private function extractActionPayload(array $result): array
+    {
+        if (array_is_list($result) && isset($result[0]) && is_array($result[0])) {
+            return $result[0];
+        }
+
+        if (isset($result['action']) && is_array($result['action'])) {
+            return $result['action'];
+        }
+
+        if (isset($result['data']) && is_array($result['data'])) {
+            return $result['data'];
+        }
+
+        if (isset($result['id']) || isset($result['Id'])) {
+            return $result;
+        }
+
+        return [];
     }
 
     public function updateTicketStatus(int $ticketId, int $statusId): array

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -565,6 +565,70 @@ class HaloPsaClient
     }
 
     /**
+     * Fetch ticket communications/actions from Halo.
+     */
+    public function getTicketActions(int $ticketId): array
+    {
+        $endpoints = [
+            'tickets/' . $ticketId . '/actions',
+            'actions',
+        ];
+
+        foreach ($endpoints as $endpoint) {
+            $query = [];
+            if ($endpoint === 'actions') {
+                $query = [
+                    'ticket_id' => $ticketId,
+                    'count' => 200,
+                ];
+            }
+
+            try {
+                $result = $this->request('GET', $endpoint, [
+                    'query' => $query,
+                ]);
+
+                $actions = $result['actions']
+                    ?? $result['ticket_actions']
+                    ?? $result['data']
+                    ?? $result['Results']
+                    ?? (array_is_list($result) ? $result : []);
+
+                if (is_array($actions)) {
+                    return array_values(array_filter($actions, 'is_array'));
+                }
+            } catch (\RuntimeException $exception) {
+                Log::warning('Failed Halo ticket action endpoint.', [
+                    'ticket_id' => $ticketId,
+                    'endpoint' => $endpoint,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Add a client-visible action/note reply to a ticket.
+     */
+    public function createTicketAction(int $ticketId, string $message): array
+    {
+        return $this->request('POST', 'actions', [
+            'json' => [
+                'ticket_id' => $ticketId,
+                'TicketId' => $ticketId,
+                'details' => $message,
+                'Details' => $message,
+                'clientvisible' => true,
+                'ClientVisible' => true,
+                'sendemail' => true,
+                'SendEmail' => true,
+            ],
+        ]);
+    }
+
+    /**
      * Fetch HaloPSA ticket types.
      */
     public function listTicketTypes(): array

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -637,26 +637,55 @@ class HaloPsaClient
                 'HiddenFromUser' => false,
                 'SendEmail' => true,
             ],
+            [
+                'ticketid' => $ticketId,
+                'note' => $message,
+                'outcome' => 'Note',
+                'hiddenfromuser' => false,
+                'sendemail' => true,
+            ],
+            [
+                'TicketID' => $ticketId,
+                'Details' => $message,
+                'Outcome' => 'Note',
+                'HiddenFromUser' => false,
+                'SendEmail' => true,
+            ],
         ];
 
-        foreach (['action', 'actions'] as $endpoint) {
+        $endpoints = [
+            'tickets/' . $ticketId . '/actions',
+            'tickets/' . $ticketId . '/action',
+            'action',
+            'actions',
+        ];
+
+        $lastError = null;
+        foreach ($endpoints as $endpoint) {
             foreach ($payloads as $payload) {
-                try {
-                    return $this->request('POST', $endpoint, [
-                        'json' => $payload,
-                    ]);
-                } catch (\RuntimeException $exception) {
-                    Log::warning('Failed Halo ticket action create payload.', [
-                        'ticket_id' => $ticketId,
-                        'endpoint' => $endpoint,
-                        'payload_keys' => array_keys($payload),
-                        'error' => $exception->getMessage(),
-                    ]);
+                foreach ([false, true] as $wrapInArray) {
+                    $jsonPayload = $wrapInArray ? [$payload] : $payload;
+
+                    try {
+                        return $this->request('POST', $endpoint, [
+                            'json' => $jsonPayload,
+                        ]);
+                    } catch (\RuntimeException $exception) {
+                        $lastError = $exception->getMessage();
+                        Log::warning('Failed Halo ticket action create payload.', [
+                            'ticket_id' => $ticketId,
+                            'endpoint' => $endpoint,
+                            'wrapped' => $wrapInArray,
+                            'payload_keys' => array_keys($payload),
+                            'error' => $lastError,
+                        ]);
+                    }
                 }
             }
         }
 
-        throw new \RuntimeException('Unable to submit reply to Halo ticket with available action payload formats.');
+        $suffix = $lastError ? ' Last error: ' . $lastError : '';
+        throw new \RuntimeException('Unable to submit reply to Halo ticket with available action payload formats.' . $suffix);
     }
 
     /**

--- a/resources/views/tickets/requests.blade.php
+++ b/resources/views/tickets/requests.blade.php
@@ -2,6 +2,12 @@
 
 @section('content')
 <div style="max-width:1080px;">
+    <div id="ticket-loading-overlay" style="position:fixed;inset:0;background:rgba(2,6,23,0.6);backdrop-filter:blur(2px);z-index:12000;display:none;align-items:center;justify-content:center;padding:20px;">
+        <div style="min-width:220px;background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:16px 18px;display:flex;align-items:center;gap:10px;color:var(--text);">
+            <span style="width:18px;height:18px;border:2px solid rgba(148,163,184,0.45);border-top-color:var(--text);border-radius:999px;display:inline-block;animation:ticket-spin 0.7s linear infinite;"></span>
+            <span id="ticket-loading-text">Loading tickets...</span>
+        </div>
+    </div>
     <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:14px;flex-wrap:wrap;">
         <div>
             <h1 class="dd-page-title" style="font-size:1.6rem;margin-bottom:10px;">Support Requests</h1>
@@ -11,7 +17,7 @@
     </div>
 
     @if($clients->isNotEmpty())
-        <form method="GET" action="{{ route('tickets.index') }}" style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:12px 14px;margin-bottom:16px;display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));align-items:end;">
+        <form id="ticket-filter-form" method="GET" action="{{ route('tickets.index') }}" style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:12px 14px;margin-bottom:16px;display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));align-items:end;">
             <div>
                 <label for="client_id" style="display:block;font-weight:600;margin-bottom:6px;">Client</label>
                 <select id="client_id" name="client_id" style="width:100%;border:1px solid var(--border-subtle);border-radius:10px;padding:9px 11px;background:var(--bg);color:var(--text);">
@@ -74,7 +80,7 @@
             </thead>
             <tbody id="support-ticket-table-body">
                 @forelse($tickets as $ticket)
-                    <tr onclick="window.location='{{ route('tickets.show', ['ticketId' => $ticket['id'] ?? 0, 'client_id' => $selectedClientId]) }}'" style="cursor:pointer;">
+                    <tr data-ticket-link="{{ route('tickets.show', ['ticketId' => $ticket['id'] ?? 0, 'client_id' => $selectedClientId]) }}" style="cursor:pointer;">
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['id'] ?? '-' }}</td>
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['summary'] ?? '-' }}</td>
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['service'] ?? '-' }}</td>
@@ -101,18 +107,61 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {
+        const loadingOverlay = document.getElementById('ticket-loading-overlay');
+        const loadingText = document.getElementById('ticket-loading-text');
+        const filterForm = document.getElementById('ticket-filter-form');
         const loadMoreButton = document.getElementById('support-ticket-load-more');
+        const tableBody = document.getElementById('support-ticket-table-body');
+
+        const showLoading = (text) => {
+            if (!loadingOverlay || !loadingText) {
+                return;
+            }
+
+            loadingText.textContent = text;
+            loadingOverlay.style.display = 'flex';
+        };
+
+        const hideLoading = () => {
+            if (!loadingOverlay) {
+                return;
+            }
+
+            loadingOverlay.style.display = 'none';
+        };
+
+        const wireTicketRowClicks = (scope) => {
+            scope.querySelectorAll('tr[data-ticket-link]').forEach((row) => {
+                row.addEventListener('click', function () {
+                    const targetUrl = row.getAttribute('data-ticket-link');
+                    if (!targetUrl) {
+                        return;
+                    }
+
+                    showLoading('Loading ticket details...');
+                    window.location.href = targetUrl;
+                });
+            });
+        };
+
+        if (filterForm) {
+            filterForm.addEventListener('submit', function () {
+                showLoading('Loading tickets...');
+            });
+        }
+
+        wireTicketRowClicks(document);
+
         if (!loadMoreButton) {
             return;
         }
 
-        const tableBody = document.getElementById('support-ticket-table-body');
         const currentPageLabel = document.getElementById('support-ticket-current-page');
         let currentPage = Number(currentPageLabel.textContent || '1');
 
         const selectedClientId = @json($selectedClientId);
         const buildRow = (row) => `
-            <tr onclick="window.location='{{ url('/tickets') }}/${row.id}?client_id=${selectedClientId}'" style="cursor:pointer;">
+            <tr data-ticket-link="{{ url('/tickets') }}/${row.id}?client_id=${selectedClientId}" style="cursor:pointer;">
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.id}</td>
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.summary}</td>
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.service}</td>
@@ -126,6 +175,7 @@
             const params = new URLSearchParams(window.location.search);
             params.set('page', String(currentPage + 1));
 
+            showLoading('Loading more tickets...');
             loadMoreButton.disabled = true;
             loadMoreButton.textContent = 'Loading...';
 
@@ -139,6 +189,7 @@
                 rows.forEach(row => {
                     tableBody.insertAdjacentHTML('beforeend', buildRow(row));
                 });
+                wireTicketRowClicks(tableBody);
 
                 currentPage = Number(data.page || currentPage + 1);
                 currentPageLabel.textContent = String(currentPage);
@@ -153,8 +204,15 @@
                 loadMoreButton.disabled = false;
                 loadMoreButton.textContent = 'Load Next 25';
                 alert('Unable to load next ticket page.');
+            } finally {
+                hideLoading();
             }
         });
     });
 </script>
+<style>
+    @keyframes ticket-spin {
+        to { transform: rotate(360deg); }
+    }
+</style>
 @endsection

--- a/resources/views/tickets/requests.blade.php
+++ b/resources/views/tickets/requests.blade.php
@@ -74,7 +74,7 @@
             </thead>
             <tbody id="support-ticket-table-body">
                 @forelse($tickets as $ticket)
-                    <tr>
+                    <tr onclick="window.location='{{ route('tickets.show', ['ticketId' => $ticket['id'] ?? 0, 'client_id' => $selectedClientId]) }}'" style="cursor:pointer;">
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['id'] ?? '-' }}</td>
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['summary'] ?? '-' }}</td>
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['service'] ?? '-' }}</td>
@@ -110,8 +110,9 @@
         const currentPageLabel = document.getElementById('support-ticket-current-page');
         let currentPage = Number(currentPageLabel.textContent || '1');
 
+        const selectedClientId = @json($selectedClientId);
         const buildRow = (row) => `
-            <tr>
+            <tr onclick="window.location='{{ url('/tickets') }}/${row.id}?client_id=${selectedClientId}'" style="cursor:pointer;">
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.id}</td>
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.summary}</td>
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.service}</td>

--- a/resources/views/tickets/requests.blade.php
+++ b/resources/views/tickets/requests.blade.php
@@ -80,7 +80,7 @@
             </thead>
             <tbody id="support-ticket-table-body">
                 @forelse($tickets as $ticket)
-                    <tr data-ticket-link="{{ route('tickets.show', ['ticketId' => $ticket['id'] ?? 0, 'client_id' => $selectedClientId]) }}" style="cursor:pointer;">
+                    <tr data-ticket-link="{{ route('tickets.show', ['ticketId' => $ticket['id'] ?? 0, 'client_id' => $selectedClientId, 'service' => $ticket['service'] ?? '']) }}" style="cursor:pointer;">
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['id'] ?? '-' }}</td>
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['summary'] ?? '-' }}</td>
                         <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">{{ $ticket['service'] ?? '-' }}</td>
@@ -161,7 +161,7 @@
 
         const selectedClientId = @json($selectedClientId);
         const buildRow = (row) => `
-            <tr data-ticket-link="{{ url('/tickets') }}/${row.id}?client_id=${selectedClientId}" style="cursor:pointer;">
+            <tr data-ticket-link="{{ url('/tickets') }}/${row.id}?client_id=${selectedClientId}&service=${encodeURIComponent(row.service || '')}" style="cursor:pointer;">
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.id}</td>
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.summary}</td>
                 <td style="padding:10px 12px;border-bottom:1px solid var(--border-subtle);">${row.service}</td>

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -1,0 +1,74 @@
+@extends('layouts.app')
+
+@section('content')
+<div style="max-width:1080px;display:grid;gap:14px;">
+    <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;">
+        <div>
+            <h1 class="dd-page-title" style="font-size:1.6rem;margin-bottom:6px;">Ticket #{{ $ticketId }}</h1>
+            <p style="margin:0;color:var(--text-muted);">{{ $ticket['summary'] ?? $ticket['Summary'] ?? 'Support ticket details' }}</p>
+        </div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+            <a href="{{ route('tickets.index', ['client_id' => $selectedClientId]) }}" style="padding:9px 12px;border-radius:10px;border:1px solid var(--border-subtle);text-decoration:none;color:var(--text-muted);">Back to tickets</a>
+            @if($portalUrl)
+                <a href="{{ $portalUrl }}" target="_blank" rel="noopener noreferrer" class="btn-accent" style="text-decoration:none;">Open in Client Portal</a>
+            @endif
+        </div>
+    </div>
+
+    @if(session('status'))
+        <div style="background:rgba(16,185,129,0.14);border:1px solid rgba(16,185,129,0.45);color:#10b981;border-radius:12px;padding:12px 14px;">
+            {{ session('status') }}
+        </div>
+    @endif
+
+    @if($errors->any())
+        <div style="background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.35);color:#ef4444;border-radius:12px;padding:12px 14px;">
+            <strong>Unable to complete action.</strong>
+            <ul style="margin:8px 0 0 18px;padding:0;">
+                @foreach($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:12px 14px;display:grid;gap:8px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));">
+        <div><strong>Client</strong><br>{{ $selectedClient->business_name }}</div>
+        <div><strong>Status</strong><br>{{ $ticket['status_name'] ?? $ticket['StatusName'] ?? $ticket['status'] ?? '-' }}</div>
+        <div><strong>Type</strong><br>{{ $ticket['tickettype_name'] ?? $ticket['TicketTypeName'] ?? $ticket['tickettype'] ?? '-' }}</div>
+        <div><strong>Last Update</strong><br>{{ $ticket['lastactiondate'] ?? $ticket['LastActionDate'] ?? $ticket['datecreated'] ?? '-' }}</div>
+    </div>
+
+    <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;overflow:hidden;">
+        <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);font-weight:600;">Client Visible Communications / Email Actions</div>
+        <div style="max-height:460px;overflow:auto;">
+            @forelse($actions as $action)
+                @php
+                    $isClientVisible = (bool) ($action['clientvisible'] ?? $action['ClientVisible'] ?? $action['is_client_visible'] ?? true);
+                @endphp
+                @if($isClientVisible)
+                    <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);display:grid;gap:6px;">
+                        <div style="display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+                            <strong>{{ $action['agent_name'] ?? $action['AgentName'] ?? $action['who'] ?? 'Update' }}</strong>
+                            <span style="color:var(--text-muted);font-size:12px;">{{ $action['datecreated'] ?? $action['DateCreated'] ?? $action['date'] ?? '-' }}</span>
+                        </div>
+                        <div style="white-space:pre-wrap;">{{ $action['details'] ?? $action['Details'] ?? $action['note'] ?? '-' }}</div>
+                    </div>
+                @endif
+            @empty
+                <div style="padding:14px;color:var(--text-muted);">No client-visible communications were returned for this ticket.</div>
+            @endforelse
+        </div>
+    </div>
+
+    <form method="POST" action="{{ route('tickets.reply', ['ticketId' => $ticketId]) }}" style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:14px;display:grid;gap:10px;">
+        @csrf
+        <input type="hidden" name="client_id" value="{{ $selectedClientId }}">
+        <label for="ticket_reply" style="font-weight:600;">Reply to technician / provide update</label>
+        <textarea id="ticket_reply" name="message" rows="5" required style="width:100%;border:1px solid var(--border-subtle);border-radius:10px;padding:10px 11px;background:var(--bg);color:var(--text);">{{ old('message') }}</textarea>
+        <div>
+            <button class="btn-accent" type="submit">Submit Reply</button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -1,11 +1,35 @@
 @extends('layouts.app')
 
 @section('content')
+@php
+    $ticketSummary = $ticket['summary'] ?? $ticket['Summary'] ?? 'Support ticket details';
+    if (!is_string($ticketSummary) || trim($ticketSummary) === '') {
+        $ticketSummary = 'Support ticket details';
+    }
+
+    $ticketStatus = $ticket['status_name'] ?? $ticket['StatusName'] ?? $ticket['status'] ?? '-';
+    if (is_array($ticketStatus)) {
+        $ticketStatus = $ticketStatus['name'] ?? $ticketStatus['Name'] ?? '-';
+    }
+    $ticketStatus = is_string($ticketStatus) ? $ticketStatus : '-';
+
+    $ticketType = $ticket['tickettype_name'] ?? $ticket['TicketTypeName'] ?? $ticket['tickettype'] ?? '-';
+    if (is_array($ticketType)) {
+        $ticketType = $ticketType['name'] ?? $ticketType['Name'] ?? '-';
+    }
+    $ticketType = is_string($ticketType) ? $ticketType : '-';
+
+    $ticketUpdated = $ticket['lastactiondate'] ?? $ticket['LastActionDate'] ?? $ticket['datecreated'] ?? '-';
+    if (is_array($ticketUpdated)) {
+        $ticketUpdated = '-';
+    }
+    $ticketUpdated = is_string($ticketUpdated) ? $ticketUpdated : '-';
+@endphp
 <div style="max-width:1080px;display:grid;gap:14px;">
     <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;">
         <div>
             <h1 class="dd-page-title" style="font-size:1.6rem;margin-bottom:6px;">Ticket #{{ $ticketId }}</h1>
-            <p style="margin:0;color:var(--text-muted);">{{ $ticket['summary'] ?? $ticket['Summary'] ?? 'Support ticket details' }}</p>
+            <p style="margin:0;color:var(--text-muted);">{{ $ticketSummary }}</p>
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
             <a href="{{ route('tickets.index', ['client_id' => $selectedClientId]) }}" style="padding:9px 12px;border-radius:10px;border:1px solid var(--border-subtle);text-decoration:none;color:var(--text-muted);">Back to tickets</a>
@@ -34,9 +58,9 @@
 
     <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:12px 14px;display:grid;gap:8px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));">
         <div><strong>Client</strong><br>{{ $selectedClient->business_name }}</div>
-        <div><strong>Status</strong><br>{{ $ticket['status_name'] ?? $ticket['StatusName'] ?? $ticket['status'] ?? '-' }}</div>
-        <div><strong>Type</strong><br>{{ $ticket['tickettype_name'] ?? $ticket['TicketTypeName'] ?? $ticket['tickettype'] ?? '-' }}</div>
-        <div><strong>Last Update</strong><br>{{ $ticket['lastactiondate'] ?? $ticket['LastActionDate'] ?? $ticket['datecreated'] ?? '-' }}</div>
+        <div><strong>Status</strong><br>{{ $ticketStatus }}</div>
+        <div><strong>Type</strong><br>{{ $ticketType }}</div>
+        <div><strong>Last Update</strong><br>{{ $ticketUpdated }}</div>
     </div>
 
     <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;overflow:hidden;">
@@ -45,14 +69,31 @@
             @forelse($actions as $action)
                 @php
                     $isClientVisible = (bool) ($action['clientvisible'] ?? $action['ClientVisible'] ?? $action['is_client_visible'] ?? true);
+                    $actionAuthor = $action['agent_name'] ?? $action['AgentName'] ?? $action['who'] ?? 'Update';
+                    if (!is_string($actionAuthor) || trim($actionAuthor) === '') {
+                        $actionAuthor = 'Update';
+                    }
+
+                    $actionDate = $action['datecreated'] ?? $action['DateCreated'] ?? $action['date'] ?? '-';
+                    if (!is_string($actionDate) || trim($actionDate) === '') {
+                        $actionDate = '-';
+                    }
+
+                    $actionDetails = $action['details'] ?? $action['Details'] ?? $action['note'] ?? '-';
+                    if (is_array($actionDetails)) {
+                        $actionDetails = $actionDetails['text'] ?? $actionDetails['Text'] ?? '-';
+                    }
+                    if (!is_string($actionDetails) || trim($actionDetails) === '') {
+                        $actionDetails = '-';
+                    }
                 @endphp
                 @if($isClientVisible)
                     <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);display:grid;gap:6px;">
                         <div style="display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;">
-                            <strong>{{ $action['agent_name'] ?? $action['AgentName'] ?? $action['who'] ?? 'Update' }}</strong>
-                            <span style="color:var(--text-muted);font-size:12px;">{{ $action['datecreated'] ?? $action['DateCreated'] ?? $action['date'] ?? '-' }}</span>
+                            <strong>{{ $actionAuthor }}</strong>
+                            <span style="color:var(--text-muted);font-size:12px;">{{ $actionDate }}</span>
                         </div>
-                        <div style="white-space:pre-wrap;">{{ $action['details'] ?? $action['Details'] ?? $action['note'] ?? '-' }}</div>
+                        <div style="white-space:pre-wrap;">{{ $actionDetails }}</div>
                     </div>
                 @endif
             @empty

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -7,19 +7,19 @@
         $ticketSummary = 'Support ticket details';
     }
 
-    $ticketStatus = $ticket['status_name'] ?? $ticket['StatusName'] ?? $ticket['status'] ?? '-';
+    $ticketStatus = $ticketStatusLabel ?? $ticket['status_name'] ?? $ticket['StatusName'] ?? $ticket['status'] ?? '-';
     if (is_array($ticketStatus)) {
         $ticketStatus = $ticketStatus['name'] ?? $ticketStatus['Name'] ?? '-';
     }
     $ticketStatus = is_string($ticketStatus) ? $ticketStatus : '-';
 
-    $ticketType = $ticket['tickettype_name'] ?? $ticket['TicketTypeName'] ?? $ticket['tickettype'] ?? '-';
+    $ticketType = $ticketTypeLabel ?? $ticket['tickettype_name'] ?? $ticket['TicketTypeName'] ?? $ticket['tickettype'] ?? '-';
     if (is_array($ticketType)) {
         $ticketType = $ticketType['name'] ?? $ticketType['Name'] ?? '-';
     }
     $ticketType = is_string($ticketType) ? $ticketType : '-';
 
-    $ticketUpdated = $ticket['lastactiondate'] ?? $ticket['LastActionDate'] ?? $ticket['datecreated'] ?? '-';
+    $ticketUpdated = $ticketUpdatedLabel ?? $ticket['lastactiondate'] ?? $ticket['LastActionDate'] ?? $ticket['datecreated'] ?? '-';
     if (is_array($ticketUpdated)) {
         $ticketUpdated = '-';
     }

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -68,7 +68,6 @@
         <div style="max-height:460px;overflow:auto;">
             @forelse($actions as $action)
                 @php
-                    $isClientVisible = (bool) ($action['clientvisible'] ?? $action['ClientVisible'] ?? $action['is_client_visible'] ?? true);
                     $actionAuthor = $action['agent_name'] ?? $action['AgentName'] ?? $action['who'] ?? 'Update';
                     if (!is_string($actionAuthor) || trim($actionAuthor) === '') {
                         $actionAuthor = 'Update';
@@ -87,15 +86,13 @@
                         $actionDetails = '-';
                     }
                 @endphp
-                @if($isClientVisible)
-                    <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);display:grid;gap:6px;">
-                        <div style="display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;">
-                            <strong>{{ $actionAuthor }}</strong>
-                            <span style="color:var(--text-muted);font-size:12px;">{{ $actionDate }}</span>
-                        </div>
-                        <div style="white-space:pre-wrap;">{{ $actionDetails }}</div>
+                <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);display:grid;gap:6px;">
+                    <div style="display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;">
+                        <strong>{{ $actionAuthor }}</strong>
+                        <span style="color:var(--text-muted);font-size:12px;">{{ $actionDate }}</span>
                     </div>
-                @endif
+                    <div style="white-space:pre-wrap;">{{ $actionDetails }}</div>
+                </div>
             @empty
                 <div style="padding:14px;color:var(--text-muted);">No client-visible communications were returned for this ticket.</div>
             @endforelse

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -39,11 +39,7 @@
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
             <button type="button" id="open-reply-modal" class="btn-accent">Submit Reply</button>
-            <form method="POST" action="{{ route('tickets.close', ['ticketId' => $ticketId]) }}" style="margin:0;">
-                @csrf
-                <input type="hidden" name="client_id" value="{{ $selectedClientId }}">
-                <button type="submit" style="padding:9px 12px;border-radius:10px;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.15);color:#ef4444;cursor:pointer;">Close Ticket</button>
-            </form>
+            <button type="button" id="open-close-modal" style="padding:9px 12px;border-radius:10px;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.15);color:#ef4444;cursor:pointer;">Close Ticket</button>
             <a href="{{ route('tickets.index', ['client_id' => $selectedClientId]) }}" style="padding:9px 12px;border-radius:10px;border:1px solid var(--border-subtle);text-decoration:none;color:var(--text-muted);">Back to tickets</a>
             @if($portalUrl)
                 <a href="{{ $portalUrl }}" target="_blank" rel="noopener noreferrer" class="btn-accent" style="text-decoration:none;">Open in Client Portal</a>
@@ -86,7 +82,14 @@
                         $actionAuthor = 'Update';
                     }
 
-                    $actionDate = $action['datecreated'] ?? $action['DateCreated'] ?? $action['date'] ?? '-';
+                    $actionDate = $action['datecreated']
+                        ?? $action['DateCreated']
+                        ?? $action['date']
+                        ?? $action['datetime']
+                        ?? $action['DateTime']
+                        ?? $action['startdate']
+                        ?? $action['StartDate']
+                        ?? '-';
                     if (!is_string($actionDate) || trim($actionDate) === '') {
                         $actionDate = '-';
                     }
@@ -120,9 +123,26 @@
                 <label for="ticket_reply" style="font-weight:600;">Reply to technician / provide update</label>
                 <button type="button" id="close-reply-modal" style="padding:6px 10px;border-radius:8px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-muted);cursor:pointer;">Close</button>
             </div>
-            <textarea id="ticket_reply" name="message" rows="8" required style="width:100%;border:1px solid var(--border-subtle);border-radius:10px;padding:10px 11px;background:var(--bg);color:var(--text);">{{ old('message') }}</textarea>
+            <input type="hidden" id="ticket_reply" name="message" value="{{ old('message') }}">
+            <div id="ticket_reply_editor" contenteditable="true" style="width:100%;min-height:220px;border:1px solid var(--border-subtle);border-radius:10px;padding:10px 11px;background:var(--bg);color:var(--text);overflow:auto;"></div>
             <div>
                 <button class="btn-accent" type="submit">Submit Reply</button>
+            </div>
+        </form>
+    </div>
+
+    <div id="close-modal" style="display:none;position:fixed;inset:0;background:rgba(2,6,23,0.72);z-index:12050;align-items:center;justify-content:center;padding:16px;">
+        <form method="POST" action="{{ route('tickets.close', ['ticketId' => $ticketId]) }}" style="width:min(640px, 96vw);background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:14px;display:grid;gap:10px;">
+            @csrf
+            <input type="hidden" name="client_id" value="{{ $selectedClientId }}">
+            <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;">
+                <label for="close_reason" style="font-weight:600;">Reason for closure</label>
+                <button type="button" id="close-close-modal" style="padding:6px 10px;border-radius:8px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-muted);cursor:pointer;">Close</button>
+            </div>
+            <input type="hidden" id="close_reason" name="reason" value="{{ old('reason') }}">
+            <div id="close_reason_editor" contenteditable="true" style="width:100%;min-height:180px;border:1px solid var(--border-subtle);border-radius:10px;padding:10px 11px;background:var(--bg);color:var(--text);overflow:auto;"></div>
+            <div>
+                <button type="submit" style="padding:9px 12px;border-radius:10px;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.15);color:#ef4444;cursor:pointer;">Confirm Close Ticket</button>
             </div>
         </form>
     </div>
@@ -133,28 +153,76 @@
         const openButton = document.getElementById('open-reply-modal');
         const closeButton = document.getElementById('close-reply-modal');
         const modal = document.getElementById('reply-modal');
+        const openCloseButton = document.getElementById('open-close-modal');
+        const closeCloseButton = document.getElementById('close-close-modal');
+        const closeModal = document.getElementById('close-modal');
+        const replyEditor = document.getElementById('ticket_reply_editor');
+        const replyInput = document.getElementById('ticket_reply');
+        const closeReasonEditor = document.getElementById('close_reason_editor');
+        const closeReasonInput = document.getElementById('close_reason');
 
-        if (!openButton || !closeButton || !modal) {
+        if (!openButton || !closeButton || !modal || !openCloseButton || !closeCloseButton || !closeModal || !replyEditor || !replyInput || !closeReasonEditor || !closeReasonInput) {
             return;
         }
 
-        const openModal = () => {
+        const openReplyModal = () => {
             modal.style.display = 'flex';
         };
-        const closeModal = () => {
+        const hideReplyModal = () => {
             modal.style.display = 'none';
         };
+        const openCloseModal = () => {
+            closeModal.style.display = 'flex';
+        };
+        const hideCloseModal = () => {
+            closeModal.style.display = 'none';
+        };
 
-        openButton.addEventListener('click', openModal);
-        closeButton.addEventListener('click', closeModal);
+        const syncEditorToInput = (editor, input) => {
+            input.value = editor.innerHTML.trim();
+        };
+        const hydrateEditor = (editor, input) => {
+            if (input.value.trim() !== '') {
+                editor.innerHTML = input.value;
+            }
+        };
+
+        hydrateEditor(replyEditor, replyInput);
+        hydrateEditor(closeReasonEditor, closeReasonInput);
+        syncEditorToInput(replyEditor, replyInput);
+        syncEditorToInput(closeReasonEditor, closeReasonInput);
+
+        openButton.addEventListener('click', openReplyModal);
+        closeButton.addEventListener('click', hideReplyModal);
+        openCloseButton.addEventListener('click', openCloseModal);
+        closeCloseButton.addEventListener('click', hideCloseModal);
+        replyEditor.addEventListener('input', () => syncEditorToInput(replyEditor, replyInput));
+        closeReasonEditor.addEventListener('input', () => syncEditorToInput(closeReasonEditor, closeReasonInput));
+
+        modal.querySelector('form')?.addEventListener('submit', function () {
+            syncEditorToInput(replyEditor, replyInput);
+        });
+        closeModal.querySelector('form')?.addEventListener('submit', function () {
+            syncEditorToInput(closeReasonEditor, closeReasonInput);
+        });
+
         modal.addEventListener('click', function (event) {
             if (event.target === modal) {
-                closeModal();
+                hideReplyModal();
+            }
+        });
+        closeModal.addEventListener('click', function (event) {
+            if (event.target === closeModal) {
+                hideCloseModal();
             }
         });
 
         @if($errors->any())
-            openModal();
+            @if(old('reason'))
+                openCloseModal();
+            @else
+                openReplyModal();
+            @endif
         @endif
     });
 </script>

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -19,6 +19,12 @@
     }
     $ticketType = is_string($ticketType) ? $ticketType : '-';
 
+    $ticketService = $ticketServiceLabel ?? $ticket['category_1'] ?? $ticket['Category1'] ?? $ticket['category1'] ?? '-';
+    if (is_array($ticketService)) {
+        $ticketService = $ticketService['name'] ?? $ticketService['Name'] ?? '-';
+    }
+    $ticketService = is_string($ticketService) ? $ticketService : '-';
+
     $ticketUpdated = $ticketUpdatedLabel ?? $ticket['lastactiondate'] ?? $ticket['LastActionDate'] ?? $ticket['datecreated'] ?? '-';
     if (is_array($ticketUpdated)) {
         $ticketUpdated = '-';
@@ -56,9 +62,10 @@
         </div>
     @endif
 
-    <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:12px 14px;display:grid;gap:8px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));">
+    <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:12px 14px;display:grid;gap:8px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));">
         <div><strong>Client</strong><br>{{ $selectedClient->business_name }}</div>
         <div><strong>Status</strong><br>{{ $ticketStatus }}</div>
+        <div><strong>Service</strong><br>{{ $ticketService }}</div>
         <div><strong>Type</strong><br>{{ $ticketType }}</div>
         <div><strong>Last Update</strong><br>{{ $ticketUpdated }}</div>
     </div>

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -38,6 +38,12 @@
             <p style="margin:0;color:var(--text-muted);">{{ $ticketSummary }}</p>
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+            <button type="button" id="open-reply-modal" class="btn-accent">Submit Reply</button>
+            <form method="POST" action="{{ route('tickets.close', ['ticketId' => $ticketId]) }}" style="margin:0;">
+                @csrf
+                <input type="hidden" name="client_id" value="{{ $selectedClientId }}">
+                <button type="submit" style="padding:9px 12px;border-radius:10px;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.15);color:#ef4444;cursor:pointer;">Close Ticket</button>
+            </form>
             <a href="{{ route('tickets.index', ['client_id' => $selectedClientId]) }}" style="padding:9px 12px;border-radius:10px;border:1px solid var(--border-subtle);text-decoration:none;color:var(--text-muted);">Back to tickets</a>
             @if($portalUrl)
                 <a href="{{ $portalUrl }}" target="_blank" rel="noopener noreferrer" class="btn-accent" style="text-decoration:none;">Open in Client Portal</a>
@@ -72,7 +78,7 @@
 
     <div style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;overflow:hidden;">
         <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);font-weight:600;">Client Visible Communications / Email Actions</div>
-        <div style="max-height:460px;overflow:auto;">
+        <div style="max-height:520px;overflow:auto;padding:10px;">
             @forelse($actions as $action)
                 @php
                     $actionAuthor = $action['agent_name'] ?? $action['AgentName'] ?? $action['who'] ?? 'Update';
@@ -93,7 +99,7 @@
                         $actionDetails = '-';
                     }
                 @endphp
-                <div style="padding:12px 14px;border-bottom:1px solid var(--border-subtle);display:grid;gap:6px;">
+                <div style="padding:14px;border:1px solid var(--border-subtle);border-radius:10px;display:grid;gap:8px;margin-bottom:10px;background:rgba(15,23,42,0.36);">
                     <div style="display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;">
                         <strong>{{ $actionAuthor }}</strong>
                         <span style="color:var(--text-muted);font-size:12px;">{{ $actionDate }}</span>
@@ -106,14 +112,50 @@
         </div>
     </div>
 
-    <form method="POST" action="{{ route('tickets.reply', ['ticketId' => $ticketId]) }}" style="background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:14px;display:grid;gap:10px;">
-        @csrf
-        <input type="hidden" name="client_id" value="{{ $selectedClientId }}">
-        <label for="ticket_reply" style="font-weight:600;">Reply to technician / provide update</label>
-        <textarea id="ticket_reply" name="message" rows="5" required style="width:100%;border:1px solid var(--border-subtle);border-radius:10px;padding:10px 11px;background:var(--bg);color:var(--text);">{{ old('message') }}</textarea>
-        <div>
-            <button class="btn-accent" type="submit">Submit Reply</button>
-        </div>
-    </form>
+    <div id="reply-modal" style="display:none;position:fixed;inset:0;background:rgba(2,6,23,0.72);z-index:12050;align-items:center;justify-content:center;padding:16px;">
+        <form method="POST" action="{{ route('tickets.reply', ['ticketId' => $ticketId]) }}" style="width:min(720px, 96vw);background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;padding:14px;display:grid;gap:10px;">
+            @csrf
+            <input type="hidden" name="client_id" value="{{ $selectedClientId }}">
+            <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;">
+                <label for="ticket_reply" style="font-weight:600;">Reply to technician / provide update</label>
+                <button type="button" id="close-reply-modal" style="padding:6px 10px;border-radius:8px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-muted);cursor:pointer;">Close</button>
+            </div>
+            <textarea id="ticket_reply" name="message" rows="8" required style="width:100%;border:1px solid var(--border-subtle);border-radius:10px;padding:10px 11px;background:var(--bg);color:var(--text);">{{ old('message') }}</textarea>
+            <div>
+                <button class="btn-accent" type="submit">Submit Reply</button>
+            </div>
+        </form>
+    </div>
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const openButton = document.getElementById('open-reply-modal');
+        const closeButton = document.getElementById('close-reply-modal');
+        const modal = document.getElementById('reply-modal');
+
+        if (!openButton || !closeButton || !modal) {
+            return;
+        }
+
+        const openModal = () => {
+            modal.style.display = 'flex';
+        };
+        const closeModal = () => {
+            modal.style.display = 'none';
+        };
+
+        openButton.addEventListener('click', openModal);
+        closeButton.addEventListener('click', closeModal);
+        modal.addEventListener('click', function (event) {
+            if (event.target === modal) {
+                closeModal();
+            }
+        });
+
+        @if($errors->any())
+            openModal();
+        @endif
+    });
+</script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         // Tickets
         Route::get('/tickets/create', [TicketController::class,'create'])->name('tickets.create');
         Route::get('/tickets', [TicketController::class,'index'])->name('tickets.index');
+        Route::get('/tickets/{ticketId}', [TicketController::class,'show'])->whereNumber('ticketId')->name('tickets.show');
+        Route::post('/tickets/{ticketId}/reply', [TicketController::class,'reply'])->whereNumber('ticketId')->name('tickets.reply');
         Route::post('/tickets', [TicketController::class,'store'])->name('tickets.store');
 
         // Domain admin area (permission-driven for Administrator/Technician roles)

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ Route::middleware(['auth','verified','mfa.policy'])->group(function () {
         Route::get('/tickets', [TicketController::class,'index'])->name('tickets.index');
         Route::get('/tickets/{ticketId}', [TicketController::class,'show'])->whereNumber('ticketId')->name('tickets.show');
         Route::post('/tickets/{ticketId}/reply', [TicketController::class,'reply'])->whereNumber('ticketId')->name('tickets.reply');
+        Route::post('/tickets/{ticketId}/close', [TicketController::class,'close'])->whereNumber('ticketId')->name('tickets.close');
         Route::post('/tickets', [TicketController::class,'store'])->name('tickets.store');
 
         // Domain admin area (permission-driven for Administrator/Technician roles)


### PR DESCRIPTION
### Motivation
- Provide a way for agents to open a ticket from the Support Requests list and view client-visible communications (email/actions) retrieved from HaloPSA. 
- Allow staff to submit replies/updates back to Halo without leaving DomainDash and open the ticket in the client portal in a new tab.

### Description
- Added routes `GET /tickets/{ticketId}` (`tickets.show`) and `POST /tickets/{ticketId}/reply` (`tickets.reply`) in `routes/web.php`.
- Implemented `show()` and `reply()` in `app/Http/Controllers/TicketController.php` with client ownership checks and a helper `extractPortalUrl()` to find portal links in Halo payloads.
- Extended `app/Services/Halo/HaloPsaClient.php` with `getTicketActions(int $ticketId)` to fetch/normalize communications and `createTicketAction(int $ticketId, string $message)` to post a client-visible reply.
- Made ticket rows clickable in the support list by updating `resources/views/tickets/requests.blade.php` so rows navigate to the detail page and preserved the same behavior for dynamically loaded rows.
- Added a new ticket detail view `resources/views/tickets/show.blade.php` that shows ticket metadata, lists client-visible communications, provides a reply form, and renders an "Open in Client Portal" button with `target="_blank"` and `rel="noopener noreferrer"`.

### Testing
- Ran PHP syntax checks `php -l` on `app/Http/Controllers/TicketController.php`, `app/Services/Halo/HaloPsaClient.php`, and `resources/views/tickets/show.blade.php`; all reported no syntax errors (success).
- Attempted `php artisan route:list --path=tickets` but it could not run in this environment because `vendor/autoload.php` is missing (failure due to environment, not code).
- No other automated tests exist for this feature; manual runtime validation is recommended in an environment with installed dependencies and Halo API access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9fe134670833090bd05ae8c0c92b0)