### PR TITLE
Fix Halo ticket timeline visibility and close status propagation

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -373,14 +373,14 @@ class TicketController extends Controller
             $closeAction = $halo->createTicketAction(
                 $ticketId,
                 $closeReason,
-                'Close No Survey',
+                'Close - User Portal',
                 auth()->user()?->name ?? 'Client',
                 false,
                 $closeActionMeta
             );
 
             $outcome = strtolower(trim((string) ($closeAction['outcome'] ?? $closeAction['Outcome'] ?? '')));
-            $hasClosure = in_array($outcome, ['close no survey', 'closed'], true);
+            $hasClosure = in_array($outcome, ['close - user portal', 'close no survey', 'closed'], true);
             $actionClosedStatusId = (int) ($closeAction['new_status'] ?? $closeAction['NewStatus'] ?? 0);
             $expectedClosedStatusId = (int) ($closedStatus['id'] ?? 0);
             $statusUpdatedByAction = $expectedClosedStatusId > 0 && $actionClosedStatusId === $expectedClosedStatusId;

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -362,16 +362,32 @@ class TicketController extends Controller
             }
 
             $closeReason = trim((string) $data['reason']);
+            $closedStatus = $this->resolveClosedStatus($halo);
+            $closeActionMeta = [];
+            if (($closedStatus['id'] ?? 0) > 0) {
+                $closeActionMeta['new_status'] = $closedStatus['id'];
+                $closeActionMeta['new_status_name'] = $closedStatus['name'];
+            }
+
             $closeAction = $halo->createTicketAction(
                 $ticketId,
                 $closeReason,
                 'Close No Survey',
-                auth()->user()?->name ?? 'Client'
+                auth()->user()?->name ?? 'Client',
+                false,
+                $closeActionMeta
             );
 
             $outcome = strtolower(trim((string) ($closeAction['outcome'] ?? $closeAction['Outcome'] ?? '')));
             $hasClosure = in_array($outcome, ['close no survey', 'closed'], true);
-            if (!$hasClosure) {
+            $actionClosedStatusId = (int) ($closeAction['new_status'] ?? $closeAction['NewStatus'] ?? 0);
+            $expectedClosedStatusId = (int) ($closedStatus['id'] ?? 0);
+            $statusUpdatedByAction = $expectedClosedStatusId > 0 && $actionClosedStatusId === $expectedClosedStatusId;
+            if ($expectedClosedStatusId > 0 && !$statusUpdatedByAction) {
+                $halo->updateTicketStatus($ticketId, $expectedClosedStatusId);
+            }
+
+            if (!$hasClosure && !$statusUpdatedByAction) {
                 throw new \RuntimeException('Closure request was accepted by Halo, but no close action was returned afterwards.');
             }
         } catch (\RuntimeException $exception) {
@@ -816,25 +832,53 @@ class TicketController extends Controller
             }
         }
 
-        $clientFacingTypes = [
-            strtolower(trim((string) ($action['outcome'] ?? ''))),
-            strtolower(trim((string) ($action['Outcome'] ?? ''))),
-            strtolower(trim((string) ($action['actiontype'] ?? ''))),
-            strtolower(trim((string) ($action['ActionType'] ?? ''))),
-            strtolower(trim((string) ($action['type'] ?? ''))),
-            strtolower(trim((string) ($action['Type'] ?? ''))),
-        ];
-        foreach ($clientFacingTypes as $typeLabel) {
-            if ($typeLabel === '') {
+        // Halo's /Actions endpoint can already be filtered with
+        // excludeprivate=true, and many client-visible actions do not carry
+        // explicit "public" flags. If no private/internal marker exists, keep
+        // the action visible to avoid hiding agent updates and dashboard replies.
+        return true;
+    }
+
+    private function resolveClosedStatus(HaloPsaClient $halo): array
+    {
+        foreach ($this->configuredStatusMappings() as $mapping) {
+            $domainDashStatus = strtolower(trim((string) ($mapping['domaindash_status'] ?? '')));
+            $statusId = (int) ($mapping['halo_status_id'] ?? 0);
+            $statusName = trim((string) ($mapping['halo_status_name'] ?? ''));
+
+            if ($statusId <= 0) {
                 continue;
             }
 
-            if (in_array($typeLabel, ['email user', 'with user', 'client note', 'public note'], true)) {
-                return true;
+            if ($domainDashStatus === 'closed') {
+                return [
+                    'id' => $statusId,
+                    'name' => $statusName !== '' ? $statusName : 'Closed',
+                ];
             }
         }
 
-        return false;
+        foreach ($halo->listTicketStatuses() as $status) {
+            $name = trim((string) ($status['name'] ?? $status['Name'] ?? ''));
+            if (strcasecmp($name, 'Closed') !== 0) {
+                continue;
+            }
+
+            $statusId = (int) ($status['id'] ?? $status['Id'] ?? 0);
+            if ($statusId <= 0) {
+                continue;
+            }
+
+            return [
+                'id' => $statusId,
+                'name' => $name,
+            ];
+        }
+
+        return [
+            'id' => 0,
+            'name' => 'Closed',
+        ];
     }
 
     private function extractTruthyFlag(array $action, string $field): bool

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -179,6 +179,7 @@ class TicketController extends Controller
                 fn (array $action): bool => $this->isClientVisibleAction($action)
             ));
             $actions = $this->prependInitialSubmission($ticket, $actions);
+            $actions = $this->prepareActionsForDisplay($actions);
         } catch (\RuntimeException $exception) {
             return redirect()->route('tickets.index', ['client_id' => $selectedClientId])
                 ->withErrors(['halo' => $exception->getMessage()]);
@@ -938,5 +939,50 @@ class TicketController extends Controller
         }
 
         return false;
+    }
+
+    private function prepareActionsForDisplay(array $actions): array
+    {
+        $seenIds = [];
+        $prepared = [];
+
+        foreach ($actions as $action) {
+            if (!is_array($action)) {
+                continue;
+            }
+
+            $actionId = (int) ($action['id'] ?? $action['Id'] ?? 0);
+            if ($actionId > 0) {
+                if (isset($seenIds[$actionId])) {
+                    continue;
+                }
+
+                $seenIds[$actionId] = true;
+            }
+
+            $htmlNote = $action['note_html'] ?? $action['NoteHtml'] ?? $action['noteHtml'] ?? null;
+            if (is_string($htmlNote) && trim($htmlNote) !== '') {
+                $action['_display_note_html'] = $this->sanitizeActionHtml($htmlNote);
+            } else {
+                $fallback = $action['details'] ?? $action['Details'] ?? $action['note'] ?? $action['Note'] ?? '';
+                $action['_display_note_html'] = nl2br(e((string) $fallback));
+            }
+
+            $prepared[] = $action;
+        }
+
+        return $prepared;
+    }
+
+    private function sanitizeActionHtml(string $html): string
+    {
+        $sanitized = preg_replace('#<script\b[^>]*>(.*?)</script>#is', '', $html) ?? '';
+        $sanitized = preg_replace('#\son[a-zA-Z]+\s*=\s*(\"[^\"]*\"|\'[^\']*\'|[^\s>]+)#i', '', $sanitized) ?? '';
+        $sanitized = preg_replace('#\s(href|src)\s*=\s*([\"\'])\s*javascript:[^\\2]*\\2#i', '', $sanitized) ?? '';
+
+        return strip_tags(
+            $sanitized,
+            '<p><br><strong><em><b><i><u><a><ul><ol><li><blockquote><code><pre><span><div><img>'
+        );
     }
 }

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -585,18 +585,16 @@ class HaloPsaClient
     {
         $endpoints = [
             'tickets/' . $ticketId . '/actions',
-            'action',
             'actions',
+            'action',
         ];
 
         foreach ($endpoints as $endpoint) {
-            $query = [];
-            if ($endpoint === 'actions' || $endpoint === 'action') {
-                $query = [
-                    'ticket_id' => $ticketId,
-                    'count' => 200,
-                ];
-            }
+            $query = [
+                'ticket_id' => $ticketId,
+                'count' => 200,
+                'excludeprivate' => 'true',
+            ];
 
             try {
                 $result = $this->request('GET', $endpoint, [
@@ -632,28 +630,29 @@ class HaloPsaClient
         string $message,
         string $outcome = 'Client-Responded',
         ?string $who = null,
-        bool $sendEmail = false
+        bool $sendEmail = false,
+        array $extraFields = []
     ): array {
         $author = trim((string) $who);
         $timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $effectiveAuthor = $author !== '' ? $author : 'Client';
         $payloads = [
-            [[
+            [array_merge([
                 'outcome' => $outcome,
                 'ticket_id' => $ticketId,
                 'datetime' => $timestamp,
                 'last_updated' => $timestamp,
                 'note' => $message,
                 'Who' => $effectiveAuthor,
-            ]],
-            [[
+            ], $extraFields)],
+            [array_merge([
                 'ticket_id' => $ticketId,
                 'note' => $message,
                 'outcome' => $outcome,
                 'who' => $effectiveAuthor,
                 'hiddenfromuser' => false,
                 'sendemail' => $sendEmail,
-            ]],
+            ], $extraFields)],
         ];
 
         $lastError = null;

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -594,6 +594,8 @@ class HaloPsaClient
                 'ticket_id' => $ticketId,
                 'count' => 200,
                 'excludeprivate' => 'true',
+                'excludesys' => 'true',
+                'includehtmlnote' => 'true',
             ];
 
             try {

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -31,6 +31,13 @@
     }
     $ticketUpdated = is_string($ticketUpdated) ? $ticketUpdated : '-';
 @endphp
+<style>
+    .dd-ticket-action-content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+    }
+</style>
 <div style="max-width:1080px;display:grid;gap:14px;">
     <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;flex-wrap:wrap;">
         <div>
@@ -94,12 +101,17 @@
                         $actionDate = '-';
                     }
 
-                    $actionDetails = $action['details'] ?? $action['Details'] ?? $action['note'] ?? '-';
-                    if (is_array($actionDetails)) {
-                        $actionDetails = $actionDetails['text'] ?? $actionDetails['Text'] ?? '-';
-                    }
-                    if (!is_string($actionDetails) || trim($actionDetails) === '') {
-                        $actionDetails = '-';
+                    $actionDetailsHtml = $action['_display_note_html'] ?? null;
+                    if (!is_string($actionDetailsHtml) || trim($actionDetailsHtml) === '') {
+                        $actionDetails = $action['details'] ?? $action['Details'] ?? $action['note'] ?? '-';
+                        if (is_array($actionDetails)) {
+                            $actionDetails = $actionDetails['text'] ?? $actionDetails['Text'] ?? '-';
+                        }
+                        if (!is_string($actionDetails) || trim($actionDetails) === '') {
+                            $actionDetails = '-';
+                        }
+
+                        $actionDetailsHtml = nl2br(e($actionDetails));
                     }
                 @endphp
                 <div style="padding:14px;border:1px solid var(--border-subtle);border-radius:10px;display:grid;gap:8px;margin-bottom:10px;background:rgba(15,23,42,0.36);">
@@ -107,7 +119,7 @@
                         <strong>{{ $actionAuthor }}</strong>
                         <span style="color:var(--text-muted);font-size:12px;">{{ $actionDate }}</span>
                     </div>
-                    <div style="white-space:pre-wrap;">{{ $actionDetails }}</div>
+                    <div class="dd-ticket-action-content" style="white-space:normal;overflow-wrap:anywhere;">{!! $actionDetailsHtml !!}</div>
                 </div>
             @empty
                 <div style="padding:14px;color:var(--text-muted);">No client-visible communications were returned for this ticket.</div>


### PR DESCRIPTION
### Motivation
- Agent updates and replies were not consistently appearing in the ticket timeline and closing a ticket from the dashboard did not always update the HaloPSA ticket status. 

### Description
- Always request ticket actions with `ticket_id` and `excludeprivate=true` in `app/Services/Halo/HaloPsaClient.php` so non-private agent/client updates are returned from Halo. 
- Extend `createTicketAction` in `app/Services/Halo/HaloPsaClient.php` to accept `extraFields` and merge them into the posted payload so metadata like `new_status`/`new_status_name` can be passed when creating actions. 
- Update the close flow in `app/Http/Controllers/TicketController.php` to resolve a suitable Closed status (preferring configured mappings, falling back to Halo lookup) and include `new_status`/`new_status_name` in the close action payload. 
- Add a fallback that calls `updateTicketStatus` when the close action response does not confirm the expected closed status and change `isClientVisibleAction` to default to visible when no private/internal flag exists. 

### Testing
- Linted modified files with `php -l app/Http/Controllers/TicketController.php` and `php -l app/Services/Halo/HaloPsaClient.php`, both returned no syntax errors. 
- Attempted to run unit/feature tests with `php artisan test --filter=Ticket --stop-on-failure`, but the test runner could not boot in this environment because `vendor/autoload.php` is missing (test execution failed due to environment dependency, not code errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb4e7354548330a645b164d1d2ec69)