### PR TITLE
Add encryption for sensitive settings and SSRF protection

### DIFF
--- a/app/Console/Commands/BackupRunCommand.php
+++ b/app/Console/Commands/BackupRunCommand.php
@@ -14,7 +14,7 @@ class BackupRunCommand extends Command
 
     public function handle(): int
     {
-        $backup = Setting::get('backup');
+        $backup = Setting::getSensitive('backup');
         if (!$backup || empty($backup['host'])) {
             $this->warn('Backup settings not configured.');
             return 0;

--- a/app/Http/Controllers/Admin/ClientsController.php
+++ b/app/Http/Controllers/Admin/ClientsController.php
@@ -218,7 +218,7 @@ class ClientsController extends Controller
                 ], 500);
             }
 
-            $haloSettings = Setting::get('halo', []);
+            $haloSettings = Setting::getSensitive('halo');
             $baseUrl = rtrim($haloSettings['base_url'] ?? '', '/');
 
             if (empty($baseUrl)) {
@@ -340,7 +340,7 @@ class ClientsController extends Controller
                 ], 500);
             }
 
-            $haloSettings = Setting::get('halo', []);
+            $haloSettings = Setting::getSensitive('halo');
             $baseUrl = rtrim($haloSettings['base_url'] ?? '', '/');
             
             if (!str_ends_with($baseUrl, '/api')) {
@@ -798,7 +798,7 @@ class ClientsController extends Controller
     private function getHaloAccessToken()
     {
         try {
-            $haloSettings = Setting::get('halo', []);
+            $haloSettings = Setting::getSensitive('halo');
             
             $authUrl = rtrim($haloSettings['auth_server'] ?? '', '/');
             $clientId = $haloSettings['client_id'] ?? null;
@@ -874,7 +874,7 @@ class ClientsController extends Controller
     private function fetchDnsRecordsFromSynergy($domainName)
     {
         try {
-            $synergySettings = Setting::get('synergy', []);
+            $synergySettings = Setting::getSensitive('synergy');
             $wsdlPath = $synergySettings['wsdl_path'] ?? null;
             $resellerId = $synergySettings['reseller_id'] ?? null;
             $apiKey = $synergySettings['api_key'] ?? null;

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Setting;
+use App\Rules\SafeExternalUrl;
 use Illuminate\Support\Facades\Mail;
 use App\Support\MailSettings;
 use App\Services\AuditLogger;
@@ -27,21 +28,21 @@ class SettingsController extends Controller
                 'bg_dark'          => '#0f172a',
                 'button_text_dark' => '#0f172a',
             ]),
-            'smtp'     => Setting::get('smtp', []),
-            'synergy'  => Setting::get('synergy', []),
+            'smtp'     => Setting::getSensitive('smtp'),
+            'synergy'  => Setting::getSensitive('synergy'),
             'halo'     => array_merge([
                 'ticket_type_mappings' => [],
                 'status_mappings' => [],
-            ], Setting::get('halo', [])),
-            'itglue'   => Setting::get('itglue', []),
-            'ip2whois' => Setting::get('ip2whois', []),
+            ], Setting::getSensitive('halo')),
+            'itglue'   => Setting::getSensitive('itglue'),
+            'ip2whois' => Setting::getSensitive('ip2whois'),
             'sync_schedule' => Setting::get('sync_schedule', [
                 'sync_domains' => ['enabled' => false, 'frequency' => 'daily', 'time' => '01:30'],
                 'sync_hosting_services' => ['enabled' => false, 'frequency' => 'daily', 'time' => '02:00'],
                 'sync_halo_assets' => ['enabled' => false, 'frequency' => 'daily', 'time' => '02:30'],
                 'sync_itglue' => ['enabled' => false, 'frequency' => 'daily', 'time' => '03:00'],
             ]),
-            'backup'   => Setting::get('backup', ['host'=>'','port'=>22,'username'=>'','password'=>'','path'=>'/','retention'=>7,'time'=>'02:00']),
+            'backup'   => Setting::getSensitive('backup', ['host'=>'','port'=>22,'username'=>'','password'=>'','path'=>'/','retention'=>7,'time'=>'02:00']),
             'notifications' => Setting::get('notifications', ['disk_threshold_percent'=>90]),
             'mfa' => Setting::get('mfa', [
                 'persistence_days' => 30,
@@ -64,8 +65,8 @@ class SettingsController extends Controller
             'smtp'          => 'array',
             'synergy'       => 'array',
             'halo'          => 'array',
-            'halo.base_url' => 'nullable|string|max:255',
-            'halo.auth_server' => 'nullable|string|max:255',
+            'halo.base_url' => ['nullable', 'string', 'max:255', new SafeExternalUrl()],
+            'halo.auth_server' => ['nullable', 'string', 'max:255', new SafeExternalUrl()],
             'halo.tenant' => 'nullable|string|max:120',
             'halo.client_id' => 'nullable|string|max:120',
             'halo.api_key' => 'nullable|string|max:255',
@@ -80,8 +81,9 @@ class SettingsController extends Controller
             'halo.status_mappings.*.domaindash_status' => 'nullable|string|max:120',
             'halo.status_mappings.*.halo_status_id' => 'nullable|integer|min:1',
             'halo.status_mappings.*.halo_status_name' => 'nullable|string|max:180',
-            'itglue'        => 'array',
-            'ip2whois'      => 'array',
+            'itglue'          => 'array',
+            'itglue.base_url' => ['nullable', 'string', 'max:255', new SafeExternalUrl()],
+            'ip2whois'        => 'array',
             'sync_schedule' => 'array',
             'sync_schedule.*' => 'array',
             'sync_schedule.*.enabled' => 'nullable|boolean',
@@ -105,10 +107,7 @@ class SettingsController extends Controller
          * If the form posts "********" we keep the existing secret.
          */
         if (isset($data['halo']) && is_array($data['halo'])) {
-            $currentHalo = Setting::get('halo', []);
-            if (!is_array($currentHalo)) {
-                $currentHalo = [];
-            }
+            $currentHalo = Setting::getSensitive('halo');
 
             // Merge with existing settings so missing posted keys do not erase
             // previously saved Halo credentials.
@@ -129,7 +128,7 @@ class SettingsController extends Controller
          */
         if (isset($data['synergy']) && is_array($data['synergy'])) {
             if (array_key_exists('api_key', $data['synergy']) && $data['synergy']['api_key'] === '********') {
-                $currentSynergy = Setting::get('synergy', []);
+                $currentSynergy = Setting::getSensitive('synergy');
                 if (isset($currentSynergy['api_key'])) {
                     $data['synergy']['api_key'] = $currentSynergy['api_key'];
                 } else {
@@ -160,15 +159,21 @@ class SettingsController extends Controller
                 continue;
             }
 
-            $currentValue = Setting::get($key, null);
+            $isSensitive = in_array($key, Setting::SENSITIVE_GROUPS, true);
+            $currentValue = $isSensitive ? Setting::getSensitive($key) : Setting::get($key, null);
             $diff = $this->extractChangedValues($currentValue, $value);
             if ($diff === null) {
                 continue;
             }
 
-            Setting::put($key, $value);
-            $oldValues[$key] = $diff['old'];
-            $newValues[$key] = $diff['new'];
+            if ($isSensitive) {
+                Setting::putSensitive($key, is_array($value) ? $value : []);
+            } else {
+                Setting::put($key, $value);
+            }
+
+            $oldValues[$key] = $this->redactForAudit($key, $diff['old']);
+            $newValues[$key] = $this->redactForAudit($key, $diff['new']);
         }
 
         if (!empty($newValues)) {
@@ -279,7 +284,7 @@ class SettingsController extends Controller
         $request->validate(['to' => 'required|email']);
 
         // Load SMTP settings from database
-        $smtp = Setting::get('smtp', []);
+        $smtp = Setting::getSensitive('smtp');
 
         // Validate that SMTP settings are configured
         if (! MailSettings::isConfigured($smtp)) {
@@ -294,5 +299,30 @@ class SettingsController extends Controller
         });
 
         return back()->with('status', 'Test email sent successfully to ' . $request->to);
+    }
+
+    /**
+     * Replace sensitive sub-key values with [REDACTED] before writing to the
+     * audit log.  Operates recursively so nested arrays are also covered.
+     */
+    private function redactForAudit(string $groupKey, mixed $value): mixed
+    {
+        if (! in_array($groupKey, Setting::SENSITIVE_GROUPS, true)) {
+            return $value;
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        foreach ($value as $k => &$v) {
+            if (in_array($k, Setting::SENSITIVE_SUBKEYS, true) && $v !== null && $v !== '') {
+                $v = '[REDACTED]';
+            } elseif (is_array($v)) {
+                $v = $this->redactForAudit($groupKey, $v);
+            }
+        }
+
+        return $value;
     }
 }

--- a/app/Http/Controllers/Admin/SyncController.php
+++ b/app/Http/Controllers/Admin/SyncController.php
@@ -22,7 +22,7 @@ class SyncController extends Controller
     public function getHaloClients()
     {
         try {
-            $haloConfig = Setting::get('halo', []);
+            $haloConfig = Setting::getSensitive('halo');
 
             if (empty($haloConfig['base_url']) || empty($haloConfig['client_id']) || empty($haloConfig['api_key'])) {
                 return response()->json(['error' => 'HaloPSA is not configured. Please configure it in Settings.'], 400);
@@ -96,7 +96,7 @@ class SyncController extends Controller
         ]);
 
         try {
-            $haloConfig = Setting::get('halo', []);
+            $haloConfig = Setting::getSensitive('halo');
             $token = $this->getHaloAccessToken($haloConfig);
 
             $syncedCount = 0;
@@ -206,7 +206,7 @@ class SyncController extends Controller
     public function getHaloDomains()
     {
         try {
-            $haloConfig = Setting::get('halo', []);
+            $haloConfig = Setting::getSensitive('halo');
 
             if (empty($haloConfig['base_url'])) {
                 return response()->json(['error' => 'HaloPSA is not configured'], 400);
@@ -269,7 +269,7 @@ class SyncController extends Controller
 
         try {
             $halo = new \App\Services\Halo\HaloPsaClient();
-            $haloConfig = Setting::get('halo', []);
+            $haloConfig = Setting::getSensitive('halo');
             $token = $this->getHaloAccessToken($haloConfig);
 
             $syncedCount = 0;
@@ -595,7 +595,7 @@ class SyncController extends Controller
     public function getItGlueClients()
     {
         try {
-            $itglueConfig = Setting::get('itglue', []);
+            $itglueConfig = Setting::getSensitive('itglue');
 
             if (empty($itglueConfig['base_url']) || empty($itglueConfig['api_key'])) {
                 return response()->json(['error' => 'IT Glue is not configured'], 400);
@@ -709,7 +709,7 @@ class SyncController extends Controller
     {
         try {
             $client = Client::findOrFail($clientId);
-            $itglueConfig = Setting::get('itglue', []);
+            $itglueConfig = Setting::getSensitive('itglue');
 
             // Fetch ALL organizations with pagination
             $itglueOrgs = $this->fetchAllItGlueOrganizations($itglueConfig);
@@ -1280,7 +1280,7 @@ class SyncController extends Controller
     private function fetchDnsRecordsFromSynergy($domainName)
     {
         try {
-            $synergySettings = Setting::get('synergy', []);
+            $synergySettings = Setting::getSensitive('synergy');
             $wsdlPath = $synergySettings['wsdl_path'] ?? null;
             $resellerId = $synergySettings['reseller_id'] ?? null;
             $apiKey = $synergySettings['api_key'] ?? null;
@@ -1321,7 +1321,7 @@ class SyncController extends Controller
     private function fetchWhoisFromSynergy($domainName)
     {
         try {
-            $synergySettings = Setting::get('synergy', []);
+            $synergySettings = Setting::getSensitive('synergy');
             $wsdlPath = $synergySettings['wsdl_path'] ?? null;
             $resellerId = $synergySettings['reseller_id'] ?? null;
             $apiKey = $synergySettings['api_key'] ?? null;

--- a/app/Http/Controllers/Admin/UsersController.php
+++ b/app/Http/Controllers/Admin/UsersController.php
@@ -214,8 +214,18 @@ class UsersController extends Controller
     /**
      * Start impersonation.
      */
-    public function impersonate(User $user)
+    public function impersonate(Request $request, User $user)
     {
+        // Prevent privilege escalation: admins may not impersonate other admins.
+        if ($user->hasRole('Administrator')) {
+            abort(403, 'You cannot impersonate another Administrator.');
+        }
+
+        // Prevent impersonating a disabled account.
+        if (! $user->is_active) {
+            return back()->withErrors(['user' => 'Cannot impersonate a disabled user.']);
+        }
+
         session(['impersonate_as' => $user->id]);
 
         return redirect()

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -488,7 +488,7 @@ class TicketController extends Controller
 
     private function haloSettings(): array
     {
-        $haloSettings = Setting::get('halo', []);
+        $haloSettings = Setting::getSensitive('halo');
         return is_array($haloSettings) ? $haloSettings : [];
     }
 

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 
 class Setting extends Model
 {
@@ -10,11 +11,55 @@ class Setting extends Model
 
     protected $casts = ['value' => 'array'];
 
+    // Setting groups whose values must be encrypted at rest.
+    public const SENSITIVE_GROUPS = ['synergy', 'halo', 'smtp', 'backup', 'itglue', 'ip2whois'];
+
+    // Sub-keys within sensitive groups that must be redacted in audit logs.
+    public const SENSITIVE_SUBKEYS = ['api_key', 'password', 'secret', 'client_secret'];
+
     public static function get(string $key, $default = null){
         return optional(static::where('key',$key)->first())->value ?? $default;
     }
 
     public static function put(string $key, $value): void {
         static::updateOrCreate(['key' => $key], ['value' => $value]);
+    }
+
+    /**
+     * Store a sensitive setting group encrypted at rest.
+     * The value array is JSON-encoded then AES-encrypted; the cipher is wrapped
+     * in {"_enc": "..."} so the existing array cast stores/retrieves it cleanly.
+     */
+    public static function putSensitive(string $key, array $value): void
+    {
+        $cipher = Crypt::encryptString(json_encode($value));
+        static::updateOrCreate(['key' => $key], ['value' => ['_enc' => $cipher]]);
+    }
+
+    /**
+     * Retrieve a sensitive setting group, decrypting if stored encrypted.
+     * Falls back gracefully to plaintext legacy rows.
+     */
+    public static function getSensitive(string $key, array $default = []): array
+    {
+        $row = static::where('key', $key)->first();
+        if (! $row) {
+            return $default;
+        }
+
+        $stored = $row->value; // already array-cast by Eloquent
+
+        if (is_array($stored) && isset($stored['_enc'])) {
+            try {
+                $decoded = json_decode(Crypt::decryptString($stored['_enc']), true);
+                return is_array($decoded) ? $decoded : $default;
+            } catch (\Exception $e) {
+                return $default;
+            }
+        }
+
+        // Legacy plaintext row — return as-is so the app keeps working until
+        // the next settings save re-encrypts it.
+        return is_array($stored) ? $stored : $default;
     }
 }

--- a/app/Rules/SafeExternalUrl.php
+++ b/app/Rules/SafeExternalUrl.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Rejects URLs that point to private/loopback/link-local network ranges to
+ * prevent Server-Side Request Forgery (SSRF) via admin-controlled base_url
+ * settings (HaloPSA, ITGlue, etc.).
+ *
+ * Enforces:
+ *  - HTTPS scheme only
+ *  - Valid hostname
+ *  - Not a private / loopback / link-local / reserved address
+ */
+class SafeExternalUrl implements ValidationRule
+{
+    // RFC-1918, loopback, link-local, and other non-routable ranges.
+    private const BLOCKED_CIDRS = [
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16',
+        '127.0.0.0/8',
+        '169.254.0.0/16',   // link-local / AWS metadata
+        '100.64.0.0/10',    // CGNAT
+        '192.0.0.0/24',
+        '198.18.0.0/15',
+        '198.51.100.0/24',
+        '203.0.113.0/24',
+        '240.0.0.0/4',
+        '::1/128',          // IPv6 loopback
+        'fc00::/7',         // IPv6 unique-local
+        'fe80::/10',        // IPv6 link-local
+    ];
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        $parsed = parse_url((string) $value);
+
+        if (! $parsed || ! isset($parsed['host'])) {
+            $fail('The :attribute must be a valid URL.');
+            return;
+        }
+
+        if (($parsed['scheme'] ?? '') !== 'https') {
+            $fail('The :attribute must use HTTPS.');
+            return;
+        }
+
+        $host = $parsed['host'];
+
+        // Resolve hostname to IP; if it fails or resolves to blocked range, reject.
+        $ip = gethostbyname($host);
+
+        // gethostbyname returns the original string on failure.
+        if ($ip === $host && filter_var($host, FILTER_VALIDATE_IP) === false) {
+            // Can't resolve — allow (DNS may not be available at validation time;
+            // the important protection is blocking known private literals).
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP) !== false) {
+            foreach (self::BLOCKED_CIDRS as $cidr) {
+                if ($this->ipInCidr($ip, $cidr)) {
+                    $fail('The :attribute must not point to a private or reserved address.');
+                    return;
+                }
+            }
+        }
+    }
+
+    private function ipInCidr(string $ip, string $cidr): bool
+    {
+        [$subnet, $bits] = explode('/', $cidr);
+
+        // IPv6 check
+        if (str_contains($cidr, ':')) {
+            if (! str_contains($ip, ':')) {
+                return false;
+            }
+            $ipBin     = inet_pton($ip);
+            $subnetBin = inet_pton($subnet);
+            if ($ipBin === false || $subnetBin === false) {
+                return false;
+            }
+            $prefixBytes = (int) floor((int) $bits / 8);
+            $prefixBits  = (int) $bits % 8;
+            for ($i = 0; $i < $prefixBytes; $i++) {
+                if ($ipBin[$i] !== $subnetBin[$i]) {
+                    return false;
+                }
+            }
+            if ($prefixBits > 0 && $prefixBytes < strlen($ipBin)) {
+                $mask = 0xFF & (0xFF << (8 - $prefixBits));
+                if ((ord($ipBin[$prefixBytes]) & $mask) !== (ord($subnetBin[$prefixBytes]) & $mask)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // IPv4 check
+        if (str_contains($ip, ':')) {
+            return false;
+        }
+        $ipLong     = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+        if ($ipLong === false || $subnetLong === false) {
+            return false;
+        }
+        $mask = (int) $bits === 0 ? 0 : (~0 << (32 - (int) $bits));
+
+        return ($ipLong & $mask) === ($subnetLong & $mask);
+    }
+}

--- a/app/Services/Halo/HaloPsaClient.php
+++ b/app/Services/Halo/HaloPsaClient.php
@@ -23,7 +23,7 @@ class HaloPsaClient
 
     public function __construct()
     {
-        $halo = Setting::get('halo', []);
+        $halo = Setting::getSensitive('halo');
 
         // Resource server URL
         $baseUrl = rtrim($halo['base_url'] ?? '', '/');

--- a/app/Services/Ip2whois/Ip2whoisClient.php
+++ b/app/Services/Ip2whois/Ip2whoisClient.php
@@ -13,7 +13,7 @@ class Ip2whoisClient
 
     public function __construct()
     {
-        $cfg = Setting::get('ip2whois', []);
+        $cfg = Setting::getSensitive('ip2whois');
         $this->apiKey = $cfg['api_key'] ?? null;
     }
 

--- a/app/Services/ItGlue/ItGlueClient.php
+++ b/app/Services/ItGlue/ItGlueClient.php
@@ -19,7 +19,7 @@ class ItGlueClient
 
     public function __construct()
     {
-        $cfg = Setting::get('itglue', []);
+        $cfg = Setting::getSensitive('itglue');
 
         // Base URL – default to official ITGlue API if not configured
         $base = trim($cfg['base_url'] ?? '');

--- a/app/Services/Synergy/SynergyWholesaleClient.php
+++ b/app/Services/Synergy/SynergyWholesaleClient.php
@@ -12,11 +12,7 @@ class SynergyWholesaleClient
     public function __construct(?string $wsdlPath = null)
     {
         // All Synergy config is stored under a single "synergy" setting.
-        $synergy = Setting::get('synergy', [
-            'reseller_id' => null,
-            'api_key'     => null,
-            'wsdl_path'   => null,
-        ]);
+        $synergy = Setting::getSensitive('synergy');
 
         $wsdl = $wsdlPath
             ?: ($synergy['wsdl_path'] ?? storage_path('app/wsdl/synergy.wsdl'));
@@ -32,10 +28,7 @@ class SynergyWholesaleClient
 
     protected function creds(): array
     {
-        $synergy = Setting::get('synergy', [
-            'reseller_id' => null,
-            'api_key'     => null,
-        ]);
+        $synergy = Setting::getSensitive('synergy');
 
         return [
             'resellerID' => $synergy['reseller_id'] ?? null,

--- a/app/Support/MailSettings.php
+++ b/app/Support/MailSettings.php
@@ -23,7 +23,7 @@ class MailSettings
 
     public static function applyFromDatabase(): bool
     {
-        $smtp = Setting::get('smtp', []);
+        $smtp = Setting::getSensitive('smtp');
 
         if (! self::isConfigured($smtp)) {
             return false;

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -144,7 +144,9 @@ return [
     */
 
     'features' => [
-        Features::registration(),
+        // Self-registration is disabled. All users are provisioned by an
+        // Administrator via the admin user management panel (/admin/users/create).
+        // Features::registration(),
         Features::resetPasswords(),
         // Features::emailVerification(),
         Features::updateProfileInformation(),

--- a/database/migrations/2026_04_29_000001_encrypt_sensitive_settings.php
+++ b/database/migrations/2026_04_29_000001_encrypt_sensitive_settings.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Crypt;
+use App\Models\Setting;
+
+/**
+ * One-time migration: re-encrypts any sensitive setting groups that are
+ * currently stored as plaintext JSON in the settings table.
+ *
+ * Safe to re-run: rows already using the {"_enc":"..."} envelope are skipped.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        foreach (Setting::SENSITIVE_GROUPS as $key) {
+            $row = DB::table('settings')->where('key', $key)->first();
+            if (! $row) {
+                continue;
+            }
+
+            $decoded = json_decode($row->value, true);
+
+            // Already encrypted — the envelope has a single "_enc" key.
+            if (is_array($decoded) && array_keys($decoded) === ['_enc']) {
+                continue;
+            }
+
+            // Plaintext array — encrypt it now.
+            if (is_array($decoded) && ! empty($decoded)) {
+                $cipher = Crypt::encryptString(json_encode($decoded));
+                DB::table('settings')
+                    ->where('key', $key)
+                    ->update(['value' => json_encode(['_enc' => $cipher])]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Intentionally not reversible: we do not want to decrypt secrets back
+        // to plaintext on a rollback. If a rollback is needed, re-deploy the
+        // prior application version (which uses Setting::get) first.
+    }
+};


### PR DESCRIPTION
## Summary
This PR implements encryption at rest for sensitive configuration settings and adds Server-Side Request Forgery (SSRF) protection for external URLs used in integrations like HaloPSA and IT Glue.

## Key Changes

### Security Enhancements
- **Sensitive Settings Encryption**: Added `Setting::getSensitive()` and `Setting::putSensitive()` methods to encrypt sensitive configuration groups (synergy, halo, smtp, backup, itglue, ip2whois) at rest using Laravel's encryption
- **SSRF Protection**: Introduced `SafeExternalUrl` validation rule that:
  - Enforces HTTPS-only URLs
  - Validates hostnames and resolves them to IP addresses
  - Blocks requests to private/loopback/link-local/reserved IP ranges (RFC-1918, IPv6 unique-local, etc.)
  - Applied to `halo.base_url`, `halo.auth_server`, and `itglue.base_url` settings
- **Audit Log Redaction**: Added `redactForAudit()` method to mask sensitive sub-keys (api_key, password, secret, client_secret) in audit logs before persistence

### Database & Model Changes
- Added migration `2026_04_29_000001_encrypt_sensitive_settings.php` to one-time encrypt existing plaintext sensitive settings
- Updated `Setting` model with:
  - `SENSITIVE_GROUPS` constant defining which setting groups require encryption
  - `SENSITIVE_SUBKEYS` constant for audit log redaction
  - New encryption/decryption methods with graceful fallback for legacy plaintext rows

### Controller Updates
- **SettingsController**: Updated to use `getSensitive()` for all sensitive setting groups; added validation rules for external URLs; implemented audit log redaction
- **UsersController**: Added privilege escalation prevention in `impersonate()` method (admins cannot impersonate other admins; cannot impersonate disabled users)
- Updated all service/client constructors and controllers to use `getSensitive()` instead of `get()` for sensitive settings

### Configuration
- Disabled self-registration in `config/fortify.php` (users must be provisioned by administrators)

## Implementation Details
- Encrypted values are stored as `{"_enc": "..."}` envelope in the database, allowing seamless integration with existing array casting
- Migration is idempotent and safe to re-run
- Graceful degradation: legacy plaintext settings continue to work until next save (which re-encrypts them)
- SSRF validation supports both IPv4 and IPv6 CIDR ranges
- Audit logging preserves change history while protecting secrets

https://claude.ai/code/session_011RjcRWNNjTaMiQmGab8d7Q